### PR TITLE
Add agentOptions support to ExperimentConfig

### DIFF
--- a/.changeset/add-agent-options.md
+++ b/.changeset/add-agent-options.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add `agentOptions` field to `ExperimentConfig` for passing agent-specific options (like `binaryUrl` and `extraProviders`) at runtime. This enables replicable eval configs for unreleased models that require patched agent binaries.

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -49,25 +49,45 @@ function extractTranscriptFromOutput(output: string): string | undefined {
 }
 
 /**
- * Generate OpenCode config file content.
- * Configures the Vercel AI Gateway provider.
+ * Additional provider configuration for models not yet available in the
+ * default Vercel AI Gateway (e.g., early access / unreleased models).
  */
-function generateOpenCodeConfig(): string {
-  return `{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "vercel": {
-      "options": {
-        "apiKey": "{env:AI_GATEWAY_API_KEY}"
-      }
-    }
-  },
-  "permission": {
-    "write": "allow",
-    "edit": "allow",
-    "bash": "allow"
-  }
-}`;
+export interface OpenCodeProviderConfig {
+  npm?: string;
+  options?: Record<string, unknown>;
+  models?: Record<string, {
+    name?: string;
+    tool_call?: boolean;
+    reasoning?: boolean;
+    attachment?: boolean;
+    temperature?: boolean;
+    limit?: { context: number; output: number };
+  }>;
+}
+
+/**
+ * Generate OpenCode config file content.
+ * Configures the Vercel AI Gateway provider, plus any additional providers.
+ */
+function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>): string {
+  const providers: Record<string, unknown> = {
+    vercel: {
+      options: {
+        apiKey: '{env:AI_GATEWAY_API_KEY}',
+      },
+    },
+    ...extraProviders,
+  };
+
+  return JSON.stringify({
+    $schema: 'https://opencode.ai/config.json',
+    provider: providers,
+    permission: {
+      write: 'allow',
+      edit: 'allow',
+      bash: 'allow',
+    },
+  }, null, 2);
 }
 
 /**
@@ -169,18 +189,32 @@ export function createOpenCodeAgent(): Agent {
           throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
         }
 
-        // Install OpenCode CLI globally
-        const cliInstall = await sandbox.runCommand('npm', [
-          'install',
-          '-g',
-          'opencode-ai',
-        ]);
-        if (cliInstall.exitCode !== 0) {
-          throw new Error(`OpenCode CLI install failed: ${cliInstall.stderr}`);
+        // Install OpenCode CLI
+        const binaryUrl = options.agentOptions?.binaryUrl as string | undefined;
+        const extraProviders = options.agentOptions?.extraProviders as Record<string, OpenCodeProviderConfig> | undefined;
+
+        if (binaryUrl) {
+          // Download custom binary (e.g., patched build for unreleased models)
+          const cliInstall = await sandbox.runCommand('bash', [
+            '-c',
+            `curl -sL "${binaryUrl}" -o /usr/local/bin/opencode && chmod +x /usr/local/bin/opencode`,
+          ]);
+          if (cliInstall.exitCode !== 0) {
+            throw new Error(`OpenCode CLI install failed: ${cliInstall.stdout} ${cliInstall.stderr}`);
+          }
+        } else {
+          const cliInstall = await sandbox.runCommand('npm', [
+            'install',
+            '-g',
+            'opencode-ai',
+          ]);
+          if (cliInstall.exitCode !== 0) {
+            throw new Error(`OpenCode CLI install failed: ${cliInstall.stderr}`);
+          }
         }
 
         // Create OpenCode config file in the project directory
-        const configContent = generateOpenCodeConfig();
+        const configContent = generateOpenCodeConfig(extraProviders);
         await sandbox.writeFiles({
           'opencode.json': configContent,
         });

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -24,6 +24,8 @@ export interface AgentRunOptions {
   signal?: AbortSignal;
   /** Sandbox backend to use */
   sandbox?: SandboxBackend | 'auto';
+  /** Agent-specific options (e.g., binaryUrl, extraProviders for opencode) */
+  agentOptions?: Record<string, unknown>;
 }
 
 /**

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -50,6 +50,7 @@ const experimentConfigSchema = z.object({
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
   copyFiles: z.enum(['none', 'changed', 'all']).optional(),
+  agentOptions: z.record(z.unknown()).optional(),
 });
 
 /**
@@ -91,6 +92,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
     editPrompt: config.editPrompt,
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
+    agentOptions: config.agentOptions,
   };
 }
 

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -189,6 +189,7 @@ export async function runExperiment(
         scripts: config.scripts,
         signal: attemptController.signal,
         sandbox: config.sandbox,
+        agentOptions: config.agentOptions,
       }),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -98,6 +98,10 @@ export interface ExperimentConfig {
    * - 'all': Original project files + agent changes overlaid on top
    * @default 'none' */
   copyFiles?: 'none' | 'changed' | 'all';
+
+  /** Agent-specific options passed at runtime (e.g., binaryUrl, extraProviders for opencode).
+   * These are forwarded to the agent's run() method. @default undefined */
+  agentOptions?: Record<string, unknown>;
 }
 
 /**
@@ -115,6 +119,7 @@ export interface ResolvedExperimentConfig {
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
+  agentOptions?: Record<string, unknown>;
 }
 
 /**
@@ -132,6 +137,7 @@ export interface RunnableExperimentConfig {
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
+  agentOptions?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `agentOptions` field to `ExperimentConfig` so experiment configs can pass agent-specific options (like `binaryUrl` and `extraProviders`) at runtime
- Previously these could only be set at agent registration time in code, making configs for unreleased models non-replicable
- The options flow: `ExperimentConfig` → runner → `AgentRunOptions` → `agent.run()`

## Example usage

```typescript
const config: ExperimentConfig = {
  agent: 'vercel-ai-gateway/opencode',
  model: 'ai-gateway/zai/glm-5.1',
  agentOptions: {
    binaryUrl: 'https://blob.vercel-storage.com/opencode-linux-x64-patched',
  },
  // ...
};
```

## Changed files
- `lib/types.ts` — added `agentOptions` to `ExperimentConfig`, `ResolvedExperimentConfig`, `RunnableExperimentConfig`
- `lib/agents/types.ts` — added `agentOptions` to `AgentRunOptions`
- `lib/config.ts` — added zod validation + passthrough in `resolveConfig()`
- `lib/runner.ts` — passes `agentOptions` to `agent.run()`
- `lib/agents/opencode.ts` — reads `binaryUrl`/`extraProviders` from `options.agentOptions`, adds `OpenCodeProviderConfig` type and `extraProviders` support to `generateOpenCodeConfig()`

## Test plan
- [x] `npm run build` passes
- [x] Smoke tested end-to-end with `binaryUrl` in an experiment config (next-evals-oss)
- [x] Configs without `agentOptions` are unchanged (default opencode from npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)