### PR TITLE
feat: add `editPrompt` config to experiment

### DIFF
--- a/.changeset/funny-snakes-switch.md
+++ b/.changeset/funny-snakes-switch.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+feat: add `editPrompt` config to experiment

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -44,6 +44,7 @@ const experimentConfigSchema = z.object({
   timeout: z.number().positive().optional(),
   setup: z.function().optional(),
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
+  editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
 });
 
 /**
@@ -83,6 +84,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     timeout: config.timeout ?? CONFIG_DEFAULTS.timeout,
     setup: config.setup,
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
+    editPrompt: config.editPrompt,
   };
 }
 

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -132,7 +132,7 @@ export async function runExperiment(
 
     const agentResult = await Promise.race([
       agent.run(fixture.path, {
-        prompt: fixture.prompt,
+        prompt: config.editPrompt ? config.editPrompt(fixture.prompt) : fixture.prompt,
         model: config.model,
         timeout: timeoutMs,
         apiKey,
@@ -257,19 +257,21 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     setup?: ResolvedExperimentConfig['setup'];
     scripts?: string[];
     sandbox?: ResolvedExperimentConfig['sandbox'];
+    editPrompt?: (prompt: string) => string;
     verbose?: boolean;
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
 
   const models: string[] = Array.isArray(options.model) ? options.model : [options.model];
+  const prompt = options.editPrompt ? options.editPrompt(fixture.prompt) : fixture.prompt;
 
   const results: EvalRunData[] = [];
 
   for (const model of models) {
 
 	const agentResult = await agent.run(fixture.path, {
-		prompt: fixture.prompt,
+		prompt,
 		model,
 		timeout: options.timeout * 1000,
 		apiKey: options.apiKey,

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -86,6 +86,9 @@ export interface ExperimentConfig {
 
   /** Sandbox backend to use. @default 'auto' (Vercel if token present, else Docker) */
   sandbox?: SandboxBackend | 'auto';
+
+  /** Optional function to modify the prompt before running the experiment. @default undefined */
+  editPrompt?: (prompt: string) => string;
 }
 
 /**
@@ -101,6 +104,7 @@ export interface ResolvedExperimentConfig {
   timeout: number;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
+  editPrompt?: (prompt: string) => string;
 }
 
 /**
@@ -116,6 +120,7 @@ export interface RunnableExperimentConfig {
   timeout: number;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
+  editPrompt?: (prompt: string) => string;
 }
 
 /**


### PR DESCRIPTION
This adds an `editPrompt` function to the experiment config so that you can change the prompt before sending it to the agent allowing for customizations at the experiment level (like adding "use the skill" or wrapping the prompt in an MCP prompt)