### PR TITLE
Add --concurrency flag and custom OpenCode binary support

### DIFF
--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -59,7 +59,7 @@ function resolveConfigPath(input: string): string {
 /**
  * Run experiment command handler
  */
-async function runExperimentCommand(configInput: string, options: { dry?: boolean; smoke?: boolean }) {
+async function runExperimentCommand(configInput: string, options: { dry?: boolean; smoke?: boolean; concurrency?: number }) {
   try {
     const configPath = resolveConfigPath(configInput);
     const absoluteConfigPath = resolve(process.cwd(), configPath);
@@ -182,6 +182,7 @@ async function runExperimentCommand(configInput: string, options: { dry?: boolea
         resultsDir,
         experimentName,
         smoke: options.smoke,
+        concurrency: options.concurrency,
         onProgress: createConsoleProgressHandler({
           experimentName,
           model,
@@ -278,7 +279,7 @@ program
  * and classification. Used by both `run-all` subcommand and the default
  * (no-args) invocation.
  */
-async function runAllCommand(experimentArgs: string[], options: { dry?: boolean; force?: boolean; smoke?: boolean; ackFailures?: boolean }) {
+async function runAllCommand(experimentArgs: string[], options: { dry?: boolean; force?: boolean; smoke?: boolean; concurrency?: number; ackFailures?: boolean }) {
     try {
       const projectDir = process.cwd();
       const experimentsDir = resolve(projectDir, 'experiments');
@@ -532,6 +533,7 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
               experimentName,
               fingerprints,
               smoke: options.smoke,
+              concurrency: options.concurrency,
               onProgress,
               rateLimiter,
             });
@@ -657,6 +659,7 @@ program
   .option('--dry', 'Preview what would run without executing')
   .option('--force', 'Ignore fingerprints, re-run everything')
   .option('--smoke', 'Run 1 eval per experiment for sanity checking')
+  .option('--concurrency <number>', 'Maximum number of eval runs in-flight at once (default: unlimited)', parseInt)
   .option('--ack-failures', 'Keep non-model failures (infra/timeout) as final results instead of deleting them')
   .action(runAllCommand);
 
@@ -672,8 +675,9 @@ program
   .option('--dry', 'Preview what would run without executing')
   .option('--smoke', 'Run a single eval to verify setup (API keys, model IDs, sandbox)')
   .option('--force', 'Ignore fingerprints, re-run everything (only applies when running all)')
+  .option('--concurrency <number>', 'Maximum number of eval runs in-flight at once (default: unlimited)', parseInt)
   .option('--ack-failures', 'Keep non-model failures (infra/timeout) as final results instead of deleting them')
-  .action(async (configInput: string | undefined, options: { dry?: boolean; smoke?: boolean; force?: boolean; ackFailures?: boolean }) => {
+  .action(async (configInput: string | undefined, options: { dry?: boolean; smoke?: boolean; force?: boolean; concurrency?: number; ackFailures?: boolean }) => {
     if (!configInput) {
       await runAllCommand([], options);
       return;

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -49,32 +49,69 @@ function extractTranscriptFromOutput(output: string): string | undefined {
 }
 
 /**
- * Generate OpenCode config file content.
- * Configures the Vercel AI Gateway provider.
+ * Additional provider configuration for models not yet available in the
+ * default Vercel AI Gateway (e.g., early access / unreleased models).
+ * Keys are provider IDs, values follow the OpenCode provider config schema.
  */
-function generateOpenCodeConfig(): string {
-  return `{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "vercel": {
-      "options": {
-        "apiKey": "{env:AI_GATEWAY_API_KEY}"
-      }
-    }
-  },
-  "permission": {
-    "write": "allow",
-    "edit": "allow",
-    "bash": "allow"
-  }
-}`;
+export interface OpenCodeProviderConfig {
+  npm?: string;
+  options?: Record<string, unknown>;
+  models?: Record<string, {
+    name?: string;
+    tool_call?: boolean;
+    reasoning?: boolean;
+    attachment?: boolean;
+    temperature?: boolean;
+    limit?: { context: number; output: number };
+  }>;
+}
+
+/**
+ * Generate OpenCode config file content.
+ * Configures the Vercel AI Gateway provider, plus any additional providers.
+ */
+function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>): string {
+  const providers: Record<string, unknown> = {
+    vercel: {
+      options: {
+        apiKey: '{env:AI_GATEWAY_API_KEY}',
+      },
+    },
+    ...extraProviders,
+  };
+
+  return JSON.stringify({
+    $schema: 'https://opencode.ai/config.json',
+    provider: providers,
+    permission: {
+      write: 'allow',
+      edit: 'allow',
+      bash: 'allow',
+    },
+  }, null, 2);
+}
+
+export interface OpenCodeAgentOptions {
+  /**
+   * URL to a custom OpenCode binary. When set, the agent downloads this binary
+   * instead of installing `opencode-ai` from npm. Useful for running patched
+   * builds that support models not yet listed on models.dev.
+   */
+  binaryUrl?: string;
+
+  /**
+   * Additional provider configurations to include in opencode.json.
+   * Use this to add providers for models not available through the default
+   * Vercel AI Gateway (e.g., early access models via an OpenAI-compatible endpoint).
+   */
+  extraProviders?: Record<string, OpenCodeProviderConfig>;
 }
 
 /**
  * Create OpenCode agent with Vercel AI Gateway authentication.
  * Note: OpenCode only supports Vercel AI Gateway, not direct provider APIs.
  */
-export function createOpenCodeAgent(): Agent {
+export function createOpenCodeAgent(agentOptions?: OpenCodeAgentOptions): Agent {
   return {
     name: 'vercel-ai-gateway/opencode',
     displayName: 'OpenCode (Vercel AI Gateway)',
@@ -169,18 +206,29 @@ export function createOpenCodeAgent(): Agent {
           throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
         }
 
-        // Install OpenCode CLI globally
-        const cliInstall = await sandbox.runCommand('npm', [
-          'install',
-          '-g',
-          'opencode-ai',
-        ]);
-        if (cliInstall.exitCode !== 0) {
-          throw new Error(`OpenCode CLI install failed: ${cliInstall.stderr}`);
+        // Install OpenCode CLI
+        if (agentOptions?.binaryUrl) {
+          // Download custom binary (e.g., patched build for unreleased models)
+          const cliInstall = await sandbox.runCommand('bash', [
+            '-c',
+            `curl -sL "${agentOptions.binaryUrl}" -o /usr/local/bin/opencode && chmod +x /usr/local/bin/opencode`,
+          ]);
+          if (cliInstall.exitCode !== 0) {
+            throw new Error(`OpenCode CLI install failed: ${cliInstall.stdout} ${cliInstall.stderr}`);
+          }
+        } else {
+          const cliInstall = await sandbox.runCommand('npm', [
+            'install',
+            '-g',
+            'opencode-ai',
+          ]);
+          if (cliInstall.exitCode !== 0) {
+            throw new Error(`OpenCode CLI install failed: ${cliInstall.stderr}`);
+          }
         }
 
         // Create OpenCode config file in the project directory
-        const configContent = generateOpenCodeConfig();
+        const configContent = generateOpenCodeConfig(agentOptions?.extraProviders);
         await sandbox.writeFiles({
           'opencode.json': configContent,
         });

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -207,11 +207,15 @@ export function createOpenCodeAgent(agentOptions?: OpenCodeAgentOptions): Agent 
         }
 
         // Install OpenCode CLI
-        if (agentOptions?.binaryUrl) {
+        // Options can come from runtime agentOptions (experiment config) or closure agentOptions (registration)
+        const binaryUrl = (options.agentOptions?.binaryUrl ?? agentOptions?.binaryUrl) as string | undefined;
+        const extraProviders = (options.agentOptions?.extraProviders ?? agentOptions?.extraProviders) as Record<string, OpenCodeProviderConfig> | undefined;
+
+        if (binaryUrl) {
           // Download custom binary (e.g., patched build for unreleased models)
           const cliInstall = await sandbox.runCommand('bash', [
             '-c',
-            `curl -sL "${agentOptions.binaryUrl}" -o /usr/local/bin/opencode && chmod +x /usr/local/bin/opencode`,
+            `curl -sL "${binaryUrl}" -o /usr/local/bin/opencode && chmod +x /usr/local/bin/opencode`,
           ]);
           if (cliInstall.exitCode !== 0) {
             throw new Error(`OpenCode CLI install failed: ${cliInstall.stdout} ${cliInstall.stderr}`);
@@ -228,7 +232,7 @@ export function createOpenCodeAgent(agentOptions?: OpenCodeAgentOptions): Agent 
         }
 
         // Create OpenCode config file in the project directory
-        const configContent = generateOpenCodeConfig(agentOptions?.extraProviders);
+        const configContent = generateOpenCodeConfig(extraProviders);
         await sandbox.writeFiles({
           'opencode.json': configContent,
         });

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -24,6 +24,8 @@ export interface AgentRunOptions {
   signal?: AbortSignal;
   /** Sandbox backend to use */
   sandbox?: SandboxBackend | 'auto';
+  /** Agent-specific options (e.g., binaryUrl, extraProviders for opencode) */
+  agentOptions?: Record<string, unknown>;
 }
 
 /**

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -50,6 +50,7 @@ const experimentConfigSchema = z.object({
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
   copyFiles: z.enum(['none', 'changed', 'all']).optional(),
+  agentOptions: z.record(z.unknown()).optional(),
 });
 
 /**
@@ -91,6 +92,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
     editPrompt: config.editPrompt,
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
+    agentOptions: config.agentOptions,
   };
 }
 

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -191,6 +191,7 @@ export async function runExperiment(
         scripts: config.scripts,
         signal: attemptController.signal,
         sandbox: config.sandbox,
+        agentOptions: config.agentOptions,
       }),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -94,6 +94,8 @@ export interface RunExperimentOptions {
   smoke?: boolean;
   /** Shared rate limiter to control how many sandbox runs start per time window */
   rateLimiter?: StartRateLimiter;
+  /** Maximum number of eval runs in-flight at once. Useful for providers with limited capacity. */
+  concurrency?: number;
 }
 
 /**
@@ -283,7 +285,22 @@ export async function runExperiment(
     return result;
   };
 
-  const results = await Promise.all(attempts.map(runOne));
+  let results: AttemptResult[];
+  if (options.concurrency && options.concurrency < attempts.length) {
+    // Concurrency-limited execution
+    const limit = options.concurrency;
+    results = new Array(attempts.length);
+    let idx = 0;
+    const next = async () => {
+      while (idx < attempts.length) {
+        const i = idx++;
+        results[i] = await runOne(attempts[i]);
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(limit, attempts.length) }, () => next()));
+  } else {
+    results = await Promise.all(attempts.map(runOne));
+  }
 
   // Group results by fixture, excluding aborted results
   const resultsByFixture = new Map<string, AttemptResult[]>();

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -98,6 +98,10 @@ export interface ExperimentConfig {
    * - 'all': Original project files + agent changes overlaid on top
    * @default 'none' */
   copyFiles?: 'none' | 'changed' | 'all';
+
+  /** Agent-specific options passed at runtime (e.g., binaryUrl, extraProviders for opencode).
+   * These are forwarded to the agent's run() method. @default undefined */
+  agentOptions?: Record<string, unknown>;
 }
 
 /**
@@ -115,6 +119,7 @@ export interface ResolvedExperimentConfig {
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
+  agentOptions?: Record<string, unknown>;
 }
 
 /**
@@ -132,6 +137,7 @@ export interface RunnableExperimentConfig {
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
+  agentOptions?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `--concurrency` CLI flag to limit the number of eval runs in-flight at once, useful for providers with limited capacity that return 503s under high parallelism
- Adds `binaryUrl` and `extraProviders` options to the OpenCode agent, enabling evals against early access models not yet listed on models.dev

## Test plan
- [ ] Run evals with `--concurrency 2` and verify only 2 runs execute at a time
- [ ] Run evals with a custom OpenCode binary URL and verify it downloads and works
- [ ] Run evals with `extraProviders` config for an unreleased model
- [ ] Verify default behavior (no `--concurrency` flag) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)