### PR TITLE
[OpenCode] Pass timeout to provider config

### DIFF
--- a/.changeset/huge-rivers-tap.md
+++ b/.changeset/huge-rivers-tap.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Pass experiment timeout to OpenCode provider config so the Vercel AI Gateway has a request-level timeout.

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -69,10 +69,11 @@ export interface OpenCodeProviderConfig {
  * Generate OpenCode config file content.
  * Configures the Vercel AI Gateway provider, plus any additional providers.
  */
-function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>, apiKey?: string): string {
+function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>, apiKey?: string, timeoutMs?: number): string {
   const vercelBase: Record<string, unknown> = {
     options: {
       apiKey: apiKey || '{env:AI_GATEWAY_API_KEY}',
+      ...(timeoutMs ? { timeout: timeoutMs } : {}),
     },
   };
   const { vercel: vercelExtra, ...otherProviders } = extraProviders || {};
@@ -221,7 +222,7 @@ export function createOpenCodeAgent(): Agent {
         }
 
         // Create OpenCode config file in the project directory
-        const configContent = generateOpenCodeConfig(extraProviders, options.apiKey);
+        const configContent = generateOpenCodeConfig(extraProviders, options.apiKey, options.timeout);
         await sandbox.writeFiles({
           'opencode.json': configContent,
         });


### PR DESCRIPTION
The experiment's `timeout` option was passed to the sandbox but not forwarded to the OpenCode provider config. This means the Vercel AI Gateway provider had no request-level timeout, so long-running model calls could hang until the sandbox itself timed out. This threads `timeoutMs` through `generateOpenCodeConfig` so the provider `options.timeout` is set in `opencode.json`.