### PR TITLE
[CLI] Add override flag to dotenv config to allow shell env vars to take precedence

### DIFF
--- a/.changeset/dotenv-override.md
+++ b/.changeset/dotenv-override.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Add `override: true` to dotenv config so `.env.local` and `.env` values consistently take precedence over pre-existing shell environment variables.

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -27,8 +27,8 @@ import { minimatch } from 'minimatch';
 import pLimit from 'p-limit';
 
 // Load environment variables (.env.local first, then .env as fallback)
-dotenvConfig({ path: '.env.local' });
-dotenvConfig();
+dotenvConfig({ path: '.env.local', override: true });
+dotenvConfig({ override: true });
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Without the `override: true` flag, `dotenvConfig` will not overwrite environment variables that are already set in the shell. This means if you have `AI_GATEWAY_API_KEY` set in both your shell and `.env.local`, the `.env.local` value silently wins on some runs but not others depending on load order, making local development confusing.

Adding `override: true` to both `dotenvConfig` calls ensures that `.env.local` values consistently take precedence over `.env`, and both take precedence over pre-existing shell variables. This matches the typical expectation that dotfiles closer to the project override broader environment settings.