### PR TITLE
fix(codex): append to config.toml instead of overwriting

### DIFF
--- a/.changeset/fix-codex-config-append.md
+++ b/.changeset/fix-codex-config-append.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Fix Codex agent to append to config.toml instead of overwriting it, preserving any config written by the experiment's setup function.

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -221,7 +221,7 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
       // Create Codex config directory and config file
       await sandbox.runShell('mkdir -p ~/.codex');
       const configContent = generateCodexConfig(baseModel, useVercelAiGateway);
-      await sandbox.runShell(`cat > ~/.codex/config.toml << 'EOF'
+      await sandbox.runShell(`cat >> ~/.codex/config.toml << 'EOF'
 ${configContent}
 EOF`);
 


### PR DESCRIPTION
## Problem

The Codex agent overwrites `~/.codex/config.toml` with `cat >` after the experiment's `setup` function runs. This destroys any config that `setup` wrote, for example, MCP server configuration added during setup.

## Fix

Change `cat >` to `cat >>` (append) so the framework adds model/provider config without destroying existing config from `setup`.

## Backwards compatibility

If `setup` didn't write anything, appending to an empty/nonexistent file is identical to overwriting.