### PR TITLE
[Sandbox] Reconnect on terminated streams to avoid spurious failures on long commands

### DIFF
--- a/.changeset/sandbox-reconnect-on-stream-terminated.md
+++ b/.changeset/sandbox-reconnect-on-stream-terminated.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Reconnect on terminated HTTP streams in `SandboxManager.runCommand`/`runShell` so in-sandbox commands exceeding ~5 min don't fail spuriously with `error: "terminated"`.

--- a/packages/agent-eval/src/lib/sandbox.ts
+++ b/packages/agent-eval/src/lib/sandbox.ts
@@ -3,7 +3,7 @@
  * Supports both Vercel Sandbox and Docker backends.
  */
 
-import { Sandbox as VercelSandbox } from '@vercel/sandbox';
+import { Sandbox as VercelSandbox, type Command } from '@vercel/sandbox';
 import type { Sandbox } from './types.js';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -93,6 +93,48 @@ export interface SandboxFile {
 }
 
 /**
+ * Vercel's edge infrastructure cuts long streaming HTTP responses at ~5-6 min,
+ * surfacing as `TypeError: terminated` from undici. Commands are started detached
+ * and waited on with reconnect loops so no single HTTP request needs to outlive
+ * that cutoff — only the in-sandbox process lifetime (bounded by sandbox timeout).
+ */
+function isStreamTerminated(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'TypeError' && err.message === 'terminated') return true;
+  const cause = (err as { cause?: { code?: string } }).cause;
+  const code = (err as { code?: string }).code ?? cause?.code;
+  return code === 'UND_ERR_SOCKET' || code === 'ECONNRESET';
+}
+
+async function waitForDetachedCommand(cmd: Command): Promise<CommandResult> {
+  let finished;
+  while (true) {
+    try {
+      finished = await cmd.wait();
+      break;
+    } catch (err) {
+      if (!isStreamTerminated(err)) throw err;
+    }
+  }
+
+  const readOutput = async (read: () => Promise<string>) => {
+    while (true) {
+      try {
+        return await read();
+      } catch (err) {
+        if (!isStreamTerminated(err)) throw err;
+      }
+    }
+  };
+
+  return {
+    stdout: await readOutput(() => finished.stdout()),
+    stderr: await readOutput(() => finished.stderr()),
+    exitCode: finished.exitCode,
+  };
+}
+
+/**
  * Wrapper around Vercel Sandbox providing a cleaner API.
  */
 export class SandboxManager implements Sandbox {
@@ -134,34 +176,28 @@ export class SandboxManager implements Sandbox {
     args: string[] = [],
     options: { env?: Record<string, string> } = {}
   ): Promise<CommandResult> {
-    const result = await this.sandbox.runCommand({
-      cmd: command,
-      args,
-      env: options.env,
-    });
-
-    return {
-      stdout: await result.stdout(),
-      stderr: await result.stderr(),
-      exitCode: result.exitCode,
-    };
+    return waitForDetachedCommand(
+      await this.sandbox.runCommand({
+        cmd: command,
+        args,
+        env: options.env,
+        detached: true,
+      })
+    );
   }
 
   /**
    * Run a shell command (through bash).
    */
   async runShell(command: string, env?: Record<string, string>): Promise<CommandResult> {
-    const result = await this.sandbox.runCommand({
-      cmd: 'bash',
-      args: ['-c', command],
-      env,
-    });
-
-    return {
-      stdout: await result.stdout(),
-      stderr: await result.stderr(),
-      exitCode: result.exitCode,
-    };
+    return waitForDetachedCommand(
+      await this.sandbox.runCommand({
+        cmd: 'bash',
+        args: ['-c', command],
+        env,
+        detached: true,
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
Vercel's edge infrastructure cuts long streaming HTTP responses at ~5–6 minutes, surfacing as `TypeError: terminated` from undici. `@vercel/sandbox`'s default `runCommand(wait:true)` holds a single ndjson stream for the entire command lifetime, so any in-sandbox command that exceeds the cutoff fails spuriously even when the sandbox timeout is set much higher. Across prior result directories, 28 runs across 9 experiments fell in a tight 363–428s window (mean 385s) with `error: "terminated"` — then mislabeled as "timeout" by the classifier, biasing pass rates against configs that need more wall time (e.g. opus-4.7 + AGENTS.md + effort max on `agent-030-app-router-migration-hard`).

`SandboxManager.runCommand` and `runShell` now start detached and wait via `Command.wait()` with a reconnect loop that retries on `TypeError('terminated')`, `UND_ERR_SOCKET`, and `ECONNRESET`. The same retry wraps `stdout()`/`stderr()` reads, which also stream ndjson. No single HTTP request needs to outlive the cutoff — only the in-sandbox process lifetime, still bounded by the sandbox timeout. Verified on the prior failing case (opus-4.7 + AGENTS.md + effort max on `agent-030`): 373s → `terminated` before, 498s → pass after.