### PR TITLE
[Kimi] Add Kimi CLI agent harness

### DIFF
--- a/.changeset/add-kimi-cli-agent.md
+++ b/.changeset/add-kimi-cli-agent.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add Kimi CLI agent harness. Supports two variants: `vercel-ai-gateway/kimi` (routes through the Vercel AI Gateway's OpenAI-compatible endpoint — no Moonshot account required) and `kimi` (direct Moonshot API via `MOONSHOT_API_KEY`). The sandbox installs Kimi CLI via `uv tool install kimi-cli` and runs it in `--print --output-format stream-json` mode, with a transcript parser that normalizes Kimi's OpenAI-style JSONL to the common o11y schema.

--- a/README.md
+++ b/README.md
@@ -226,12 +226,14 @@ export default config;
 agent: 'vercel-ai-gateway/claude-code'  // Claude Code via AI Gateway
 agent: 'vercel-ai-gateway/codex'        // OpenAI Codex via AI Gateway
 agent: 'vercel-ai-gateway/opencode'     // OpenCode via AI Gateway
+agent: 'vercel-ai-gateway/kimi'         // Kimi CLI via AI Gateway (no Moonshot account required)
 
 // Direct API (uses provider keys directly)
 agent: 'claude-code'  // requires ANTHROPIC_API_KEY
 agent: 'codex'        // requires OPENAI_API_KEY
 agent: 'gemini'       // requires GEMINI_API_KEY
 agent: 'cursor'       // requires CURSOR_API_KEY
+agent: 'kimi'         // requires MOONSHOT_API_KEY
 ```
 
 ### Multi-model experiments
@@ -258,6 +260,22 @@ model: 'vercel/minimax/minimax-m2.1'
 ```
 
 The `vercel/` prefix is required. Using `anthropic/claude-sonnet-4` (without `vercel/`) will fail with a "provider not found" error.
+
+### Kimi CLI model format
+
+Kimi CLI is installed in the sandbox via [`uv tool install kimi-cli`](https://pypi.org/project/kimi-cli/) and invoked in `--print --output-format stream-json` mode. When routed through the Vercel AI Gateway, pass the gateway's model id directly (no prefix). The sandbox writes a `kimi-config.toml` that wires an `openai_legacy` provider to the gateway's OpenAI-compatible endpoint.
+
+```typescript
+// Via AI Gateway — no Moonshot account required
+agent: 'vercel-ai-gateway/kimi'
+model: 'moonshotai/kimi-k2-0905'         // default
+model: 'moonshotai/kimi-k2-thinking'
+model: 'moonshotai/kimi-k2-5'
+
+// Direct Moonshot API
+agent: 'kimi'
+model: 'kimi-k2-0905-preview'            // default
+```
 
 ## A/B Testing
 
@@ -450,6 +468,7 @@ Every run requires an API key for the agent and a token for the sandbox. Classif
 | `OPENAI_API_KEY`     | `agent: 'codex'`                       | Direct OpenAI API key                                                                        |
 | `GEMINI_API_KEY`     | `agent: 'gemini'`                      | Direct Google Gemini API key                                                                 |
 | `CURSOR_API_KEY`     | `agent: 'cursor'`                      | Direct Cursor API key                                                                        |
+| `MOONSHOT_API_KEY`   | `agent: 'kimi'`                        | Direct Moonshot API key (not required for `vercel-ai-gateway/kimi`)                          |
 | `VERCEL_TOKEN`       | Always (pick one)                      | Vercel personal access token -- for local dev                                                |
 | `VERCEL_OIDC_TOKEN`  | Always (pick one) OR for classifier    | Vercel OIDC token -- for CI/CD pipelines, or enables classifier without `AI_GATEWAY_API_KEY` |
 

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -46,6 +46,8 @@ const hasGeminiCredentials = !!process.env.GEMINI_API_KEY && hasSandbox;
 const hasCursorCredentials = !!process.env.CURSOR_API_KEY && hasSandbox;
 // OpenCode credentials (only supports AI Gateway)
 const hasOpenCodeCredentials = hasAiGatewayCredentials;
+// Kimi via AI Gateway: no Moonshot account required.
+const hasKimiGatewayCredentials = hasAiGatewayCredentials;
 
 describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
   beforeAll(() => {
@@ -968,6 +970,70 @@ test('contains greeting', () => {
         }
       }
     }, 300000); // 5 minute timeout
+  });
+
+  describe.skipIf(!hasKimiGatewayCredentials)('Kimi CLI (Vercel AI Gateway) sandbox execution', () => {
+    it('can run a simple eval with Kimi CLI via AI Gateway', async () => {
+      const fixtureDir = join(TEST_DIR, 'simple-eval-kimi');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Add a function called greet in src/index.ts that returns "Hello from Kimi!"'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+test('greet exists', () => {
+  const content = readFileSync('src/index.ts', 'utf-8');
+  expect(content).toContain('greet');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'simple-eval-kimi',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+
+      const fixture = loadFixture(TEST_DIR, 'simple-eval-kimi');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/kimi',
+        model: 'moonshotai/kimi-k2-0905',
+        timeout: 240,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: ['build'],
+      });
+
+      expect(result.result.duration).toBeGreaterThan(0);
+      expect(result.result.status).toBeDefined();
+      if (result.result.status === 'failed') {
+        console.error('Kimi agent failed with error:', result.result.error);
+      }
+      expect(result.result.status).toBe('passed');
+      // Verify transcript was captured and parsed successfully.
+      expect(result.transcript).toBeTruthy();
+    }, 420000); // 7 minute timeout — uv install + first Kimi run can be slow.
   });
 
   describe.skipIf(!hasOpenCodeCredentials)('OpenCode (Vercel AI Gateway) sandbox execution', () => {

--- a/packages/agent-eval/src/lib/agents/index.ts
+++ b/packages/agent-eval/src/lib/agents/index.ts
@@ -8,6 +8,7 @@ import { createCodexAgent } from './codex.js';
 import { createOpenCodeAgent } from './opencode.js';
 import { createGeminiAgent } from './gemini.js';
 import { createCursorAgent } from './cursor.js';
+import { createKimiAgent } from './kimi.js';
 
 // Register all agent variants (Vercel AI Gateway + Direct API)
 registerAgent(createClaudeCodeAgent({ useVercelAiGateway: true }));   // vercel-ai-gateway/claude-code
@@ -15,6 +16,8 @@ registerAgent(createClaudeCodeAgent({ useVercelAiGateway: false }));  // claude-
 registerAgent(createCodexAgent({ useVercelAiGateway: true }));        // vercel-ai-gateway/codex
 registerAgent(createCodexAgent({ useVercelAiGateway: false }));       // codex
 registerAgent(createOpenCodeAgent());                                 // vercel-ai-gateway/opencode
+registerAgent(createKimiAgent({ useVercelAiGateway: true }));         // vercel-ai-gateway/kimi
+registerAgent(createKimiAgent({ useVercelAiGateway: false }));        // kimi
 registerAgent(createGeminiAgent());                                   // gemini
 registerAgent(createCursorAgent());                                   // cursor
 

--- a/packages/agent-eval/src/lib/agents/kimi.ts
+++ b/packages/agent-eval/src/lib/agents/kimi.ts
@@ -1,0 +1,302 @@
+/**
+ * Kimi CLI agent implementation.
+ * Supports Vercel AI Gateway (via openai_legacy provider) or direct Moonshot API.
+ */
+
+import type { Agent, AgentRunOptions, AgentRunResult } from './types.js';
+import type { ModelTier } from '../types.js';
+import {
+  createSandbox,
+  collectLocalFiles,
+  splitTestFiles,
+  verifyNoTestFiles,
+  type SandboxManager,
+} from '../sandbox.js';
+import type { DockerSandboxManager } from '../docker-sandbox.js';
+import {
+  runValidation,
+  captureGeneratedFiles,
+  createVitestConfig,
+  AI_GATEWAY,
+  MOONSHOT_DIRECT,
+  initGitAndCommit,
+  injectTranscriptContext,
+} from './shared.js';
+
+/** Union type for sandbox implementations */
+type AnySandbox = SandboxManager | DockerSandboxManager;
+
+export interface CreateKimiAgentOptions {
+  /** Route via Vercel AI Gateway (OpenAI-compatible) vs direct Moonshot API. */
+  useVercelAiGateway: boolean;
+}
+
+/**
+ * Extract transcript from Kimi CLI stream-json output.
+ * `kimi --print --output-format stream-json` emits JSONL rows of
+ * `{role: "assistant"|"tool", content, tool_calls?, tool_call_id?}`.
+ */
+function extractTranscriptFromOutput(output: string): string | undefined {
+  if (!output || !output.trim()) {
+    return undefined;
+  }
+  const lines = output.split('\n').filter((line) => {
+    const trimmed = line.trim();
+    return trimmed.startsWith('{') && trimmed.endsWith('}');
+  });
+  if (lines.length === 0) {
+    return undefined;
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Generate the Kimi config.toml that wires a single `[providers.gateway]` provider
+ * (type = openai_legacy) to the chosen endpoint, and defines a single `[models.<id>]`
+ * that references it. The CLI is then invoked with `--model <id>`.
+ */
+function generateKimiConfig(params: {
+  modelId: string;
+  providerModelId: string;
+  baseUrl: string;
+  apiKey: string;
+}): string {
+  const { modelId, providerModelId, baseUrl, apiKey } = params;
+  return [
+    `default_model = ${JSON.stringify(modelId)}`,
+    '',
+    '[providers.gateway]',
+    'type = "openai_legacy"',
+    `base_url = ${JSON.stringify(baseUrl)}`,
+    `api_key = ${JSON.stringify(apiKey)}`,
+    '',
+    `[models.${modelId}]`,
+    'provider = "gateway"',
+    `model = ${JSON.stringify(providerModelId)}`,
+    'max_context_size = 256000',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Model ID mapping.
+ *
+ * When using Vercel AI Gateway, Kimi models are served under the `moonshotai/*`
+ * namespace (e.g. `moonshotai/kimi-k2-0905`). When using Moonshot directly,
+ * Moonshot's own names apply (e.g. `kimi-k2-0905-preview`).
+ *
+ * The caller passes `options.model` as the *gateway/provider* model id; we use
+ * a local id (without slashes, which TOML doesn't allow in the section key) for
+ * the `[models.<id>]` section and `--model` flag.
+ */
+function toLocalModelId(providerModelId: string): string {
+  // Replace anything that isn't TOML-bare-key-safe with a dash.
+  return providerModelId.replace(/[^A-Za-z0-9_-]/g, '-');
+}
+
+/**
+ * Create Kimi CLI agent. Pass `useVercelAiGateway: true` to route via the Vercel
+ * AI Gateway (recommended — no Moonshot account required) or `false` to hit
+ * Moonshot's API directly via MOONSHOT_API_KEY.
+ */
+export function createKimiAgent(options: CreateKimiAgentOptions): Agent {
+  const { useVercelAiGateway } = options;
+  const name = useVercelAiGateway ? 'vercel-ai-gateway/kimi' : 'kimi';
+  const displayName = useVercelAiGateway ? 'Kimi CLI (Vercel AI Gateway)' : 'Kimi CLI';
+  const apiKeyEnvVar = useVercelAiGateway
+    ? AI_GATEWAY.apiKeyEnvVar
+    : MOONSHOT_DIRECT.apiKeyEnvVar;
+  const baseUrl = useVercelAiGateway
+    ? AI_GATEWAY.openAiBaseUrl
+    : MOONSHOT_DIRECT.baseUrl;
+  const defaultModel: ModelTier = useVercelAiGateway
+    ? 'moonshotai/kimi-k2-0905'
+    : 'kimi-k2-0905-preview';
+
+  return {
+    name,
+    displayName,
+
+    getApiKeyEnvVar(): string {
+      return apiKeyEnvVar;
+    },
+
+    getDefaultModel(): ModelTier {
+      return defaultModel;
+    },
+
+    async run(fixturePath: string, runOptions: AgentRunOptions): Promise<AgentRunResult> {
+      const startTime = Date.now();
+      let sandbox: AnySandbox | null = null;
+      let agentOutput = '';
+      let transcript: string | undefined;
+      let aborted = false;
+      let sandboxStopped = false;
+
+      const abortHandler = () => {
+        aborted = true;
+        if (sandbox && !sandboxStopped) {
+          sandboxStopped = true;
+          sandbox.stop().catch(() => {});
+        }
+      };
+
+      if (runOptions.signal) {
+        if (runOptions.signal.aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted before start',
+            duration: 0,
+          };
+        }
+        runOptions.signal.addEventListener('abort', abortHandler);
+      }
+
+      try {
+        const allFiles = await collectLocalFiles(fixturePath);
+        const { workspaceFiles, testFiles } = splitTestFiles(allFiles);
+
+        if (aborted) {
+          return { success: false, output: '', error: 'Aborted', duration: Date.now() - startTime };
+        }
+
+        sandbox = await createSandbox({
+          timeout: runOptions.timeout,
+          runtime: 'node24',
+          backend: runOptions.sandbox,
+        });
+
+        if (aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+            sandboxId: sandbox.sandboxId,
+          };
+        }
+
+        await sandbox.uploadFiles(workspaceFiles);
+        await initGitAndCommit(sandbox);
+
+        if (runOptions.setup) {
+          await runOptions.setup(sandbox);
+        }
+
+        // Install npm deps for the fixture (required by validation scripts / vitest).
+        let installResult = await sandbox.runCommand('npm', ['install']);
+        if (installResult.exitCode !== 0) {
+          installResult = await sandbox.runCommand('npm', ['install']);
+        }
+        if (installResult.exitCode !== 0) {
+          const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
+          throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
+        }
+
+        // Install Kimi CLI via uv (which bootstraps Python if needed).
+        // uv installs to $HOME/.local/bin, which we prepend to PATH below.
+        const kimiInstall = await sandbox.runShell(
+          [
+            'set -e',
+            'curl -LsSf https://astral.sh/uv/install.sh | sh',
+            'export PATH="$HOME/.local/bin:$PATH"',
+            'uv tool install kimi-cli',
+            'kimi --version',
+          ].join(' && ')
+        );
+        if (kimiInstall.exitCode !== 0) {
+          throw new Error(
+            `Kimi CLI install failed: ${(kimiInstall.stdout + kimiInstall.stderr).slice(-500)}`
+          );
+        }
+
+        // Write the config.toml that routes Kimi through the chosen provider.
+        const providerModelId = runOptions.model;
+        const localModelId = toLocalModelId(providerModelId);
+        const configContent = generateKimiConfig({
+          modelId: localModelId,
+          providerModelId,
+          baseUrl,
+          apiKey: runOptions.apiKey,
+        });
+        await sandbox.writeFiles({ 'kimi-config.toml': configContent });
+
+        await verifyNoTestFiles(sandbox);
+
+        // Run Kimi in non-interactive print mode with stream-json output.
+        // --yolo is implicit with --print, but we pass it explicitly for clarity.
+        const kimiResult = await sandbox.runShell(
+          [
+            'export PATH="$HOME/.local/bin:$PATH"',
+            `kimi --config-file kimi-config.toml --model ${JSON.stringify(localModelId)} --print --yolo --output-format stream-json --prompt ${JSON.stringify(runOptions.prompt)}`,
+          ].join(' && '),
+          {
+            [apiKeyEnvVar]: runOptions.apiKey,
+          }
+        );
+
+        agentOutput = kimiResult.stdout + kimiResult.stderr;
+        transcript = extractTranscriptFromOutput(agentOutput);
+
+        if (kimiResult.exitCode !== 0) {
+          const errorLines = agentOutput.trim().split('\n').slice(-5).join('\n');
+          return {
+            success: false,
+            output: agentOutput,
+            transcript,
+            error: errorLines || `Kimi CLI exited with code ${kimiResult.exitCode}`,
+            duration: Date.now() - startTime,
+            sandboxId: sandbox.sandboxId,
+          };
+        }
+
+        await sandbox.uploadFiles(testFiles);
+        await createVitestConfig(sandbox);
+        await injectTranscriptContext(sandbox, transcript, name, runOptions.model);
+
+        const validationResults = await runValidation(sandbox, runOptions.scripts ?? []);
+        const { generatedFiles, deletedFiles } = await captureGeneratedFiles(sandbox);
+
+        return {
+          success: validationResults.allPassed,
+          output: agentOutput,
+          transcript,
+          duration: Date.now() - startTime,
+          testResult: validationResults.test,
+          scriptsResults: validationResults.scripts,
+          sandboxId: sandbox.sandboxId,
+          generatedFiles,
+          deletedFiles,
+        };
+      } catch (error) {
+        if (aborted) {
+          return {
+            success: false,
+            output: agentOutput,
+            transcript,
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+            sandboxId: sandbox?.sandboxId,
+          };
+        }
+        return {
+          success: false,
+          output: agentOutput,
+          transcript,
+          error: error instanceof Error ? error.message : String(error),
+          duration: Date.now() - startTime,
+          sandboxId: sandbox?.sandboxId,
+        };
+      } finally {
+        if (runOptions.signal) {
+          runOptions.signal.removeEventListener('abort', abortHandler);
+        }
+        if (sandbox && !sandboxStopped) {
+          sandboxStopped = true;
+          await sandbox.stop();
+        }
+      }
+    },
+  };
+}

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -243,3 +243,11 @@ export const GEMINI_DIRECT = {
 export const CURSOR_DIRECT = {
   apiKeyEnvVar: 'CURSOR_API_KEY',
 } as const;
+
+/**
+ * Direct API configuration for Moonshot AI (Kimi).
+ */
+export const MOONSHOT_DIRECT = {
+  baseUrl: 'https://api.moonshot.ai/v1',
+  apiKeyEnvVar: 'MOONSHOT_API_KEY',
+} as const;

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -35,6 +35,8 @@ const experimentConfigSchema = z.object({
     'vercel-ai-gateway/codex',
     'codex',
     'vercel-ai-gateway/opencode',
+    'vercel-ai-gateway/kimi',
+    'kimi',
     'gemini',
     'cursor',
   ]),

--- a/packages/agent-eval/src/lib/o11y/index.ts
+++ b/packages/agent-eval/src/lib/o11y/index.ts
@@ -24,3 +24,4 @@ export { parseCodexTranscript } from './parsers/codex.js';
 export { parseOpenCodeTranscript } from './parsers/opencode.js';
 export { parseGeminiTranscript } from './parsers/gemini.js';
 export { parseCursorTranscript } from './parsers/cursor.js';
+export { parseKimiTranscript } from './parsers/kimi.js';

--- a/packages/agent-eval/src/lib/o11y/o11y.test.ts
+++ b/packages/agent-eval/src/lib/o11y/o11y.test.ts
@@ -10,6 +10,7 @@ import { parseCodexTranscript } from './parsers/codex.js';
 import { parseOpenCodeTranscript } from './parsers/opencode.js';
 import { parseGeminiTranscript } from './parsers/gemini.js';
 import { parseCursorTranscript } from './parsers/cursor.js';
+import { parseKimiTranscript } from './parsers/kimi.js';
 
 describe('o11y', () => {
   describe('parseTranscript', () => {
@@ -47,7 +48,7 @@ describe('o11y', () => {
 
       expect(result.parseSuccess).toBe(false);
       expect(result.parseErrors).toContain(
-        'No parser available for agent: unsupported-agent. Supported agents: claude-code, codex, opencode, gemini, cursor'
+        'No parser available for agent: unsupported-agent. Supported agents: claude-code, codex, opencode, gemini, cursor, kimi'
       );
       expect(result.events).toEqual([]);
       expect(result.summary.totalToolCalls).toBe(0);
@@ -734,6 +735,143 @@ describe('o11y', () => {
       expect(result.summary.toolCalls.file_read).toBe(1);
       expect(result.summary.totalToolCalls).toBe(1);
       expect(result.summary.filesRead).toContain('a.ts');
+    });
+  });
+
+  describe('Kimi parser', () => {
+    it('parses assistant message with tool_calls', () => {
+      const line = JSON.stringify({
+        role: 'assistant',
+        content: "I'll write the file.",
+        tool_calls: [
+          {
+            id: 'functions.WriteFile:0',
+            type: 'function',
+            function: {
+              name: 'WriteFile',
+              arguments: JSON.stringify({ path: 'hello.txt', content: 'hi' }),
+            },
+          },
+        ],
+      });
+
+      const { events } = parseKimiTranscript(line);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('message');
+      expect(events[0].role).toBe('assistant');
+      expect(events[1].type).toBe('tool_call');
+      expect(events[1].tool?.name).toBe('file_write');
+      expect(events[1].tool?.originalName).toBe('WriteFile');
+      expect(events[1].tool?.args?._extractedPath).toBe('hello.txt');
+    });
+
+    it('parses tool result and pairs it with pending call', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'ReadFile', arguments: JSON.stringify({ path: 'a.ts' }) },
+            },
+          ],
+        }),
+        JSON.stringify({
+          role: 'tool',
+          content: 'file contents',
+          tool_call_id: 'call_1',
+        }),
+      ].join('\n');
+
+      const { events } = parseKimiTranscript(transcript);
+
+      const result = events.find((e) => e.type === 'tool_result');
+      expect(result).toBeDefined();
+      expect(result?.tool?.name).toBe('file_read');
+      expect(result?.tool?.originalName).toBe('ReadFile');
+      expect(result?.tool?.success).toBe(true);
+    });
+
+    it('marks tool_result as failed when content mentions error', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'c1',
+              type: 'function',
+              function: { name: 'Shell', arguments: JSON.stringify({ command: 'false' }) },
+            },
+          ],
+        }),
+        JSON.stringify({
+          role: 'tool',
+          content: '<system>Command failed with exit code 1.</system>',
+          tool_call_id: 'c1',
+        }),
+      ].join('\n');
+
+      const { events } = parseKimiTranscript(transcript);
+      const result = events.find((e) => e.type === 'tool_result');
+      expect(result?.tool?.success).toBe(false);
+    });
+
+    it('strips functions. prefix from tool names', () => {
+      const line = JSON.stringify({
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'x',
+            type: 'function',
+            function: { name: 'functions.Shell', arguments: JSON.stringify({ command: 'ls' }) },
+          },
+        ],
+      });
+
+      const { events } = parseKimiTranscript(line);
+      const call = events.find((e) => e.type === 'tool_call');
+      expect(call?.tool?.name).toBe('shell');
+      expect(call?.tool?.args?._extractedCommand).toBe('ls');
+    });
+
+    it('produces a full summary from a realistic transcript', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: "I'll create the file.",
+          tool_calls: [
+            {
+              id: 'c1',
+              type: 'function',
+              function: {
+                name: 'WriteFile',
+                arguments: JSON.stringify({ path: 'hello.txt', content: 'hi' }),
+              },
+            },
+          ],
+        }),
+        JSON.stringify({
+          role: 'tool',
+          content: '<system>File successfully overwritten. Current size: 2 bytes.</system>',
+          tool_call_id: 'c1',
+        }),
+        JSON.stringify({
+          role: 'assistant',
+          content: 'Done.',
+        }),
+      ].join('\n');
+
+      const result = parseTranscript(transcript, 'kimi');
+
+      expect(result.parseSuccess).toBe(true);
+      expect(result.summary.totalTurns).toBe(2);
+      expect(result.summary.toolCalls.file_write).toBe(1);
+      expect(result.summary.filesModified).toContain('hello.txt');
     });
   });
 

--- a/packages/agent-eval/src/lib/o11y/parsers/index.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/index.ts
@@ -16,6 +16,7 @@ import { parseCodexTranscript } from './codex.js';
 import { parseOpenCodeTranscript } from './opencode.js';
 import { parseGeminiTranscript } from './gemini.js';
 import { parseCursorTranscript } from './cursor.js';
+import { parseKimiTranscript } from './kimi.js';
 
 /**
  * Supported agent types for parsing.
@@ -26,6 +27,8 @@ export type ParseableAgent =
   | 'vercel-ai-gateway/codex'
   | 'codex'
   | 'vercel-ai-gateway/opencode'
+  | 'vercel-ai-gateway/kimi'
+  | 'kimi'
   | 'gemini'
   | 'cursor';
 
@@ -38,6 +41,7 @@ const AGENT_PARSERS = {
   'opencode': parseOpenCodeTranscript,
   'gemini': parseGeminiTranscript,
   'cursor': parseCursorTranscript,
+  'kimi': parseKimiTranscript,
 } as const;
 
 /**

--- a/packages/agent-eval/src/lib/o11y/parsers/kimi.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/kimi.ts
@@ -1,0 +1,206 @@
+/**
+ * Parser for Kimi CLI transcript format.
+ *
+ * Kimi CLI emits JSONL when invoked with `--print --output-format stream-json`.
+ * Each row is an OpenAI-style chat message:
+ *
+ *   {"role":"assistant","content":"...","tool_calls":[{"id":"...","type":"function","function":{"name":"WriteFile","arguments":"{...json...}"}}]}
+ *   {"role":"tool","content":"...","tool_call_id":"..."}
+ *   {"role":"assistant","content":"final message"}
+ *
+ * `content` may be an empty string when the assistant is only issuing tool calls.
+ * `function.arguments` is a JSON string that we parse into an object.
+ */
+
+import type { TranscriptEvent, ToolName } from '../types.js';
+
+/**
+ * Map Kimi tool names (as exposed by the built-in `default` agent) to canonical
+ * observability tool names.
+ */
+const KIMI_TOOL_MAP: Record<string, ToolName> = {
+  ReadFile: 'file_read',
+  WriteFile: 'file_write',
+  EditFile: 'file_edit',
+  ApplyPatch: 'file_edit',
+  DeleteFile: 'file_write',
+  ListDir: 'list_dir',
+  ListDirectory: 'list_dir',
+  Glob: 'glob',
+  Grep: 'grep',
+  Search: 'grep',
+  Shell: 'shell',
+  Bash: 'shell',
+  RunShell: 'shell',
+  RunCommand: 'shell',
+  WebFetch: 'web_fetch',
+  Fetch: 'web_fetch',
+  WebSearch: 'web_search',
+  Task: 'agent_task',
+  TodoWrite: 'agent_task',
+  UpdateTodos: 'agent_task',
+};
+
+/**
+ * Normalize a Kimi tool name to a canonical ToolName. Kimi occasionally prefixes
+ * function names with `functions.` — strip that prefix before lookup.
+ */
+function canonicalToolName(rawName: string): ToolName {
+  const stripped = rawName.replace(/^functions\./, '');
+  return KIMI_TOOL_MAP[stripped] || 'unknown';
+}
+
+/**
+ * Safely parse a tool-call `arguments` JSON string. Returns an empty object on
+ * failure so downstream summary extraction still works.
+ */
+function parseToolArgs(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string') {
+    if (raw && typeof raw === 'object') return raw as Record<string, unknown>;
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function extractFilePath(args: Record<string, unknown>): string | undefined {
+  return (args.path || args.filePath || args.file || args.file_path) as string | undefined;
+}
+
+function extractCommand(args: Record<string, unknown>): string | undefined {
+  if (typeof args.command === 'string') return args.command;
+  if (typeof args.cmd === 'string') return args.cmd;
+  if (typeof args.script === 'string') return args.script;
+  return undefined;
+}
+
+function extractUrl(args: Record<string, unknown>): string | undefined {
+  return (args.url || args.uri) as string | undefined;
+}
+
+interface PendingToolCall {
+  originalName: string;
+  canonicalName: ToolName;
+}
+
+function parseKimiLine(
+  line: string,
+  pending: Map<string, PendingToolCall>
+): TranscriptEvent[] {
+  const events: TranscriptEvent[] = [];
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(line);
+  } catch {
+    return events;
+  }
+
+  const role = data.role as string | undefined;
+
+  if (role === 'assistant') {
+    const content = data.content;
+    if (typeof content === 'string' && content.trim()) {
+      events.push({
+        type: 'message',
+        role: 'assistant',
+        content,
+        raw: data,
+      });
+    }
+
+    const toolCalls = data.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      for (const call of toolCalls) {
+        if (!call || typeof call !== 'object') continue;
+        const c = call as Record<string, unknown>;
+        const id = typeof c.id === 'string' ? c.id : undefined;
+        const fn = c.function as Record<string, unknown> | undefined;
+        const rawName = typeof fn?.name === 'string' ? fn.name : 'unknown';
+        const canonicalName = canonicalToolName(rawName);
+        const args = parseToolArgs(fn?.arguments);
+
+        const extracted: Record<string, unknown> = {};
+        if (canonicalName === 'file_read' || canonicalName === 'file_write' || canonicalName === 'file_edit') {
+          const p = extractFilePath(args);
+          if (p) extracted._extractedPath = p;
+        }
+        if (canonicalName === 'shell') {
+          const cmd = extractCommand(args);
+          if (cmd) extracted._extractedCommand = cmd;
+        }
+        if (canonicalName === 'web_fetch') {
+          const url = extractUrl(args);
+          if (url) extracted._extractedUrl = url;
+        }
+
+        events.push({
+          type: 'tool_call',
+          tool: {
+            name: canonicalName,
+            originalName: rawName,
+            args: { ...args, ...extracted },
+          },
+          raw: call,
+        });
+
+        if (id) pending.set(id, { originalName: rawName, canonicalName });
+      }
+    }
+    return events;
+  }
+
+  if (role === 'tool') {
+    const id = typeof data.tool_call_id === 'string' ? data.tool_call_id : undefined;
+    const pendingCall = id ? pending.get(id) : undefined;
+    const content = typeof data.content === 'string' ? data.content : '';
+    // Heuristic: Kimi wraps error results in `<system>...</system>` tags that
+    // often include the word "error" or "failed". Treat those as failures.
+    const lower = content.toLowerCase();
+    const success = !(lower.includes('error') || lower.includes('failed'));
+
+    events.push({
+      type: 'tool_result',
+      tool: {
+        name: pendingCall?.canonicalName || 'unknown',
+        originalName: pendingCall?.originalName || 'unknown',
+        result: content,
+        success,
+      },
+      raw: data,
+    });
+
+    if (id) pending.delete(id);
+    return events;
+  }
+
+  // Ignore user/system rows — they only echo the incoming prompt.
+  return events;
+}
+
+/**
+ * Parse Kimi CLI stream-json output into normalized transcript events.
+ */
+export function parseKimiTranscript(raw: string): {
+  events: TranscriptEvent[];
+  errors: string[];
+} {
+  const events: TranscriptEvent[] = [];
+  const errors: string[] = [];
+  const pending = new Map<string, PendingToolCall>();
+
+  const lines = raw.split('\n').filter((line) => line.trim());
+  for (const line of lines) {
+    try {
+      events.push(...parseKimiLine(line, pending));
+    } catch (e) {
+      errors.push(`Failed to parse line: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return { events, errors };
+}

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -11,6 +11,8 @@ export type AgentType =
   | 'vercel-ai-gateway/codex'
   | 'codex'
   | 'vercel-ai-gateway/opencode'
+  | 'vercel-ai-gateway/kimi'
+  | 'kimi'
   | 'gemini'
   | 'cursor';
 


### PR DESCRIPTION
## Summary

Adds a Kimi CLI agent harness with two variants:

- **`vercel-ai-gateway/kimi`** — routes through the Vercel AI Gateway's OpenAI-compatible endpoint via Kimi's `openai_legacy` provider type. **No Moonshot account or `MOONSHOT_API_KEY` required** — reuses the existing `AI_GATEWAY_API_KEY`.
- **`kimi`** — direct Moonshot API via `MOONSHOT_API_KEY`.

In the sandbox we install [`kimi-cli`](https://pypi.org/project/kimi-cli/) via `uv tool install` (uv auto-bootstraps Python if needed) and invoke it as:

```
kimi --config-file kimi-config.toml --model <id> --print --yolo --output-format stream-json --prompt "…"
```

The generated `kimi-config.toml` wires a single `[providers.gateway]` of type `openai_legacy` pointing to either `https://ai-gateway.vercel.sh/v1` or `https://api.moonshot.ai/v1`, and registers one `[models.<id>]` that references it.

The transcript parser normalizes Kimi's OpenAI-style JSONL rows (`{role, content, tool_calls}` / `{role: "tool", content, tool_call_id}`) to the shared o11y schema, mapping Kimi's tool names (`WriteFile`, `ReadFile`, `Shell`, …) to canonical tool names (`file_write`, `file_read`, `shell`, …).

## Prototype validation

Locally installed kimi-cli and confirmed AI Gateway routing works end-to-end — Kimi K2 is available on the Gateway, generates tool calls against `WriteFile`, and emits stream-json JSONL cleanly (the file was actually written to disk). Cost per short call: ~\$0.00002.

## Test plan

- [x] Unit tests: 71/71 passing (adds 5 Kimi parser tests)
- [x] Typecheck + build + lint clean
- [ ] Integration test (`INTEGRATION_TEST=1 npx vitest run src/integration.test.ts --testNamePattern="Kimi"`) — needs to run in CI or with sandbox creds
- [ ] Smoke test a multi-model experiment using `vercel-ai-gateway/kimi` alongside other gateway agents

## Follow-ups

- Add Kimi to classification model options if helpful.
- Consider adding `kimi-k2-thinking` variant to default model list once stabilized.