### PR TITLE
fix: capture framework files (.vue, .svelte, .astro, etc.) in captureGeneratedFiles

### DIFF
--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -100,7 +100,7 @@ export async function captureGeneratedFiles(sandbox: AnySandbox): Promise<Record
   try {
     // Find all source files
     const findResult = await sandbox.runShell(
-      "find . -path './node_modules' -prune -o \\( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \\) -type f -print"
+      "find . -path './node_modules' -prune -o -path './dist' -prune -o \\( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.vue' -o -name '*.svelte' -o -name '*.astro' -o -name '*.css' -o -name '*.html' -o -name '*.json' \\) -type f -print"
     );
 
     const filePaths = findResult.stdout


### PR DESCRIPTION
## Summary

- Add `.vue`, `.svelte`, `.astro`, `.css`, `.html`, `.json` extensions to the `find` command in `captureGeneratedFiles` so framework-based eval projects have their generated files captured correctly
- Prune `./dist` directory to avoid capturing build artifacts

Fixes #51

## Context

When running evals on Vue/Svelte/Astro projects, `captureGeneratedFiles` silently misses all framework-specific files (`.vue`, `.svelte`, `.astro`) as well as `.css`, `.html`, and `.json` files. This causes incomplete eval results — assertions that inspect generated files won't see the actual framework code the agent wrote.

## Test plan

- [ ] Run an eval that generates `.vue` files and verify they appear in `generatedFiles`
- [ ] Verify `dist/` build artifacts are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)