### PR TITLE
[OpenCode] Add binaryUrl and extraProviders options for unreleased models

### DIFF
--- a/.changeset/opencode-custom-binary-providers.md
+++ b/.changeset/opencode-custom-binary-providers.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Add `binaryUrl` and `extraProviders` options to `createOpenCodeAgent`. `binaryUrl` downloads a custom OpenCode binary instead of installing from npm, and `extraProviders` adds provider entries to `opencode.json` — together these enable evals against early access models not yet listed on models.dev.

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -49,32 +49,69 @@ function extractTranscriptFromOutput(output: string): string | undefined {
 }
 
 /**
- * Generate OpenCode config file content.
- * Configures the Vercel AI Gateway provider.
+ * Additional provider configuration for models not yet available in the
+ * default Vercel AI Gateway (e.g., early access / unreleased models).
+ * Keys are provider IDs, values follow the OpenCode provider config schema.
  */
-function generateOpenCodeConfig(): string {
-  return `{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "vercel": {
-      "options": {
-        "apiKey": "{env:AI_GATEWAY_API_KEY}"
-      }
-    }
-  },
-  "permission": {
-    "write": "allow",
-    "edit": "allow",
-    "bash": "allow"
-  }
-}`;
+export interface OpenCodeProviderConfig {
+  npm?: string;
+  options?: Record<string, unknown>;
+  models?: Record<string, {
+    name?: string;
+    tool_call?: boolean;
+    reasoning?: boolean;
+    attachment?: boolean;
+    temperature?: boolean;
+    limit?: { context: number; output: number };
+  }>;
+}
+
+/**
+ * Generate OpenCode config file content.
+ * Configures the Vercel AI Gateway provider, plus any additional providers.
+ */
+function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>): string {
+  const providers: Record<string, unknown> = {
+    vercel: {
+      options: {
+        apiKey: '{env:AI_GATEWAY_API_KEY}',
+      },
+    },
+    ...extraProviders,
+  };
+
+  return JSON.stringify({
+    $schema: 'https://opencode.ai/config.json',
+    provider: providers,
+    permission: {
+      write: 'allow',
+      edit: 'allow',
+      bash: 'allow',
+    },
+  }, null, 2);
+}
+
+export interface OpenCodeAgentOptions {
+  /**
+   * URL to a custom OpenCode binary. When set, the agent downloads this binary
+   * instead of installing `opencode-ai` from npm. Useful for running patched
+   * builds that support models not yet listed on models.dev.
+   */
+  binaryUrl?: string;
+
+  /**
+   * Additional provider configurations to include in opencode.json.
+   * Use this to add providers for models not available through the default
+   * Vercel AI Gateway (e.g., early access models via an OpenAI-compatible endpoint).
+   */
+  extraProviders?: Record<string, OpenCodeProviderConfig>;
 }
 
 /**
  * Create OpenCode agent with Vercel AI Gateway authentication.
  * Note: OpenCode only supports Vercel AI Gateway, not direct provider APIs.
  */
-export function createOpenCodeAgent(): Agent {
+export function createOpenCodeAgent(agentOptions?: OpenCodeAgentOptions): Agent {
   return {
     name: 'vercel-ai-gateway/opencode',
     displayName: 'OpenCode (Vercel AI Gateway)',
@@ -169,18 +206,29 @@ export function createOpenCodeAgent(): Agent {
           throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
         }
 
-        // Install OpenCode CLI globally
-        const cliInstall = await sandbox.runCommand('npm', [
-          'install',
-          '-g',
-          'opencode-ai',
-        ]);
-        if (cliInstall.exitCode !== 0) {
-          throw new Error(`OpenCode CLI install failed: ${cliInstall.stderr}`);
+        // Install OpenCode CLI
+        if (agentOptions?.binaryUrl) {
+          // Download custom binary (e.g., patched build for unreleased models)
+          const cliInstall = await sandbox.runCommand('bash', [
+            '-c',
+            `curl -sL "${agentOptions.binaryUrl}" -o /usr/local/bin/opencode && chmod +x /usr/local/bin/opencode`,
+          ]);
+          if (cliInstall.exitCode !== 0) {
+            throw new Error(`OpenCode CLI install failed: ${cliInstall.stdout} ${cliInstall.stderr}`);
+          }
+        } else {
+          const cliInstall = await sandbox.runCommand('npm', [
+            'install',
+            '-g',
+            'opencode-ai',
+          ]);
+          if (cliInstall.exitCode !== 0) {
+            throw new Error(`OpenCode CLI install failed: ${cliInstall.stderr}`);
+          }
         }
 
         // Create OpenCode config file in the project directory
-        const configContent = generateOpenCodeConfig();
+        const configContent = generateOpenCodeConfig(agentOptions?.extraProviders);
         await sandbox.writeFiles({
           'opencode.json': configContent,
         });


### PR DESCRIPTION
Ports the OpenCode portion of #103. The `--concurrency` flag is intentionally left out per PR feedback; it can land separately if needed.

`createOpenCodeAgent` now accepts an optional `OpenCodeAgentOptions` with two fields. `binaryUrl` points at a custom OpenCode build; when set, the agent `curl`s it into `/usr/local/bin/opencode` inside the sandbox instead of `npm install -g opencode-ai`. This unblocks evals against patched builds that know about models not yet published to models.dev. `extraProviders` is a map of provider entries that get merged into the generated `opencode.json` alongside the default `vercel` provider, so custom OpenAI-compatible endpoints (e.g. early access gateways) can be wired up without touching the agent code.

`generateOpenCodeConfig` was also switched from a hand-built template string to `JSON.stringify` on a plain object so the merge is unambiguous.

The new options aren't exposed through `ExperimentConfig` yet — the agent is still registered in `src/lib/agents/index.ts` as `createOpenCodeAgent()` with no arguments — so this is a programmatic API addition, not a CLI change. A changeset is included.