### PR TITLE
Skip missing validation scripts

### DIFF
--- a/.changeset/skip-missing-scripts.md
+++ b/.changeset/skip-missing-scripts.md
@@ -1,0 +1,5 @@
+---
+"agent-eval": patch
+---
+
+Skip configured validation scripts when not defined in the sandbox's `package.json`.

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -60,6 +60,20 @@ async function detectEvalFile(sandbox: AnySandbox): Promise<string> {
 }
 
 /**
+ * Read the scripts defined in the sandbox's package.json.
+ * Returns an empty set if package.json doesn't exist or is invalid.
+ */
+async function getAvailableScripts(sandbox: AnySandbox): Promise<Set<string>> {
+  try {
+    const content = await sandbox.readFile('package.json');
+    const pkg = JSON.parse(content);
+    return new Set(Object.keys(pkg.scripts ?? {}));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
  * Run validation scripts in the sandbox.
  */
 export async function runValidation(
@@ -84,8 +98,13 @@ export async function runValidation(
     results.allPassed = false;
   }
 
-  // Run configured scripts
+  // Run configured scripts, skipping any not defined in package.json
+  const availableScripts = await getAvailableScripts(sandbox);
   for (const script of scripts) {
+    if (!availableScripts.has(script)) {
+      continue;
+    }
+
     const scriptResult = await sandbox.runCommand('npm', ['run', script]);
     const result: ScriptResult = {
       success: scriptResult.exitCode === 0,


### PR DESCRIPTION
When the experiment config specifies `scripts: ["build"]`, `runValidation` in `shared.ts` unconditionally runs `npm run build` in the sandbox. If the fixture's `package.json` doesn't define that script — or doesn't exist at all, as in evals where the agent scaffolds the project from scratch — this fails and counts as a validation failure even though the missing script isn't the agent's fault.

`getAvailableScripts()` now reads `package.json` from the sandbox and returns the set of defined script names. If the file is missing or invalid, it returns an empty set. `runValidation` checks this before running each script and skips any that aren't defined.