### PR TITLE
[Agents] Add AI SDK Harness for evaluating any AI Gateway model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,9 @@ Configuration should be done through the experiment config file, not environment
 - All experiment settings belong in `ExperimentConfig` (see `src/lib/types.ts`)
 - The only acceptable env vars are API keys (e.g., `AI_GATEWAY_API_KEY`, `ANTHROPIC_API_KEY`, `VERCEL_TOKEN`)
 - When adding new configuration options, add them to the config schema in `src/lib/config.ts`
+
+### Testing
+
+- Always use the existing integration test framework (`src/integration.test.ts`) for testing
+- Do not create standalone test scripts in `/tmp` - they won't have proper module resolution
+- Run integration tests with: `INTEGRATION_TEST=1 npx vitest run src/integration.test.ts --testNamePattern="<pattern>"`

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Choose your agent and authentication method:
 agent: 'vercel-ai-gateway/claude-code'  // Claude Code via AI Gateway
 agent: 'vercel-ai-gateway/codex'        // OpenAI Codex via AI Gateway
 agent: 'vercel-ai-gateway/opencode'     // OpenCode via AI Gateway
+agent: 'vercel-ai-gateway/ai-sdk-harness' // Simple AI SDK harness (any model)
 
 // Direct API (uses provider keys directly)
 agent: 'claude-code'  // requires ANTHROPIC_API_KEY
@@ -261,6 +262,28 @@ Under the hood, the agent creates an `opencode.json` config file that configures
 
 And runs: `opencode run "<prompt>" --model {provider}/{model} --format json`
 
+### AI SDK Harness Model Configuration
+
+The AI SDK harness (`vercel-ai-gateway/ai-sdk-harness`) is a lightweight agent that works with **any model** available on Vercel AI Gateway. Unlike OpenCode, it uses the standard `{provider}/{model}` format without a `vercel/` prefix:
+
+```typescript
+// Anthropic models
+model: 'anthropic/claude-sonnet-4'
+model: 'anthropic/claude-opus-4'
+
+// Moonshot AI (Kimi) models
+model: 'moonshotai/kimi-k2.5'
+model: 'moonshotai/kimi-k2-thinking'
+
+// Minimax models
+model: 'minimax/minimax-m2.1'
+
+// OpenAI models
+model: 'openai/gpt-4o'
+```
+
+The AI SDK harness includes these tools: `readFile`, `writeFile`, `editFile`, `listFiles`, `glob`, `grep`, and `bash`. It's ideal for evaluating models that may not be fully compatible with OpenCode.
+
 ### Full Configuration
 
 ```typescript
@@ -274,6 +297,7 @@ const config: ExperimentConfig = {
   // - claude-code: 'opus'
   // - codex: 'openai/gpt-5.2-codex'
   // - opencode: 'vercel/anthropic/claude-sonnet-4' (note: vercel/ prefix required)
+  // - ai-sdk-harness: 'anthropic/claude-sonnet-4' (works with any AI Gateway model)
   model: 'opus',
 
   // How many times to run each eval

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -743,6 +743,269 @@ test('contains greeting', () => {
   });
 
   // ============================================================================
+  // AI SDK Harness tests
+  // Tests the new AI SDK agent with various models via AI Gateway
+  // ============================================================================
+
+  describe.skipIf(!hasAiGatewayCredentials)('AI SDK Harness tests', () => {
+    // First test with Claude to verify the agent implementation works
+    it('AI SDK Harness with anthropic/claude-sonnet-4 (baseline)', async () => {
+      const fixtureDir = join(TEST_DIR, 'ai-sdk-claude-baseline');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Add a function called greet that returns "Hello from Claude!"'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+test('greet exists', () => {
+  const content = readFileSync('src/index.ts', 'utf-8');
+  expect(content).toContain('greet');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'ai-sdk-claude-baseline',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+      writeFileSync(join(fixtureDir, 'src/index.ts'), '// TODO: implement');
+
+      const fixture = loadFixture(TEST_DIR, 'ai-sdk-claude-baseline');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/ai-sdk-harness',
+        model: 'anthropic/claude-sonnet-4',
+        timeout: 300,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: ['build'],
+      });
+
+      console.log('\n=== AI SDK Harness + anthropic/claude-sonnet-4 (baseline) ===');
+      console.log('Status:', result.result.status);
+      console.log('Duration:', result.result.duration);
+      if (result.result.error) {
+        console.log('Error:', result.result.error);
+      }
+      if (result.transcript) {
+        console.log('Transcript length:', result.transcript.length);
+        console.log('Transcript preview:', result.transcript.substring(0, 1000));
+      }
+
+      expect(result.result.duration).toBeGreaterThan(0);
+      expect(result.result.status).toBeDefined();
+      // This should pass if the agent implementation is correct
+      expect(result.result.status).toBe('passed');
+    }, 600000);
+    // Test with moonshotai/kimi-k2.5
+    it('AI SDK Harness with moonshotai/kimi-k2.5', async () => {
+      const fixtureDir = join(TEST_DIR, 'ai-sdk-kimi-k2.5');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Add a function called greet that returns "Hello from Kimi!"'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+test('greet exists', () => {
+  const content = readFileSync('src/index.ts', 'utf-8');
+  expect(content).toContain('greet');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'ai-sdk-kimi-k2.5',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+      writeFileSync(join(fixtureDir, 'src/index.ts'), '// TODO: implement');
+
+      const fixture = loadFixture(TEST_DIR, 'ai-sdk-kimi-k2.5');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/ai-sdk-harness',
+        model: 'moonshotai/kimi-k2.5',
+        timeout: 300,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: ['build'],
+      });
+
+      // Log detailed info for debugging
+      console.log('\n=== AI SDK Harness + moonshotai/kimi-k2.5 ===');
+      console.log('Status:', result.result.status);
+      console.log('Duration:', result.result.duration);
+      if (result.result.error) {
+        console.log('Error:', result.result.error);
+      }
+      if (result.transcript) {
+        console.log('Transcript length:', result.transcript.length);
+        console.log('Transcript preview:', result.transcript.substring(0, 500));
+      }
+
+      // Verify result structure
+      expect(result.result.duration).toBeGreaterThan(0);
+      expect(result.result.status).toBeDefined();
+      expect(['passed', 'failed']).toContain(result.result.status);
+
+      // Verify transcript is captured
+      if (result.transcript) {
+        expect(typeof result.transcript).toBe('string');
+        expect(result.transcript.length).toBeGreaterThan(0);
+      }
+    }, 600000);
+
+    // Comprehensive test verifying transcript and result structure
+    it('verifies AI SDK Harness + Kimi K2.5 transcript and result structure', async () => {
+      const fixtureDir = join(TEST_DIR, 'ai-sdk-kimi-structure-test');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Create a hello.ts file in the src directory that exports a greeting constant set to "Hello from Kimi K2.5!"'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+
+test('hello.ts exists', () => {
+  expect(existsSync('src/hello.ts')).toBe(true);
+});
+
+test('contains greeting constant', () => {
+  const content = readFileSync('src/hello.ts', 'utf-8');
+  expect(content).toContain('greeting');
+  expect(content).toContain('Hello from Kimi');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'ai-sdk-kimi-structure-test',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+
+      const fixture = loadFixture(TEST_DIR, 'ai-sdk-kimi-structure-test');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/ai-sdk-harness',
+        model: 'moonshotai/kimi-k2.5',
+        timeout: 300,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: ['build'],
+      });
+
+      console.log('\n=== AI SDK + Kimi K2.5 Structure Test ===');
+      console.log('Status:', result.result.status);
+      console.log('Duration:', result.result.duration);
+      console.log('Has transcript:', !!result.transcript);
+      console.log('Has outputContent:', !!result.outputContent);
+      console.log('Has generatedFiles:', !!result.generatedFiles);
+
+      // Verify EvalRunData structure
+      expect(result).toHaveProperty('result');
+      expect(result.result).toHaveProperty('status');
+      expect(result.result).toHaveProperty('duration');
+
+      // Verify optional properties have correct types when present
+      if (result.result.error) {
+        expect(typeof result.result.error).toBe('string');
+        console.log('Error:', result.result.error);
+      }
+
+      // Verify transcript structure if present
+      if (result.transcript) {
+        expect(typeof result.transcript).toBe('string');
+        expect(result.transcript.length).toBeGreaterThan(0);
+
+        // AI SDK agent outputs JSON events
+        const firstLine = result.transcript.split('\n')[0];
+        try {
+          const parsed = JSON.parse(firstLine);
+          console.log('Transcript first event type:', parsed.type || 'unknown');
+        } catch {
+          console.log('Transcript is not JSONL format');
+        }
+      }
+
+      // Verify output content structure if present
+      if (result.outputContent) {
+        console.log('Output content keys:', Object.keys(result.outputContent));
+        if (result.outputContent.eval) {
+          expect(typeof result.outputContent.eval).toBe('string');
+        }
+        if (result.outputContent.scripts?.build) {
+          expect(typeof result.outputContent.scripts.build).toBe('string');
+        }
+      }
+
+      // Verify generated files if present
+      if (result.generatedFiles) {
+        console.log('Generated files:', Object.keys(result.generatedFiles));
+      }
+    }, 600000);
+  });
+
+  // ============================================================================
   // Parallel sandbox tests for all agents/models
   // ============================================================================
 
@@ -906,6 +1169,46 @@ test('greet exists', () => {
         expect(['passed', 'failed']).toContain(result.result.status);
       },
       300000
+    );
+
+    // AI SDK Harness + Kimi K2.5 on Docker
+    it.concurrent.skipIf(!hasDockerSandbox)(
+      'AI SDK Harness + kimi-k2.5 on Docker',
+      async () => {
+        const fixture = createTestFixture('ai-sdk-kimi-docker');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/ai-sdk-harness',
+          model: 'moonshotai/kimi-k2.5',
+          timeout: 300,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'docker',
+        });
+        console.log('AI SDK + kimi-k2.5 Docker:', result.result.status, result.result.error || '');
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      600000
+    );
+
+    // AI SDK Harness + Kimi K2.5 on Vercel
+    it.concurrent.skipIf(!hasVercelSandbox)(
+      'AI SDK Harness + kimi-k2.5 on Vercel',
+      async () => {
+        const fixture = createTestFixture('ai-sdk-kimi-vercel');
+        const result = await runSingleEval(fixture, {
+          agent: 'vercel-ai-gateway/ai-sdk-harness',
+          model: 'moonshotai/kimi-k2.5',
+          timeout: 300,
+          apiKey: process.env.AI_GATEWAY_API_KEY!,
+          scripts: ['build'],
+          sandbox: 'vercel',
+        });
+        console.log('AI SDK + kimi-k2.5 Vercel:', result.result.status, result.result.error || '');
+        expect(result.result.duration).toBeGreaterThan(0);
+        expect(['passed', 'failed']).toContain(result.result.status);
+      },
+      600000
     );
   });
 

--- a/src/lib/agents/ai-sdk-agent.ts
+++ b/src/lib/agents/ai-sdk-agent.ts
@@ -1,0 +1,472 @@
+/**
+ * AI SDK Agent - A simple coding agent using the Vercel AI SDK.
+ * Works with any model available on Vercel AI Gateway.
+ */
+
+import type { Agent, AgentRunOptions, AgentRunResult } from './types.js';
+import type { ModelTier } from '../types.js';
+import {
+  createSandbox,
+  collectLocalFiles,
+  splitTestFiles,
+  verifyNoTestFiles,
+  type SandboxManager,
+} from '../sandbox.js';
+import type { DockerSandboxManager } from '../docker-sandbox.js';
+import {
+  runValidation,
+  captureGeneratedFiles,
+  createVitestConfig,
+  AI_GATEWAY,
+} from './shared.js';
+
+/** Union type for sandbox implementations */
+type AnySandbox = SandboxManager | DockerSandboxManager;
+
+/**
+ * The CLI script source code that runs inside the sandbox.
+ * This is a self-contained script that uses the AI SDK.
+ */
+const CLI_SCRIPT = `
+import { generateText, tool, stepCountIs } from 'ai';
+import { createGateway } from '@ai-sdk/gateway';
+import { z } from 'zod';
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { execSync } from 'child_process';
+import { join, dirname } from 'path';
+import { mkdirSync } from 'fs';
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+let prompt = '';
+let model = '';
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--prompt' && args[i + 1]) {
+    prompt = args[++i];
+  } else if (args[i] === '--model' && args[i + 1]) {
+    model = args[++i];
+  }
+}
+
+if (!prompt || !model) {
+  console.error('Usage: ai-sdk-agent --prompt "..." --model "provider/model"');
+  process.exit(1);
+}
+
+// Create AI Gateway client
+const gateway = createGateway({
+  apiKey: process.env.AI_GATEWAY_API_KEY,
+});
+
+// Transcript events
+const events = [];
+
+function logEvent(type, data) {
+  const event = { type, timestamp: Date.now(), ...data };
+  events.push(event);
+  console.log(JSON.stringify(event));
+}
+
+// Define coding tools
+const tools = {
+  readFile: tool({
+    description: 'Read the contents of a file at the given path',
+    inputSchema: z.object({
+      path: z.string().describe('The file path to read'),
+    }),
+    execute: async ({ path }) => {
+      try {
+        const content = readFileSync(path, 'utf-8');
+        logEvent('tool_result', { tool: 'readFile', path, success: true });
+        return content;
+      } catch (error) {
+        logEvent('tool_result', { tool: 'readFile', path, success: false, error: error.message });
+        return \`Error reading file: \${error.message}\`;
+      }
+    },
+  }),
+
+  writeFile: tool({
+    description: 'Write content to a file at the given path. Creates directories if needed.',
+    inputSchema: z.object({
+      path: z.string().describe('The file path to write'),
+      content: z.string().describe('The content to write'),
+    }),
+    execute: async ({ path, content }) => {
+      try {
+        const dir = dirname(path);
+        if (dir && dir !== '.') {
+          mkdirSync(dir, { recursive: true });
+        }
+        writeFileSync(path, content);
+        logEvent('tool_result', { tool: 'writeFile', path, success: true });
+        return 'File written successfully';
+      } catch (error) {
+        logEvent('tool_result', { tool: 'writeFile', path, success: false, error: error.message });
+        return \`Error writing file: \${error.message}\`;
+      }
+    },
+  }),
+
+  editFile: tool({
+    description: 'Edit a file by replacing a specific string with new content',
+    inputSchema: z.object({
+      path: z.string().describe('The file path to edit'),
+      oldString: z.string().describe('The exact string to find and replace'),
+      newString: z.string().describe('The replacement string'),
+    }),
+    execute: async ({ path, oldString, newString }) => {
+      try {
+        const content = readFileSync(path, 'utf-8');
+        if (!content.includes(oldString)) {
+          logEvent('tool_result', { tool: 'editFile', path, success: false, error: 'String not found' });
+          return 'Error: The specified string was not found in the file';
+        }
+        const newContent = content.replace(oldString, newString);
+        writeFileSync(path, newContent);
+        logEvent('tool_result', { tool: 'editFile', path, success: true });
+        return 'File edited successfully';
+      } catch (error) {
+        logEvent('tool_result', { tool: 'editFile', path, success: false, error: error.message });
+        return \`Error editing file: \${error.message}\`;
+      }
+    },
+  }),
+
+  listFiles: tool({
+    description: 'List files in a directory. Call with path="." to list current directory.',
+    inputSchema: z.object({
+      path: z.string().describe('The directory path to list (use "." for current directory)'),
+      recursive: z.boolean().describe('Whether to list recursively').optional(),
+    }),
+    execute: async ({ path, recursive }) => {
+      const targetPath = path || '.';
+      const isRecursive = recursive || false;
+      try {
+        if (isRecursive) {
+          const result = execSync(\`find \${targetPath} -type f | head -100\`, { encoding: 'utf-8' });
+          logEvent('tool_result', { tool: 'listFiles', path: targetPath, recursive: isRecursive, success: true });
+          return result;
+        }
+        const files = readdirSync(targetPath);
+        logEvent('tool_result', { tool: 'listFiles', path: targetPath, recursive: isRecursive, success: true });
+        return files.join('\\n');
+      } catch (error) {
+        logEvent('tool_result', { tool: 'listFiles', path: targetPath, success: false, error: error.message });
+        return \`Error listing files: \${error.message}\`;
+      }
+    },
+  }),
+
+  glob: tool({
+    description: 'Find files matching a pattern (e.g., "*.ts" for TypeScript files)',
+    inputSchema: z.object({
+      pattern: z.string().describe('The file pattern (e.g., "*.ts", "*.js")'),
+    }),
+    execute: async ({ pattern }) => {
+      try {
+        // Extract just the file pattern, remove any path prefix
+        const filePattern = pattern.replace(/^\\*\\*\\//, '').replace(/^\\.\\//, '');
+        const result = execSync(\`find . -name "\${filePattern}" -type f 2>/dev/null | grep -v node_modules | head -50\`, { encoding: 'utf-8' });
+        logEvent('tool_result', { tool: 'glob', pattern, success: true });
+        return result.trim() || 'No files found';
+      } catch (error) {
+        logEvent('tool_result', { tool: 'glob', pattern, success: false, error: error.message });
+        return 'No files found';
+      }
+    },
+  }),
+
+  grep: tool({
+    description: 'Search for a text pattern in files',
+    inputSchema: z.object({
+      pattern: z.string().describe('The search pattern'),
+      path: z.string().describe('The file or directory to search in').optional(),
+    }),
+    execute: async ({ pattern, path }) => {
+      const targetPath = path || '.';
+      try {
+        const result = execSync(\`grep -rn "\${pattern}" \${targetPath} 2>/dev/null | grep -v node_modules | head -50\`, { encoding: 'utf-8' });
+        logEvent('tool_result', { tool: 'grep', pattern, path: targetPath, success: true });
+        return result.trim() || 'No matches found';
+      } catch (error) {
+        logEvent('tool_result', { tool: 'grep', pattern, path: targetPath, success: false });
+        return 'No matches found';
+      }
+    },
+  }),
+
+  bash: tool({
+    description: 'Run a bash command',
+    inputSchema: z.object({
+      command: z.string().describe('The command to run'),
+    }),
+    execute: async ({ command }) => {
+      try {
+        const result = execSync(command, { encoding: 'utf-8', timeout: 30000 });
+        logEvent('tool_result', { tool: 'bash', command, success: true });
+        return result;
+      } catch (error) {
+        logEvent('tool_result', { tool: 'bash', command, success: false, error: error.message });
+        return \`Error: \${error.message}\\n\${error.stdout || ''}\\n\${error.stderr || ''}\`;
+      }
+    },
+  }),
+};
+
+// System prompt for the coding agent
+const systemPrompt = \`You are an expert coding agent. Your job is to complete programming tasks by reading, writing, and modifying files.
+
+Available tools:
+- readFile(path): Read a file's contents
+- writeFile(path, content): Write/create a file (creates directories if needed)
+- editFile(path, oldString, newString): Replace a specific string in a file
+- listFiles(path): List files in a directory (use path="." for current directory)
+- glob(pattern): Find files by pattern (e.g., "*.ts")
+- grep(pattern, path): Search for text in files
+- bash(command): Run shell commands
+
+IMPORTANT WORKFLOW:
+1. First, list files to understand the project structure: listFiles(path=".")
+2. Read any relevant existing files to understand the context
+3. Make the necessary code changes using writeFile or editFile
+4. If needed, run build/test commands with bash to verify
+
+RULES:
+- Always check what files exist before modifying them
+- Create complete, working code - not placeholders
+- Put files in the correct directories (e.g., src/ for source files)
+- Be thorough but efficient\`;
+
+// Run the agent
+async function main() {
+  logEvent('start', { model, prompt });
+
+  try {
+    const result = await generateText({
+      model: gateway(model),
+      tools,
+      stopWhen: stepCountIs(100), // Allow up to 100 steps
+      system: systemPrompt,
+      prompt,
+      onStepFinish: ({ stepType, text, toolCalls, toolResults }) => {
+        logEvent('step', { stepType, text, toolCalls: toolCalls?.length, toolResults: toolResults?.length });
+      },
+    });
+
+    logEvent('complete', {
+      success: true,
+      steps: result.steps.length,
+      text: result.text,
+    });
+  } catch (error) {
+    logEvent('error', {
+      success: false,
+      error: error.message,
+      name: error.name,
+    });
+    process.exit(1);
+  }
+}
+
+main();
+`;
+
+/**
+ * Create AI SDK agent with Vercel AI Gateway authentication.
+ */
+export function createAiSdkAgent(): Agent {
+  return {
+    name: 'vercel-ai-gateway/ai-sdk-harness',
+    displayName: 'AI SDK Harness (Vercel AI Gateway)',
+
+    getApiKeyEnvVar(): string {
+      return AI_GATEWAY.apiKeyEnvVar;
+    },
+
+    getDefaultModel(): ModelTier {
+      return 'anthropic/claude-sonnet-4';
+    },
+
+    async run(fixturePath: string, options: AgentRunOptions): Promise<AgentRunResult> {
+      const startTime = Date.now();
+      let sandbox: AnySandbox | null = null;
+      let agentOutput = '';
+      let aborted = false;
+      let sandboxStopped = false;
+
+      // Handle abort signal
+      const abortHandler = () => {
+        aborted = true;
+        if (sandbox && !sandboxStopped) {
+          sandboxStopped = true;
+          sandbox.stop().catch(() => {});
+        }
+      };
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted before start',
+            duration: 0,
+          };
+        }
+        options.signal.addEventListener('abort', abortHandler);
+      }
+
+      try {
+        // Collect files from fixture
+        const allFiles = await collectLocalFiles(fixturePath);
+        const { workspaceFiles, testFiles } = splitTestFiles(allFiles);
+
+        // Check for abort before expensive operations
+        if (aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+          };
+        }
+
+        // Create sandbox
+        sandbox = await createSandbox({
+          timeout: options.timeout,
+          runtime: 'node24',
+          backend: options.sandbox,
+        });
+
+        // Check for abort after sandbox creation
+        if (aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+            sandboxId: sandbox.sandboxId,
+          };
+        }
+
+        // Upload workspace files (excluding tests)
+        await sandbox.uploadFiles(workspaceFiles);
+
+        // Run setup function if provided
+        if (options.setup) {
+          await options.setup(sandbox);
+        }
+
+        // Install dependencies
+        const installResult = await sandbox.runCommand('npm', ['install']);
+        if (installResult.exitCode !== 0) {
+          throw new Error(`npm install failed: ${installResult.stderr}`);
+        }
+
+        // Install AI SDK dependencies
+        const aiInstall = await sandbox.runCommand('npm', [
+          'install',
+          'ai@^5.0.11',
+          '@ai-sdk/gateway@^1.0.0',
+          'zod@^3.23.8',
+        ]);
+        if (aiInstall.exitCode !== 0) {
+          throw new Error(`AI SDK install failed: ${aiInstall.stderr}`);
+        }
+
+        // Write the CLI script to the sandbox
+        await sandbox.writeFiles({
+          'ai-sdk-agent.mjs': CLI_SCRIPT,
+        });
+
+        // Verify no test files in sandbox
+        await verifyNoTestFiles(sandbox);
+
+        // Run the AI SDK agent
+        const agentResult = await sandbox.runCommand(
+          'node',
+          [
+            'ai-sdk-agent.mjs',
+            '--prompt',
+            options.prompt,
+            '--model',
+            options.model,
+          ],
+          {
+            env: {
+              [AI_GATEWAY.apiKeyEnvVar]: options.apiKey,
+            },
+          }
+        );
+
+        agentOutput = agentResult.stdout + agentResult.stderr;
+
+        if (agentResult.exitCode !== 0) {
+          // Extract meaningful error from output
+          const errorLines = agentOutput.trim().split('\n').slice(-5).join('\n');
+          return {
+            success: false,
+            output: agentOutput,
+            error: errorLines || `AI SDK agent exited with code ${agentResult.exitCode}`,
+            duration: Date.now() - startTime,
+            sandboxId: sandbox.sandboxId,
+          };
+        }
+
+        // Upload test files for validation
+        await sandbox.uploadFiles(testFiles);
+
+        // Create vitest config for EVAL.ts/tsx
+        await createVitestConfig(sandbox);
+
+        // The agent outputs JSON events, use that as transcript
+        const transcript = agentOutput;
+
+        // Run validation scripts
+        const validationResults = await runValidation(sandbox, options.scripts ?? []);
+
+        // Capture generated files
+        const generatedFiles = await captureGeneratedFiles(sandbox);
+
+        return {
+          success: validationResults.allPassed,
+          output: agentOutput,
+          transcript,
+          duration: Date.now() - startTime,
+          testResult: validationResults.test,
+          scriptsResults: validationResults.scripts,
+          sandboxId: sandbox.sandboxId,
+          generatedFiles,
+        };
+      } catch (error) {
+        // Check if this was an abort
+        if (aborted) {
+          return {
+            success: false,
+            output: agentOutput,
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+            sandboxId: sandbox?.sandboxId,
+          };
+        }
+        return {
+          success: false,
+          output: agentOutput,
+          error: error instanceof Error ? error.message : String(error),
+          duration: Date.now() - startTime,
+          sandboxId: sandbox?.sandboxId,
+        };
+      } finally {
+        // Clean up abort listener
+        if (options.signal) {
+          options.signal.removeEventListener('abort', abortHandler);
+        }
+        if (sandbox && !sandboxStopped) {
+          sandboxStopped = true;
+          await sandbox.stop();
+        }
+      }
+    },
+  };
+}

--- a/src/lib/agents/index.ts
+++ b/src/lib/agents/index.ts
@@ -6,6 +6,7 @@ import { registerAgent, getAgent, listAgents, hasAgent } from './registry.js';
 import { createClaudeCodeAgent } from './claude-code.js';
 import { createCodexAgent } from './codex.js';
 import { createOpenCodeAgent } from './opencode.js';
+import { createAiSdkAgent } from './ai-sdk-agent.js';
 
 // Register all agent variants (Vercel AI Gateway + Direct API)
 registerAgent(createClaudeCodeAgent({ useVercelAiGateway: true }));   // vercel-ai-gateway/claude-code
@@ -13,6 +14,7 @@ registerAgent(createClaudeCodeAgent({ useVercelAiGateway: false }));  // claude-
 registerAgent(createCodexAgent({ useVercelAiGateway: true }));        // vercel-ai-gateway/codex
 registerAgent(createCodexAgent({ useVercelAiGateway: false }));       // codex
 registerAgent(createOpenCodeAgent());                                 // vercel-ai-gateway/opencode
+registerAgent(createAiSdkAgent());                                    // vercel-ai-gateway/ai-sdk-harness
 
 // Re-export registry functions
 export { registerAgent, getAgent, listAgents, hasAgent };


### PR DESCRIPTION
OpenCode has compatibility issues with certain models on Vercel AI Gateway. Kimi K2.5 fails with `GatewayInternalServerError: Bad Request` on multi-turn conversations, and Kimi K2 Thinking fails with Zod validation errors due to response format incompatibility.

This adds a new lightweight agent `vercel-ai-gateway/ai-sdk-harness` that uses the AI SDK directly without relying on OpenCode's CLI. The harness bundles a self-contained Node.js script into the sandbox that:

- Uses `generateText` with `stopWhen: stepCountIs(100)` for multi-step tool calling
- Defines standard coding tools: `readFile`, `writeFile`, `editFile`, `listFiles`, `glob`, `grep`, `bash`
- Works with the standard `{provider}/{model}` format (e.g., `moonshotai/kimi-k2.5`) without the `vercel/` prefix required by OpenCode
- Outputs JSON transcript events to stdout for debugging

The harness is ideal for evaluating models that may not be fully compatible with OpenCode's response parsing.

Also fixes an unused `readFileSync` import in `cli.test.ts`.