### PR TITLE
Add content fingerprinting and result reuse

### DIFF
--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -77,7 +77,7 @@ export type { Agent, ScriptResult } from './lib/agents/types.js';
 export { getAgent, listAgents, registerAgent } from './lib/agents/index.js';
 
 // Re-export results utilities
-export type { SaveResultsOptions } from './lib/results.js';
+export type { SaveResultsOptions, ReusableResult } from './lib/results.js';
 export {
   agentResultToEvalRunData,
   createEvalSummary,
@@ -86,7 +86,11 @@ export {
   formatResultsTable,
   formatRunResult,
   createProgressDisplay,
+  scanReusableResults,
 } from './lib/results.js';
+
+// Re-export fingerprinting
+export { computeFingerprint } from './lib/fingerprint.js';
 
 // Re-export runner utilities
 export type { RunExperimentOptions } from './lib/runner.js';

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { computeFingerprint } from './fingerprint.js';
+import type { RunnableExperimentConfig } from './types.js';
+
+const TEST_DIR = '/tmp/eval-framework-fingerprint-test';
+
+const baseConfig: RunnableExperimentConfig = {
+  agent: 'claude-code',
+  model: 'opus',
+  evals: '*',
+  runs: 2,
+  earlyExit: true,
+  scripts: ['build'],
+  timeout: 600,
+};
+
+function createEvalDir(name: string, files: Record<string, string>): string {
+  const dir = join(TEST_DIR, name);
+  mkdirSync(dir, { recursive: true });
+  for (const [file, content] of Object.entries(files)) {
+    const filePath = join(dir, file);
+    const fileDir = filePath.substring(0, filePath.lastIndexOf('/'));
+    mkdirSync(fileDir, { recursive: true });
+    writeFileSync(filePath, content);
+  }
+  return dir;
+}
+
+describe('computeFingerprint', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true });
+    }
+  });
+
+  it('produces consistent hash for same inputs', () => {
+    const evalDir = createEvalDir('eval-1', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, baseConfig);
+    expect(fp1).toBe(fp2);
+    expect(fp1).toMatch(/^[a-f0-9]{64}$/); // SHA-256 hex
+  });
+
+  it('changes when eval file content changes', () => {
+    const evalDir = createEvalDir('eval-2', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code v1',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+
+    writeFileSync(join(evalDir, 'EVAL.ts'), 'test code v2');
+    const fp2 = computeFingerprint(evalDir, baseConfig);
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('changes when config model changes', () => {
+    const evalDir = createEvalDir('eval-3', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, model: 'sonnet' });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('changes when config timeout changes', () => {
+    const evalDir = createEvalDir('eval-4', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, timeout: 1200 });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('is not affected by evals filter (only content matters)', () => {
+    const evalDir = createEvalDir('eval-5', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, { ...baseConfig, evals: '*' });
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, evals: ['eval-5'] });
+
+    expect(fp1).toBe(fp2);
+  });
+
+  it('ignores node_modules directory', () => {
+    const evalDir = createEvalDir('eval-6', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+
+    // Add node_modules (should be ignored)
+    mkdirSync(join(evalDir, 'node_modules', 'some-pkg'), { recursive: true });
+    writeFileSync(join(evalDir, 'node_modules', 'some-pkg', 'index.js'), 'module.exports = {}');
+
+    const fp2 = computeFingerprint(evalDir, baseConfig);
+    expect(fp1).toBe(fp2);
+  });
+
+  it('extending a model array does not invalidate existing models', () => {
+    const evalDir = createEvalDir('eval-7', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    // Simulate how CLI expands model arrays: each model gets its own config
+    const fpModelA = computeFingerprint(evalDir, { ...baseConfig, model: 'model-a' });
+    const fpModelB = computeFingerprint(evalDir, { ...baseConfig, model: 'model-b' });
+
+    // Adding model-c to the array doesn't change model-a or model-b fingerprints
+    // (CLI would just create a new experiment for model-c)
+    const fpModelAAfter = computeFingerprint(evalDir, { ...baseConfig, model: 'model-a' });
+    const fpModelBAfter = computeFingerprint(evalDir, { ...baseConfig, model: 'model-b' });
+
+    expect(fpModelA).toBe(fpModelAAfter);
+    expect(fpModelB).toBe(fpModelBAfter);
+    expect(fpModelA).not.toBe(fpModelB); // different models = different fingerprints
+  });
+});

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -1,0 +1,79 @@
+/**
+ * Content fingerprinting for eval result reuse.
+ *
+ * A fingerprint captures the eval files + config fields that affect results.
+ * If the fingerprint matches and the result is valid, the eval can be skipped.
+ */
+
+import { createHash } from 'crypto';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import type { RunnableExperimentConfig } from './types.js';
+
+/**
+ * Fields from the config that affect eval results.
+ * Functions (setup, editPrompt) can't be hashed — documented as a limitation.
+ */
+interface FingerprintableConfig {
+  agent: string;
+  model: string;
+  scripts: string[];
+  timeout: number;
+  earlyExit: boolean;
+  runs: number;
+}
+
+/**
+ * Recursively collects all files in a directory, sorted for deterministic hashing.
+ * Skips node_modules and .git.
+ */
+function collectFiles(dir: string, basePath: string = ''): Array<{ relativePath: string; content: string }> {
+  const files: Array<{ relativePath: string; content: string }> = [];
+  const entries = readdirSync(dir).sort();
+
+  for (const entry of entries) {
+    if (entry === 'node_modules' || entry === '.git') continue;
+    const fullPath = join(dir, entry);
+    const relativePath = basePath ? `${basePath}/${entry}` : entry;
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      files.push(...collectFiles(fullPath, relativePath));
+    } else {
+      files.push({ relativePath, content: readFileSync(fullPath, 'utf-8') });
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Compute a fingerprint for an (eval, config) pair.
+ *
+ * Hashes: all eval directory files + config fields that affect results.
+ * Returns a hex SHA-256 digest.
+ */
+export function computeFingerprint(evalPath: string, config: RunnableExperimentConfig): string {
+  const hash = createHash('sha256');
+
+  // Hash all files in the eval directory (sorted for determinism)
+  const files = collectFiles(evalPath);
+  for (const file of files) {
+    hash.update(`file:${file.relativePath}\n`);
+    hash.update(file.content);
+    hash.update('\0');
+  }
+
+  // Hash config fields that affect results
+  const configForHash: FingerprintableConfig = {
+    agent: config.agent,
+    model: config.model,
+    scripts: [...config.scripts].sort(),
+    timeout: config.timeout,
+    earlyExit: config.earlyExit,
+    runs: config.runs,
+  };
+  hash.update(`config:${JSON.stringify(configForHash)}`);
+
+  return hash.digest('hex');
+}

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { writeFileSync } from 'fs';
 import {
   agentResultToEvalRunData,
   createEvalSummary,
@@ -8,6 +9,7 @@ import {
   saveResults,
   formatResultsTable,
   formatRunResult,
+  scanReusableResults,
 } from './results.js';
 import type { AgentRunResult } from './agents/types.js';
 import type { EvalRunResult, EvalRunData, ResolvedExperimentConfig } from './types.js';
@@ -335,6 +337,79 @@ describe('results utilities', () => {
       expect(formatted).toContain('failing-eval');
       expect(formatted).toContain('3/10');
       expect(formatted).toContain('Test assertion failed');
+    });
+  });
+
+  describe('scanReusableResults', () => {
+    it('finds reusable results with matching fingerprint', () => {
+      // Create a fake result directory
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 2, passedRuns: 1, passRate: '50%', meanDuration: 10, fingerprint: 'abc123' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });
+      expect(result.size).toBe(1);
+      expect(result.get('eval-1')?.fingerprint).toBe('abc123');
+    });
+
+    it('skips results with mismatched fingerprint', () => {
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 2, passedRuns: 1, passRate: '50%', meanDuration: 10, fingerprint: 'old-hash' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'new-hash' });
+      expect(result.size).toBe(0);
+    });
+
+    it('skips results marked as invalid', () => {
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 2, passedRuns: 0, passRate: '0%', meanDuration: 10, fingerprint: 'abc123', valid: false })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });
+      expect(result.size).toBe(0);
+    });
+
+    it('skips results with zero passed runs', () => {
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 2, passedRuns: 0, passRate: '0%', meanDuration: 10, fingerprint: 'abc123' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });
+      expect(result.size).toBe(0);
+    });
+
+    it('returns empty map for non-existent experiment', () => {
+      const result = scanReusableResults(TEST_DIR, 'no-such-exp', { 'eval-1': 'abc123' });
+      expect(result.size).toBe(0);
+    });
+
+    it('prefers newest timestamp', () => {
+      // Create two timestamps with the same eval
+      for (const ts of ['2024-01-25T00-00-00.000Z', '2024-01-26T00-00-00.000Z']) {
+        const expDir = join(TEST_DIR, 'my-exp', ts, 'eval-1');
+        mkdirSync(expDir, { recursive: true });
+        writeFileSync(
+          join(expDir, 'summary.json'),
+          JSON.stringify({ totalRuns: 2, passedRuns: 1, passRate: '50%', meanDuration: 10, fingerprint: 'abc123' })
+        );
+      }
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });
+      expect(result.size).toBe(1);
+      expect(result.get('eval-1')?.timestamp).toBe('2024-01-26T00-00-00.000Z');
     });
   });
 });

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -2,7 +2,7 @@
  * Results storage and reporting for eval experiments.
  */
 
-import { mkdirSync, writeFileSync } from 'fs';
+import { mkdirSync, writeFileSync, readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 import chalk from 'chalk';
 import type {
@@ -91,6 +91,8 @@ export interface SaveResultsOptions {
   resultsDir: string;
   /** Experiment name (used for subdirectory) */
   experimentName: string;
+  /** Per-eval fingerprints (eval name -> fingerprint hash) */
+  fingerprints?: Record<string, string>;
 }
 
 /**
@@ -124,12 +126,16 @@ export function saveResults(
     mkdirSync(evalDir, { recursive: true });
 
     // Save summary (simplified format per design)
-    const summaryForFile = {
+    const fingerprint = options.fingerprints?.[evalSummary.name];
+    const summaryForFile: Record<string, unknown> = {
       totalRuns: evalSummary.totalRuns,
       passedRuns: evalSummary.passedRuns,
       passRate: `${evalSummary.passRate.toFixed(0)}%`,
       meanDuration: evalSummary.meanDuration,
     };
+    if (fingerprint) {
+      summaryForFile.fingerprint = fingerprint;
+    }
     writeFileSync(
       join(evalDir, 'summary.json'),
       JSON.stringify(summaryForFile, null, 2)
@@ -289,4 +295,92 @@ export function createProgressDisplay(
   totalRuns: number
 ): string {
   return chalk.blue(`Running ${evalName} [${runNumber}/${totalRuns}]...`);
+}
+
+/**
+ * A reusable result found by the scanner.
+ */
+export interface ReusableResult {
+  evalName: string;
+  fingerprint: string;
+  passRate: string;
+  timestamp: string;
+}
+
+/**
+ * Scan existing results for an experiment to find reusable eval results.
+ *
+ * A result is reusable if:
+ * 1. Its fingerprint matches the current fingerprint
+ * 2. It is "valid" (not marked as invalid by the classifier)
+ * 3. It has passedRuns > 0 (successful result worth reusing)
+ *
+ * Scans all timestamps newest-first and returns the latest match per eval.
+ */
+export function scanReusableResults(
+  resultsDir: string,
+  experimentName: string,
+  fingerprints: Record<string, string>
+): Map<string, ReusableResult> {
+  const reusable = new Map<string, ReusableResult>();
+  const experimentDir = join(resultsDir, experimentName);
+
+  if (!existsSync(experimentDir)) return reusable;
+
+  // Get all timestamps, sorted newest first
+  let timestamps: string[];
+  try {
+    timestamps = readdirSync(experimentDir)
+      .filter((t) => !t.startsWith('.'))
+      .sort()
+      .reverse();
+  } catch {
+    return reusable;
+  }
+
+  for (const timestamp of timestamps) {
+    const tsDir = join(experimentDir, timestamp);
+    if (!statSync(tsDir).isDirectory()) continue;
+
+    let evalDirs: string[];
+    try {
+      evalDirs = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
+    } catch {
+      continue;
+    }
+
+    for (const evalDir of evalDirs) {
+      // Already found a reusable result for this eval
+      if (reusable.has(evalDir)) continue;
+
+      // Check if we have a fingerprint for this eval
+      const expectedFingerprint = fingerprints[evalDir];
+      if (!expectedFingerprint) continue;
+
+      const summaryPath = join(tsDir, evalDir, 'summary.json');
+      try {
+        const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+
+        // Check fingerprint match
+        if (summary.fingerprint !== expectedFingerprint) continue;
+
+        // Check validity (valid defaults to true if not explicitly set to false)
+        if (summary.valid === false) continue;
+
+        // Check that it has at least some passed runs
+        if (summary.passedRuns <= 0) continue;
+
+        reusable.set(evalDir, {
+          evalName: evalDir,
+          fingerprint: summary.fingerprint,
+          passRate: summary.passRate,
+          timestamp,
+        });
+      } catch {
+        // Skip invalid summaries
+      }
+    }
+  }
+
+  return reusable;
 }


### PR DESCRIPTION
Reopened from #39 which was accidentally merged into a stale base branch.

## Summary

New `fingerprint.ts` module computes a SHA-256 hash from all eval directory files plus the config fields that affect results (`agent`, `model`, `scripts`, `timeout`, `earlyExit`, `runs`). The fingerprint is stored in `summary.json` alongside existing fields.

`scanReusableResults()` scans existing results for an experiment and returns matches where the fingerprint is identical, the result is valid (`valid !== false`), and `passedRuns > 0`. This allows the `run-all` command (upcoming PR) to skip evals that haven't changed.

### How reuse works

The fingerprint is computed **per (eval directory, resolved single-model config)** — not per experiment. The `evals` filter field is deliberately excluded from the hash.

On each run, `run-all`:
1. Discovers all fixtures from `evals/` on disk
2. Resolves the `evals` filter (e.g. `'*'` → `['a','b','c']`)
3. Computes a fingerprint for each eval (hashes eval files + config fields)
4. Scans `results/{experiment}/` for existing `summary.json` files, newest-first
5. A result is reusable if: fingerprint matches AND `valid !== false` AND `passedRuns > 0`
6. Only evals without a reusable result are scheduled to run

### What this means in practice

**Extending model arrays is safe.** The CLI expands `model: ['a', 'b']` into separate experiments (`experiment/a`, `experiment/b`) *before* fingerprinting. Each experiment gets a `modelConfig` with a single model string — the fingerprint never sees the array. Adding `model-c` → new experiment name `experiment/c` → empty results dir → runs fresh. Existing experiments untouched.

**Changing `evals: ['a']` to `evals: '*'` is safe.** The filter only controls which evals are selected — it's not part of the hash. If `a` was already run, its fingerprint matches and it's reused. New evals like `b`, `c` have no existing results, so they run.

**Adding a new eval to `evals/` is safe.** The new eval directory has no `summary.json` in results, so `scanReusableResults` returns no match → it runs. Existing evals are unaffected.

**Changing an eval's files invalidates only that eval.** Each fingerprint hashes only its own `evalPath` directory. Editing `evals/a/PROMPT.md` changes `a`'s fingerprint but not `b`'s or `c`'s.

Functions like `setup` and `editPrompt` can't be hashed — documented as a limitation. Users should use `--force` when these change.

## Test plan

- [x] 7 fingerprint tests (consistency, change detection, filter isolation, node_modules exclusion, model array extension safety)
- [x] 6 scanner tests (matching, mismatch, invalid, zero-pass, non-existent, newest-first preference)
- [x] Existing results tests updated and passing