### PR TITLE
Fingerprint reuse was never persisting fingerprints to results

### DIFF
--- a/.changeset/fix-fingerprint-reuse.md
+++ b/.changeset/fix-fingerprint-reuse.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Fix fingerprint reuse: fingerprints are now persisted to `summary.json` so results can actually be reused across runs. Also fixes `--dry` to check reusability and report what would run, `--smoke` to always run fresh and skip housekeeping, and housekeeping to dedupe by fingerprint so results from different configs coexist.

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -324,14 +324,7 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
       }
 
       if (options.dry) {
-        console.log(chalk.yellow('\n[DRY RUN] Would run the above experiments'));
-        if (options.smoke) {
-          console.log(chalk.yellow('  Mode: smoke test (1 eval per experiment)'));
-        }
-        if (options.force) {
-          console.log(chalk.yellow('  Force: re-run everything (ignoring fingerprints)'));
-        }
-        return;
+        console.log(chalk.yellow('\n[DRY RUN] Checking what would run...\n'));
       }
 
       // Run all experiments in parallel
@@ -365,7 +358,7 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
         const agent = getAgent(config.agent);
         const apiKeyEnvVar = agent.getApiKeyEnvVar();
         const apiKey = process.env[apiKeyEnvVar];
-        if (!apiKey) {
+        if (!apiKey && !options.dry) {
           console.error(chalk.red(`${apiKeyEnvVar} not set, skipping ${baseExperimentName}`));
           return;
         }
@@ -388,14 +381,34 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
             fingerprints[fixture.name] = computeFingerprint(fixture.path, modelConfig);
           }
 
-          // Check for reusable results (unless --force)
+          // Check for reusable results (unless --force or --smoke)
           let fixturesToRun = selectedFixtures;
-          if (!options.force) {
+          if (!options.force && !options.smoke) {
             const reusable = scanReusableResults(resultsDir, experimentName, fingerprints);
             if (reusable.size > 0) {
               console.log(chalk.gray(`  ${experimentName}: reusing ${reusable.size} cached result(s)`));
               fixturesToRun = selectedFixtures.filter((f) => !reusable.has(f.name));
             }
+          }
+
+          // Dry run: report what would happen and move on
+          if (options.dry) {
+            const cachedCount = selectedFixtures.length - fixturesToRun.length;
+            if (fixturesToRun.length === 0) {
+              console.log(chalk.gray(`  ${experimentName}: ${selectedFixtures.length} eval(s) — all cached, nothing to run`));
+            } else {
+              console.log(chalk.blue(`  ${experimentName}: ${fixturesToRun.length} to run, ${cachedCount} cached`));
+              for (const f of fixturesToRun) {
+                console.log(chalk.green(`    → ${f.name}`));
+              }
+              if (cachedCount > 0) {
+                const cachedNames = selectedFixtures
+                  .filter((f) => !fixturesToRun.some((r) => r.name === f.name))
+                  .map((f) => f.name);
+                console.log(chalk.gray(`    cached: ${cachedNames.join(', ')}`));
+              }
+            }
+            continue;
           }
 
           if (fixturesToRun.length === 0) {
@@ -409,9 +422,10 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
             const results = await runExperiment({
               config: modelConfig,
               fixtures: fixturesToRun,
-              apiKey,
+              apiKey: apiKey!,
               resultsDir,
               experimentName,
+              fingerprints,
               onProgress: (msg) => console.log(`  ${msg}`),
             });
 
@@ -448,9 +462,10 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
                 await runExperiment({
                   config: modelConfig,
                   fixtures: retryFixtures,
-                  apiKey,
+                  apiKey: apiKey!,
                   resultsDir,
                   experimentName,
+                  fingerprints,
                   onProgress: (msg) => console.log(`  [retry] ${msg}`),
                 });
               }
@@ -476,7 +491,9 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
       });
 
       await Promise.all(experimentPromises);
-      process.exit(allPassed ? 0 : 1);
+      if (!options.dry) {
+        process.exit(allPassed ? 0 : 1);
+      }
     } catch (error) {
       if (error instanceof Error) {
         console.error(chalk.red(`Error: ${error.message}`));

--- a/packages/agent-eval/src/lib/housekeeping.ts
+++ b/packages/agent-eval/src/lib/housekeeping.ts
@@ -55,7 +55,9 @@ export function housekeep(
     return stats;
   }
 
-  // Track which evals we've already seen (newest wins)
+  // Track which (eval, fingerprint) pairs we've already seen (newest wins).
+  // Results with different fingerprints (e.g. smoke vs full run) are not
+  // duplicates of each other and should coexist.
   const seenEvals = new Set<string>();
 
   for (const timestamp of timestamps) {
@@ -73,8 +75,12 @@ export function housekeep(
 
       if (!statSync(evalResultDir).isDirectory()) continue;
 
-      if (seenEvals.has(evalDir)) {
-        // Older duplicate — remove
+      // Read fingerprint to distinguish different configs (e.g. smoke vs full)
+      const fingerprint = readFingerprint(evalResultDir);
+      const dedupeKey = fingerprint ? `${evalDir}:${fingerprint}` : evalDir;
+
+      if (seenEvals.has(dedupeKey)) {
+        // Older duplicate with same fingerprint — remove
         if (!options?.dry) {
           rmSync(evalResultDir, { recursive: true });
         }
@@ -84,7 +90,7 @@ export function housekeep(
 
       // Check if this result is complete
       if (isComplete(evalResultDir)) {
-        seenEvals.add(evalDir);
+        seenEvals.add(dedupeKey);
       } else {
         // Incomplete — remove
         if (!options?.dry) {
@@ -109,6 +115,18 @@ export function housekeep(
   }
 
   return stats;
+}
+
+/**
+ * Read the fingerprint from an eval result's summary.json, if present.
+ */
+function readFingerprint(evalResultDir: string): string | undefined {
+  try {
+    const summary = JSON.parse(readFileSync(join(evalResultDir, 'summary.json'), 'utf-8'));
+    return summary.fingerprint;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -379,12 +379,24 @@ describe('results utilities', () => {
       expect(result.size).toBe(0);
     });
 
-    it('skips results with zero passed runs', () => {
+    it('reuses results with zero passed runs (use --force to re-run)', () => {
       const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
       mkdirSync(expDir, { recursive: true });
       writeFileSync(
         join(expDir, 'summary.json'),
         JSON.stringify({ totalRuns: 2, passedRuns: 0, passRate: '0%', meanDuration: 10, fingerprint: 'abc123' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });
+      expect(result.size).toBe(1);
+    });
+
+    it('skips results with zero total runs', () => {
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 0, passedRuns: 0, passRate: '0%', meanDuration: 0, fingerprint: 'abc123' })
       );
 
       const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -379,8 +379,8 @@ export function scanReusableResults(
         // Check validity (valid defaults to true if not explicitly set to false)
         if (summary.valid === false) continue;
 
-        // Check that it has at least some passed runs
-        if (summary.passedRuns <= 0) continue;
+        // Check that it has completed runs (use --force to re-run failures)
+        if (summary.totalRuns <= 0) continue;
 
         reusable.set(evalDir, {
           evalName: evalDir,

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -37,6 +37,8 @@ export interface RunExperimentOptions {
   resultsDir: string;
   /** Experiment name */
   experimentName: string;
+  /** Per-eval fingerprints (eval name -> hash) for result reuse */
+  fingerprints?: Record<string, string>;
   /** Callback for progress updates */
   onProgress?: (message: string) => void;
   /** Whether to run in verbose mode */
@@ -68,7 +70,7 @@ interface AttemptResult {
 export async function runExperiment(
   options: RunExperimentOptions
 ): Promise<ExperimentResults> {
-  const { config, fixtures, apiKey, resultsDir, experimentName, onProgress, verbose } = options;
+  const { config, fixtures, apiKey, resultsDir, experimentName, fingerprints, onProgress, verbose } = options;
   const startedAt = new Date();
 
   // Get the agent from registry
@@ -236,6 +238,7 @@ export async function runExperiment(
   const outputDir = saveResults(experimentResults, {
     resultsDir,
     experimentName,
+    fingerprints,
   });
 
   log(`\nResults saved to: ${outputDir}`);


### PR DESCRIPTION
The fingerprint-based result reuse system introduced in #41 had a critical bug: `runExperiment` never passed `fingerprints` through to `saveResults`, so every `summary.json` on disk was missing the `fingerprint` field. `scanReusableResults` would then compare `undefined !== expectedHash` and skip every result — nothing was ever actually reused.

This fixes the write side by plumbing `fingerprints` through `RunExperimentOptions` → `runExperiment` → `saveResults`. It also fixes several related issues discovered along the way:

- `--dry` returned early in `runAllCommand` before loading configs or checking reusability. It now goes through the full pipeline — loads configs, computes fingerprints, calls `scanReusableResults` — and reports what would actually run vs what's cached per experiment. API keys are no longer required for dry runs.

- `--smoke` could be skipped by the reuse system if cached results existed. Smoke is meant to verify setup (API keys, sandbox, model access), so it now always bypasses reuse and runs fresh.

- Housekeeping deduped by eval name alone, so results with different fingerprints (e.g. smoke with `runs: 1` vs full with `runs: 2`) would collide. It now dedupes by `(evalName, fingerprint)` so results from different configs coexist.

- `scanReusableResults` required `passedRuns > 0`, meaning failed results were always re-run even when the eval hadn't changed. Changed to `totalRuns > 0` so completed results are cached regardless of pass/fail. Use `--force` to re-attempt failures.

Needs tests for the new `--dry` output and fingerprint-aware housekeeping.