### PR TITLE
[Claude Code] Forward cliPackage and effort agentOptions to the CLI

### DIFF
--- a/.changeset/claude-code-cli-options.md
+++ b/.changeset/claude-code-cli-options.md
@@ -1,0 +1,5 @@
+---
+'@vercel/agent-eval': minor
+---
+
+Add `cliPackage` and `effort` `agentOptions` for Claude Code. Lets users override the installed npm package (e.g. `@anthropic-ai/claude-code@next`) and pass `--effort <level>`, which is required by models that use the new `thinking.type.adaptive` API such as Opus 4.7.

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -235,6 +235,74 @@ test('greet exists', () => {
         expect(typeof result.outputContent).toBe('object');
       }
     }, 300000); // 5 minute timeout
+
+    it('can run a smoke test with Claude Code + opus 4.7', async () => {
+      const fixtureDir = join(TEST_DIR, 'smoke-claude-opus-47');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Add a function called greet that returns "Hello!"'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+test('greet exists', () => {
+  const content = readFileSync('src/index.ts', 'utf-8');
+  expect(content).toContain('greet');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'smoke-claude-opus-47',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+      writeFileSync(join(fixtureDir, 'src/index.ts'), '// TODO: implement');
+
+      const fixture = loadFixture(TEST_DIR, 'smoke-claude-opus-47');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/claude-code',
+        model: 'claude-opus-4-7',
+        timeout: 300,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: ['build'],
+        agentOptions: {
+          cliPackage: '@anthropic-ai/claude-code@next',
+          effort: 'high',
+        },
+      });
+
+      expect(result.result.duration).toBeGreaterThan(0);
+      if (result.result.status === 'failed') {
+        console.error('Agent failed with error:', result.result.error);
+      }
+      expect(result.result.status).toBe('passed');
+
+      if (result.outputContent) {
+        expect(typeof result.outputContent).toBe('object');
+      }
+    }, 600000); // 10 minute timeout
   });
 
   describe.skipIf(!hasAnthropicCredentials)('Claude Code (Direct API) sandbox execution', () => {

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -166,10 +166,11 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
       }
 
       // Install Claude Code CLI globally
+      const cliPackage = (options.agentOptions?.cliPackage as string) || '@anthropic-ai/claude-code';
       const cliInstall = await sandbox.runCommand('npm', [
         'install',
         '-g',
-        '@anthropic-ai/claude-code',
+        cliPackage,
       ]);
       if (cliInstall.exitCode !== 0) {
         throw new Error(`Claude Code install failed: ${cliInstall.stderr}`);
@@ -198,10 +199,18 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         };
       }
 
+      // Build CLI arguments
+      const cliArgs = ['--print', '--model', options.model, '--dangerously-skip-permissions'];
+      const effort = options.agentOptions?.effort as string | undefined;
+      if (effort) {
+        cliArgs.push('--effort', effort);
+      }
+      cliArgs.push(options.prompt);
+
       // Run Claude Code with appropriate authentication
       const claudeResult = await sandbox.runCommand(
         'claude',
-        ['--print', '--model', options.model, '--dangerously-skip-permissions', options.prompt],
+        cliArgs,
         {
           env: claudeEnv,
         }

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -357,6 +357,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     sandbox?: ResolvedExperimentConfig['sandbox'];
     editPrompt?: (prompt: string) => string;
     verbose?: boolean;
+    agentOptions?: ResolvedExperimentConfig['agentOptions'];
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
@@ -376,6 +377,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		setup: options.setup,
 		scripts: options.scripts,
 		sandbox: options.sandbox,
+		agentOptions: options.agentOptions,
 	});
 
     results.push(agentResultToEvalRunData(agentResult));


### PR DESCRIPTION
Opus 4.7 requires the `--effort` flag because it uses the new `thinking.type.adaptive` API, and exercising it today needs a pre-release Claude Code CLI. Neither was reachable from agent-eval.

This threads two `agentOptions` through to the Claude Code agent: `cliPackage` overrides the globally installed npm spec (defaulting to `@anthropic-ai/claude-code`, so existing configs are unchanged) and `effort` is appended as `--effort <level>` when set. `runSingleEval` was also dropping `agentOptions` on the way into the agent — fixed by forwarding it alongside the other run options.

Smoke test covered by a new `claude-opus-4-7` case in `integration.test.ts` that pins `cliPackage: '@anthropic-ai/claude-code@next'` and `effort: 'high'`. Changeset included.