### PR TITLE
[OpenCode] Fix model format and Docker file permissions for agent compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,21 +218,27 @@ See the Environment Variables section below for setup instructions.
 
 ### OpenCode Model Configuration
 
-OpenCode uses Vercel AI Gateway exclusively. Models are specified with the `{provider}/{model}` format:
+OpenCode uses Vercel AI Gateway exclusively. Models **must** be specified with the `vercel/{provider}/{model}` format:
 
 ```typescript
 // Anthropic models
-model: 'anthropic/claude-sonnet-4'
-model: 'anthropic/claude-opus-4'
+model: 'vercel/anthropic/claude-sonnet-4'
+model: 'vercel/anthropic/claude-opus-4'
+
+// Minimax models
+model: 'vercel/minimax/minimax-m2.1'
+model: 'vercel/minimax/minimax-m2.1-lightning'
 
 // Moonshot AI (Kimi) models
-model: 'moonshotai/kimi-k2'
-model: 'moonshotai/kimi-k2-thinking'
+model: 'vercel/moonshotai/kimi-k2'
+model: 'vercel/moonshotai/kimi-k2-thinking'
 
 // OpenAI models
-model: 'openai/gpt-4o'
-model: 'openai/o3'
+model: 'vercel/openai/gpt-4o'
+model: 'vercel/openai/o3'
 ```
+
+> **Important:** The `vercel/` prefix is required. OpenCode's config sets up a `vercel` provider, so the model string must start with `vercel/` to route through Vercel AI Gateway correctly. Using just `anthropic/claude-sonnet-4` (without the `vercel/` prefix) will fail with a "provider not found" error.
 
 Under the hood, the agent creates an `opencode.json` config file that configures the Vercel provider:
 
@@ -267,7 +273,7 @@ const config: ExperimentConfig = {
   // Model to use (defaults vary by agent)
   // - claude-code: 'opus'
   // - codex: 'openai/gpt-5.2-codex'
-  // - opencode: 'anthropic/claude-sonnet-4'
+  // - opencode: 'vercel/anthropic/claude-sonnet-4' (note: vercel/ prefix required)
   model: 'opus',
 
   // How many times to run each eval

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -630,7 +630,7 @@ test('greet exists', () => {
 
       const result = await runSingleEval(fixture, {
         agent: 'vercel-ai-gateway/opencode',
-        model: 'anthropic/claude-sonnet-4',
+        model: 'vercel/anthropic/claude-sonnet-4',
         timeout: 180,
         apiKey: process.env.AI_GATEWAY_API_KEY!,
         scripts: ['build'],
@@ -703,7 +703,7 @@ test('contains greeting', () => {
 
       const result = await runSingleEval(fixture, {
         agent: 'vercel-ai-gateway/opencode',
-        model: 'anthropic/claude-sonnet-4',
+        model: 'vercel/anthropic/claude-sonnet-4',
         timeout: 180,
         apiKey: process.env.AI_GATEWAY_API_KEY!,
         scripts: ['build'],
@@ -740,6 +740,173 @@ test('contains greeting', () => {
         }
       }
     }, 300000); // 5 minute timeout
+  });
+
+  // ============================================================================
+  // Parallel sandbox tests for all agents/models
+  // ============================================================================
+
+  // Helper to create a unique fixture for each test
+  function createTestFixture(testId: string) {
+    const fixtureDir = join(TEST_DIR, testId);
+    mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+    writeFileSync(
+      join(fixtureDir, 'PROMPT.md'),
+      'Add a function called greet that returns "Hello!"'
+    );
+    writeFileSync(
+      join(fixtureDir, 'EVAL.ts'),
+      `
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+test('greet exists', () => {
+  const content = readFileSync('src/index.ts', 'utf-8');
+  expect(content).toContain('greet');
+});
+`
+    );
+    writeFileSync(
+      join(fixtureDir, 'package.json'),
+      JSON.stringify({
+        name: testId,
+        type: 'module',
+        scripts: { build: 'tsc' },
+        devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+      })
+    );
+    writeFileSync(
+      join(fixtureDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          outDir: 'dist',
+        },
+        include: ['src'],
+      })
+    );
+    writeFileSync(join(fixtureDir, 'src/index.ts'), '// TODO: implement');
+
+    return loadFixture(TEST_DIR, testId);
+  }
+
+  describe.skipIf(!hasAiGatewayCredentials)('Parallel agent/model/sandbox tests', () => {
+    // OpenCode + Minimax on Docker
+    it.concurrent.skipIf(!hasDockerSandbox)(
+      'OpenCode + minimax-m2.1 on Docker',
+      async () => {
+        const fixture = createTestFixture('opencode-minimax-docker');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/opencode',
+          model: 'vercel/minimax/minimax-m2.1',
+          timeout: 180,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'docker',
+        });
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      300000
+    );
+
+    // OpenCode + Minimax on Vercel
+    it.concurrent.skipIf(!hasVercelSandbox)(
+      'OpenCode + minimax-m2.1 on Vercel',
+      async () => {
+        const fixture = createTestFixture('opencode-minimax-vercel');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/opencode',
+          model: 'vercel/minimax/minimax-m2.1',
+          timeout: 180,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'vercel',
+        });
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      300000
+    );
+
+    // Claude Code on Docker
+    it.concurrent.skipIf(!hasDockerSandbox)(
+      'Claude Code + sonnet on Docker',
+      async () => {
+        const fixture = createTestFixture('claude-code-docker');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/claude-code',
+          model: 'sonnet',
+          timeout: 180,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'docker',
+        });
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      300000
+    );
+
+    // Claude Code on Vercel
+    it.concurrent.skipIf(!hasVercelSandbox)(
+      'Claude Code + sonnet on Vercel',
+      async () => {
+        const fixture = createTestFixture('claude-code-vercel');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/claude-code',
+          model: 'sonnet',
+          timeout: 180,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'vercel',
+        });
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      300000
+    );
+
+    // Codex on Docker
+    it.concurrent.skipIf(!hasDockerSandbox)(
+      'Codex + gpt-5.2-codex on Docker',
+      async () => {
+        const fixture = createTestFixture('codex-docker');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/codex',
+          model: 'openai/gpt-5.2-codex',
+          timeout: 180,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'docker',
+        });
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      300000
+    );
+
+    // Codex on Vercel
+    it.concurrent.skipIf(!hasVercelSandbox)(
+      'Codex + gpt-5.2-codex on Vercel',
+      async () => {
+        const fixture = createTestFixture('codex-vercel');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/codex',
+          model: 'openai/gpt-5.2-codex',
+          timeout: 180,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'vercel',
+        });
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      300000
+    );
   });
 
   describe('CLI commands', () => {

--- a/src/lib/agents/opencode.ts
+++ b/src/lib/agents/opencode.ts
@@ -82,7 +82,7 @@ export function createOpenCodeAgent(): Agent {
     },
 
     getDefaultModel(): ModelTier {
-      return 'anthropic/claude-sonnet-4';
+      return 'vercel/anthropic/claude-sonnet-4';
     },
 
     async run(fixturePath: string, options: AgentRunOptions): Promise<AgentRunResult> {

--- a/src/lib/docker-sandbox.ts
+++ b/src/lib/docker-sandbox.ts
@@ -370,6 +370,10 @@ export class DockerSandboxManager implements Sandbox {
 
     // Upload to container
     await this.container.putArchive(pack, { path: CONTAINER_WORKDIR });
+
+    // Fix ownership - putArchive uploads as root, but we need files owned by node user
+    // so that OpenCode and other agents can edit them
+    await this.runCommandAsRoot('chown', ['-R', `${SANDBOX_UID}:${SANDBOX_GID}`, CONTAINER_WORKDIR]);
   }
 
   /**


### PR DESCRIPTION
OpenCode requires the `vercel/` prefix in model strings (e.g., `vercel/minimax/minimax-m2.1`) because the agent's `opencode.json` config sets up a `vercel` provider. Without this prefix, OpenCode fails with a "provider not found" error since it looks for a provider named after the first path segment.

Additionally, the Docker sandbox was uploading files as root via `putArchive`, but OpenCode runs as the `node` user (UID 1000). This caused permission errors when the agent tried to edit files like `src/index.ts`. The fix adds a `chown` call after file upload to transfer ownership to the sandbox user.

Changes:
- Updated `getDefaultModel()` in `opencode.ts` to return `vercel/anthropic/claude-sonnet-4`
- Added `chown -R` after `uploadFiles` in `docker-sandbox.ts` 
- Updated README to document the required `vercel/` prefix with examples including minimax models
- Added parallel integration tests covering all agents (Claude Code, OpenCode + minimax, Codex) on both Docker and Vercel sandboxes using `it.concurrent`