### PR TITLE
Add run-all command with housekeeping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,8 @@ Configuration should be done through the experiment config file, not environment
 - Always use the existing integration test framework (`src/integration.test.ts`) for testing
 - Do not create standalone test scripts in `/tmp` - they won't have proper module resolution
 - Run integration tests with: `INTEGRATION_TEST=1 npx vitest run src/integration.test.ts --testNamePattern="<pattern>"`
+
+### Pull Requests
+
+- Every PR that changes user-facing behavior should update the README
+- Every PR should include a changeset (`npx changeset`) for version management

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -7,7 +7,7 @@
 import { Command } from 'commander';
 import { config as dotenvConfig } from 'dotenv';
 import { resolve, dirname, basename } from 'path';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 import chalk from 'chalk';
 import { loadConfig, resolveEvalNames } from './lib/config.js';
@@ -16,7 +16,12 @@ import { runExperiment } from './lib/runner.js';
 import { initProject, getPostInitInstructions } from './lib/init.js';
 import { getAgent } from './lib/agents/index.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
+import { computeFingerprint } from './lib/fingerprint.js';
+import { scanReusableResults } from './lib/results.js';
+import { classifyFailure, shouldRetry } from './lib/classifier.js';
+import { housekeep } from './lib/housekeeping.js';
 import { spawnSync } from 'child_process';
+import { minimatch } from 'minimatch';
 
 // Load environment variables (.env.local first, then .env as fallback)
 dotenvConfig({ path: '.env.local' });
@@ -257,6 +262,234 @@ program
     );
 
     process.exit(result.status ?? 1);
+  });
+
+/**
+ * run-all command - discover and run all experiments
+ */
+program
+  .command('run-all')
+  .description('Discover and run all experiments, with fingerprint reuse, classification, and auto-retry')
+  .argument('[experiments...]', 'Experiment names or glob patterns (default: all)')
+  .option('--dry', 'Preview what would run without executing')
+  .option('--force', 'Ignore fingerprints, re-run everything')
+  .option('--smoke', 'Run 1 eval per experiment for sanity checking')
+  .action(async (experimentArgs: string[], options: { dry?: boolean; force?: boolean; smoke?: boolean }) => {
+    try {
+      const projectDir = process.cwd();
+      const experimentsDir = resolve(projectDir, 'experiments');
+      const evalsDir = resolve(projectDir, 'evals');
+      const resultsDir = resolve(projectDir, 'results');
+
+      if (!existsSync(experimentsDir)) {
+        console.error(chalk.red('experiments/ directory not found'));
+        process.exit(1);
+      }
+      if (!existsSync(evalsDir)) {
+        console.error(chalk.red('evals/ directory not found'));
+        process.exit(1);
+      }
+
+      // Discover experiments
+      const allExperimentFiles = readdirSync(experimentsDir)
+        .filter((f) => f.endsWith('.ts') && !f.startsWith('_temp_'))
+        .sort();
+
+      // Filter by args if provided
+      let selectedFiles: string[];
+      if (experimentArgs.length > 0) {
+        selectedFiles = allExperimentFiles.filter((f) => {
+          const name = f.replace(/\.ts$/, '');
+          return experimentArgs.some((arg) =>
+            arg.includes('*') ? minimatch(name, arg) : name === arg
+          );
+        });
+        if (selectedFiles.length === 0) {
+          console.error(chalk.red(`No experiments matched: ${experimentArgs.join(', ')}`));
+          console.error(chalk.gray(`Available: ${allExperimentFiles.map((f) => f.replace(/\.ts$/, '')).join(', ')}`));
+          process.exit(1);
+        }
+      } else {
+        selectedFiles = allExperimentFiles;
+      }
+
+      console.log(chalk.blue(`Discovered ${selectedFiles.length} experiment(s):`));
+      for (const f of selectedFiles) {
+        console.log(chalk.blue(`  - ${f.replace(/\.ts$/, '')}`));
+      }
+
+      // Load all fixtures
+      const { fixtures, errors } = loadAllFixtures(evalsDir);
+      if (errors.length > 0) {
+        console.log(chalk.yellow(`\nWarning: ${errors.length} invalid fixture(s)`));
+      }
+      if (fixtures.length === 0) {
+        console.error(chalk.red('No valid eval fixtures found'));
+        process.exit(1);
+      }
+
+      if (options.dry) {
+        console.log(chalk.yellow('\n[DRY RUN] Would run the above experiments'));
+        if (options.smoke) {
+          console.log(chalk.yellow('  Mode: smoke test (1 eval per experiment)'));
+        }
+        if (options.force) {
+          console.log(chalk.yellow('  Force: re-run everything (ignoring fingerprints)'));
+        }
+        return;
+      }
+
+      // Run all experiments in parallel
+      let allPassed = true;
+      const experimentPromises = selectedFiles.map(async (file) => {
+        const configPath = resolve(experimentsDir, file);
+        const baseExperimentName = file.replace(/\.ts$/, '');
+
+        let config;
+        try {
+          config = await loadConfig(configPath);
+        } catch (err) {
+          console.error(chalk.red(`Failed to load ${file}: ${err instanceof Error ? err.message : err}`));
+          return;
+        }
+
+        const models = Array.isArray(config.model) ? config.model : [config.model];
+        const availableNames = fixtures.map((f) => f.name);
+        let evalNames: string[];
+        try {
+          evalNames = resolveEvalNames(config.evals, availableNames);
+        } catch {
+          evalNames = availableNames;
+        }
+
+        // Smoke mode: pick first eval
+        if (options.smoke) {
+          evalNames = [evalNames.sort()[0]];
+        }
+
+        const agent = getAgent(config.agent);
+        const apiKeyEnvVar = agent.getApiKeyEnvVar();
+        const apiKey = process.env[apiKeyEnvVar];
+        if (!apiKey) {
+          console.error(chalk.red(`${apiKeyEnvVar} not set, skipping ${baseExperimentName}`));
+          return;
+        }
+
+        for (const model of models) {
+          const experimentName = models.length > 1
+            ? `${baseExperimentName}/${model}`
+            : baseExperimentName;
+
+          const modelConfig = {
+            ...config,
+            model,
+            runs: options.smoke ? 1 : config.runs,
+          };
+
+          // Compute fingerprints
+          const selectedFixtures = fixtures.filter((f) => evalNames.includes(f.name));
+          const fingerprints: Record<string, string> = {};
+          for (const fixture of selectedFixtures) {
+            fingerprints[fixture.name] = computeFingerprint(fixture.path, modelConfig);
+          }
+
+          // Check for reusable results (unless --force)
+          let fixturesToRun = selectedFixtures;
+          if (!options.force) {
+            const reusable = scanReusableResults(resultsDir, experimentName, fingerprints);
+            if (reusable.size > 0) {
+              console.log(chalk.gray(`  ${experimentName}: reusing ${reusable.size} cached result(s)`));
+              fixturesToRun = selectedFixtures.filter((f) => !reusable.has(f.name));
+            }
+          }
+
+          if (fixturesToRun.length === 0) {
+            console.log(chalk.gray(`  ${experimentName}: all evals cached, skipping`));
+            continue;
+          }
+
+          console.log(chalk.blue(`\nRunning ${experimentName}: ${fixturesToRun.length} eval(s)`));
+
+          try {
+            const results = await runExperiment({
+              config: modelConfig,
+              fixtures: fixturesToRun,
+              apiKey,
+              resultsDir,
+              experimentName,
+              onProgress: (msg) => console.log(`  ${msg}`),
+            });
+
+            // Classify failures and check for auto-retry
+            const failedEvals = results.evals.filter((e) => e.passedRuns === 0);
+            if (failedEvals.length > 0 && !options.smoke) {
+              const classifications: Record<string, { failureType: string; failureReason: string }> = {};
+              const timestamp = results.startedAt.replace(/:/g, '-');
+
+              for (const evalSummary of failedEvals) {
+                const evalResultDir = resolve(resultsDir, experimentName, timestamp, evalSummary.name);
+                const classification = await classifyFailure(
+                  evalResultDir,
+                  evalSummary.name,
+                  experimentName
+                );
+                if (classification) {
+                  classifications[evalSummary.name] = classification;
+                  const icon = { model: '  ', infra: '  ', timeout: '  ' }[classification.failureType];
+                  console.log(chalk.gray(`  ${icon} ${evalSummary.name}: ${classification.failureType} — ${classification.failureReason}`));
+                }
+              }
+
+              // Auto-retry: if ALL failures are non-model, retry once
+              const classificationValues = Object.values(classifications);
+              if (
+                classificationValues.length === failedEvals.length &&
+                shouldRetry(classificationValues.map((c) => ({ failureType: c.failureType as 'model' | 'infra' | 'timeout', failureReason: c.failureReason })))
+              ) {
+                const retryFixtures = fixturesToRun.filter((f) =>
+                  failedEvals.some((e) => e.name === f.name)
+                );
+                console.log(chalk.yellow(`  Retrying ${retryFixtures.length} infra-failed eval(s)...`));
+                await runExperiment({
+                  config: modelConfig,
+                  fixtures: retryFixtures,
+                  apiKey,
+                  resultsDir,
+                  experimentName,
+                  onProgress: (msg) => console.log(`  [retry] ${msg}`),
+                });
+              }
+            }
+
+            const experimentPassed = results.evals.every((e) => e.passedRuns > 0);
+            if (!experimentPassed) allPassed = false;
+          } catch (err) {
+            console.error(chalk.red(`  Error running ${experimentName}: ${err instanceof Error ? err.message : err}`));
+            allPassed = false;
+          }
+
+          // Housekeeping after each experiment
+          const stats = housekeep(resultsDir, experimentName);
+          if (stats.removedDuplicates + stats.removedIncomplete > 0) {
+            console.log(
+              chalk.gray(
+                `  Housekeeping: removed ${stats.removedDuplicates} duplicate(s), ${stats.removedIncomplete} incomplete`
+              )
+            );
+          }
+        }
+      });
+
+      await Promise.all(experimentPromises);
+      process.exit(allPassed ? 0 : 1);
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(chalk.red(`Error: ${error.message}`));
+      } else {
+        console.error(chalk.red('An unknown error occurred'));
+      }
+      process.exit(1);
+    }
   });
 
 /**

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -101,6 +101,9 @@ export {
   shouldRetry,
 } from './lib/classifier.js';
 
+// Re-export housekeeping
+export { housekeep } from './lib/housekeeping.js';
+
 // Re-export runner utilities
 export type { RunExperimentOptions } from './lib/runner.js';
 export { runExperiment, runSingleEval } from './lib/runner.js';

--- a/packages/agent-eval/src/lib/housekeeping.test.ts
+++ b/packages/agent-eval/src/lib/housekeeping.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { housekeep } from './housekeeping.js';
+
+const TEST_DIR = '/tmp/eval-framework-housekeeping-test';
+
+function createResult(
+  dir: string,
+  opts: { summary?: boolean; transcript?: boolean; passedRuns?: number }
+) {
+  mkdirSync(dir, { recursive: true });
+  if (opts.summary !== false) {
+    writeFileSync(
+      join(dir, 'summary.json'),
+      JSON.stringify({
+        totalRuns: 2,
+        passedRuns: opts.passedRuns ?? 1,
+        passRate: '50%',
+        meanDuration: 10,
+      })
+    );
+  }
+  if (opts.transcript !== false) {
+    const runDir = join(dir, 'run-1');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, 'result.json'), JSON.stringify({ status: 'passed', duration: 10 }));
+    writeFileSync(join(runDir, 'transcript-raw.jsonl'), '{"role":"assistant"}\n');
+  }
+}
+
+describe('housekeep', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  it('keeps newest result and removes older duplicate', () => {
+    // Newer timestamp
+    createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'), {});
+    // Older timestamp
+    createResult(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', 'eval-1'), {});
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    expect(stats.removedDuplicates).toBe(1);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'))).toBe(true);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', 'eval-1'))).toBe(false);
+  });
+
+  it('removes incomplete results (no summary)', () => {
+    createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'), {
+      summary: false,
+    });
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    expect(stats.removedIncomplete).toBe(1);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'))).toBe(false);
+  });
+
+  it('removes empty timestamp directories', () => {
+    // Create a result, then mark it as incomplete so it gets removed
+    createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'), {
+      summary: false,
+    });
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    expect(stats.removedEmptyDirs).toBe(1);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z'))).toBe(false);
+  });
+
+  it('dry run does not delete anything', () => {
+    createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'), {});
+    createResult(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', 'eval-1'), {});
+
+    const stats = housekeep(TEST_DIR, 'exp', { dry: true });
+
+    expect(stats.removedDuplicates).toBe(1);
+    // Both should still exist
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'))).toBe(true);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', 'eval-1'))).toBe(true);
+  });
+
+  it('handles non-existent experiment gracefully', () => {
+    const stats = housekeep(TEST_DIR, 'no-such-exp');
+    expect(stats.removedDuplicates).toBe(0);
+    expect(stats.removedIncomplete).toBe(0);
+    expect(stats.removedEmptyDirs).toBe(0);
+  });
+
+  it('keeps results without transcript if summary has totalRuns > 0', () => {
+    createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'), {
+      transcript: false,
+      passedRuns: 0,
+    });
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    // Should be kept (model failure with valid summary)
+    expect(stats.removedIncomplete).toBe(0);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'))).toBe(true);
+  });
+});

--- a/packages/agent-eval/src/lib/housekeeping.ts
+++ b/packages/agent-eval/src/lib/housekeeping.ts
@@ -1,0 +1,147 @@
+/**
+ * Housekeeping for eval results.
+ *
+ * After experiments complete, consolidate results:
+ * - For each (experiment, eval) pair: keep only the latest valid result
+ * - Remove older duplicates and dangling/incomplete results
+ * - Remove empty timestamp directories
+ */
+
+import { readdirSync, rmSync, existsSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+interface HousekeepingStats {
+  removedDuplicates: number;
+  removedIncomplete: number;
+  removedEmptyDirs: number;
+}
+
+/**
+ * Run housekeeping on a single experiment's results directory.
+ *
+ * For each eval: keeps the newest complete result (has summary.json and
+ * at least one transcript), removes older duplicates and incomplete results.
+ * Removes empty timestamp directories afterward.
+ */
+export function housekeep(
+  resultsDir: string,
+  experimentName: string,
+  options?: { dry?: boolean }
+): HousekeepingStats {
+  const stats: HousekeepingStats = {
+    removedDuplicates: 0,
+    removedIncomplete: 0,
+    removedEmptyDirs: 0,
+  };
+
+  const experimentDir = join(resultsDir, experimentName);
+  if (!existsSync(experimentDir)) return stats;
+
+  // Get all timestamps sorted newest first
+  let timestamps: string[];
+  try {
+    timestamps = readdirSync(experimentDir)
+      .filter((t) => !t.startsWith('.'))
+      .filter((t) => {
+        try {
+          return statSync(join(experimentDir, t)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .sort()
+      .reverse();
+  } catch {
+    return stats;
+  }
+
+  // Track which evals we've already seen (newest wins)
+  const seenEvals = new Set<string>();
+
+  for (const timestamp of timestamps) {
+    const tsDir = join(experimentDir, timestamp);
+
+    let evalDirs: string[];
+    try {
+      evalDirs = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
+    } catch {
+      continue;
+    }
+
+    for (const evalDir of evalDirs) {
+      const evalResultDir = join(tsDir, evalDir);
+
+      if (!statSync(evalResultDir).isDirectory()) continue;
+
+      if (seenEvals.has(evalDir)) {
+        // Older duplicate — remove
+        if (!options?.dry) {
+          rmSync(evalResultDir, { recursive: true });
+        }
+        stats.removedDuplicates++;
+        continue;
+      }
+
+      // Check if this result is complete
+      if (isComplete(evalResultDir)) {
+        seenEvals.add(evalDir);
+      } else {
+        // Incomplete — remove
+        if (!options?.dry) {
+          rmSync(evalResultDir, { recursive: true });
+        }
+        stats.removedIncomplete++;
+      }
+    }
+
+    // Check if timestamp dir is now empty
+    try {
+      const remaining = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
+      if (remaining.length === 0) {
+        if (!options?.dry) {
+          rmSync(tsDir, { recursive: true });
+        }
+        stats.removedEmptyDirs++;
+      }
+    } catch {
+      // Directory already removed or inaccessible
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Check if an eval result directory is complete.
+ * Complete means: has summary.json and at least one run with a transcript.
+ */
+function isComplete(evalResultDir: string): boolean {
+  const summaryPath = join(evalResultDir, 'summary.json');
+  if (!existsSync(summaryPath)) return false;
+
+  // Check for at least one transcript
+  try {
+    const entries = readdirSync(evalResultDir);
+    for (const entry of entries) {
+      if (!entry.startsWith('run-')) continue;
+      const runDir = join(evalResultDir, entry);
+      if (
+        existsSync(join(runDir, 'transcript-raw.jsonl')) ||
+        existsSync(join(runDir, 'transcript.json'))
+      ) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  // No transcript found — but summary.json exists.
+  // Still consider complete if summary shows 0% (model produced nothing, which is valid).
+  try {
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+    return summary.totalRuns > 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

New `run-all` command auto-discovers `experiments/*.ts` and orchestrates the full eval pipeline:

1. **Fingerprint reuse** — computes content fingerprints (#39) and skips evals with matching cached results
2. **Failure classification** — classifies failed evals (#40) as model/infra/timeout
3. **Auto-retry** — when ALL runs of an eval fail with non-model failures, retries once automatically
4. **Housekeeping** — after each experiment, removes duplicate results (keeps newest), incomplete results, and empty timestamp directories

```bash
agent-eval run-all                      # run all experiments
agent-eval run-all claude-*             # glob filter
agent-eval run-all --smoke              # 1 eval per experiment
agent-eval run-all --force              # ignore fingerprints
agent-eval run-all --dry                # preview
```

All experiments run in parallel. This replaces the custom `run-evals.ts`, `cleanup.ts`, and most of `qa-and-export.ts` from `next-evals-oss`.

Also adds PR guideline reminders to `CLAUDE.md` (update README, include changeset).

Stacked on #40.

## Test plan

- [x] 6 housekeeping tests (dedup, incomplete removal, empty dir cleanup, dry run, graceful handling, no-transcript-with-summary)
- [x] All 48 tests across fingerprint, classifier, housekeeping, results, and runner pass