### PR TITLE
fix: allow `VERCEL_OIDC_TOKEN` if `AI_GATEWAY_API_KEY` is not set

### DIFF
--- a/.changeset/three-guests-start.md
+++ b/.changeset/three-guests-start.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+fix: allow `VERCEL_OIDC_TOKEN` if `AI_GATEWAY_API_KEY` is not set

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -141,9 +141,9 @@ async function runExperimentCommand(configInput: string, options: { dry?: boolea
     // Get the agent to check for required API key
     const agent = getAgent(config.agent);
     const apiKeyEnvVar = agent.getApiKeyEnvVar();
-    const apiKey = process.env[apiKeyEnvVar];
+    const apiKey = process.env[apiKeyEnvVar] ?? process.env.VERCEL_OIDC_TOKEN;
     if (!apiKey) {
-      console.error(chalk.red(`${apiKeyEnvVar} environment variable is required`));
+      console.error(chalk.red(`${apiKeyEnvVar} (or VERCEL_OIDC_TOKEN) environment variable is required`));
       console.error(chalk.gray(`Get your API key at: https://vercel.com/dashboard -> AI Gateway`));
       process.exit(1);
     }
@@ -357,9 +357,9 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
 
         const agent = getAgent(config.agent);
         const apiKeyEnvVar = agent.getApiKeyEnvVar();
-        const apiKey = process.env[apiKeyEnvVar];
+        const apiKey = process.env[apiKeyEnvVar] ?? process.env.VERCEL_OIDC_TOKEN;
         if (!apiKey && !options.dry) {
-          console.error(chalk.red(`${apiKeyEnvVar} not set, skipping ${baseExperimentName}`));
+          console.error(chalk.red(`${apiKeyEnvVar} (or VERCEL_OIDC_TOKEN) not set, skipping ${baseExperimentName}`));
           return;
         }
 

--- a/packages/agent-eval/src/lib/classifier.ts
+++ b/packages/agent-eval/src/lib/classifier.ts
@@ -198,7 +198,7 @@ export async function classifyWithAI(
 ): Promise<Classification | null> {
   const { generateText, hasToolCall, createGateway } = await import('ai');
 
-  const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY ?? '' });
+  const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY ?? process.env.VERCEL_OIDC_TOKEN ?? '' });
 
   let classification: Classification | null = null;
 


### PR DESCRIPTION
As per name, this makes sure that if `AI_GATEWAY_API_KEY` is not but `VERCEL_OIDC_TOKEN` it is set is, the CLI doesn't error and uses that.

I tested it with opencode and it works already, didn't test with claude code and codex tho (not sure I can).