### PR TITLE
[CLI] Surface AI Gateway errors during failure classification

### DIFF
--- a/.changeset/surface-classifier-errors.md
+++ b/.changeset/surface-classifier-errors.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Surface AI Gateway errors during classification instead of swallowing them. `classifyWithAI` and `classifyFailure` now throw on gateway/network failures, and `runAllCommand` collects per-eval classifier errors and prints them at the end of the classify phase. Previously a 402 (insufficient funds), network blip, or any other gateway error would silently leave failures with no `classification.json`, which the cache reuse path then refuses to reuse — causing those evals to re-run on every subsequent invocation.

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -549,16 +549,22 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
                   let classifyingDone = 0;
                   const classifyingTotal = failedEvals.length;
                   let hasNonModelFailures = false;
+                  const classifierErrors: { evalName: string; error: unknown }[] = [];
 
                   await Promise.all(
                     failedEvals.map((evalSummary) =>
                       classifyLimit(async () => {
                         const evalResultDir = resolve(resultsDir, experimentName, timestamp, evalSummary.name);
-                        const classification = await classifyFailure(
-                          evalResultDir,
-                          evalSummary.name,
-                          experimentName
-                        );
+                        let classification: Classification | null = null;
+                        try {
+                          classification = await classifyFailure(
+                            evalResultDir,
+                            evalSummary.name,
+                            experimentName
+                          );
+                        } catch (err) {
+                          classifierErrors.push({ evalName: evalSummary.name, error: err });
+                        }
 
                         classifyingDone++;
                         if (dashboard) {
@@ -593,6 +599,37 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
                       })
                     )
                   );
+
+                  if (classifierErrors.length > 0) {
+                    // Surface classifier failures loudly. Without classification.json,
+                    // the cache reuse logic in scanReusableResults will force these
+                    // failures to re-run on every subsequent invocation. The user
+                    // needs to know exactly why classification failed (e.g. AI gateway
+                    // billing, network) so they can fix the root cause.
+                    console.error(
+                      chalk.red(
+                        `\n  ⚠️  Classifier failed for ${classifierErrors.length}/${classifyingTotal} eval(s):`
+                      )
+                    );
+                    const seen = new Set<string>();
+                    for (const { evalName, error } of classifierErrors) {
+                      const msg = error instanceof Error ? error.message : String(error);
+                      console.error(chalk.red(`     - ${evalName}: ${msg.split('\n')[0]}`));
+                      seen.add(msg.split('\n')[0]);
+                    }
+                    console.error(
+                      chalk.gray(
+                        `     These failures have no classification.json and will re-run next invocation.`
+                      )
+                    );
+                    if (seen.size === 1 && [...seen][0].toLowerCase().includes('insufficient funds')) {
+                      console.error(
+                        chalk.gray(
+                          `     Top up your AI Gateway credits at https://vercel.com/dashboard → AI to fix.`
+                        )
+                      );
+                    }
+                  }
 
                   if (hasNonModelFailures && !options.ackFailures && !dashboard) {
                     console.log(chalk.yellow(`\n  To keep non-model failures as final results, re-run with --ack-failures`));

--- a/packages/agent-eval/src/lib/classifier.ts
+++ b/packages/agent-eval/src/lib/classifier.ts
@@ -199,6 +199,10 @@ export function createClassifierTools(evalResultDir: string) {
 /**
  * Classify a failure using AI via the Vercel AI Gateway.
  * Requires AI_GATEWAY_API_KEY in the environment.
+ *
+ * Throws on AI gateway / network errors so the caller can surface them.
+ * Returns null only when the model itself failed to call classify() within
+ * its tool budget — a soft, semantic miss.
  */
 export async function classifyWithAI(
   evalResultDir: string,
@@ -231,19 +235,15 @@ export async function classifyWithAI(
     }),
   };
 
-  try {
-    await generateText({
-      model: gateway('anthropic/claude-haiku-4-5-20251001'),
-      system: CLASSIFIER_SYSTEM_PROMPT,
-      prompt: `Classify the failure for eval "${evalName}" (experiment: ${experimentName}). Use the exploration tools to investigate, then call classify() with your verdict.`,
-      tools: allTools,
-      stopWhen: hasToolCall('classify'),
-    });
+  await generateText({
+    model: gateway('anthropic/claude-haiku-4-5-20251001'),
+    system: CLASSIFIER_SYSTEM_PROMPT,
+    prompt: `Classify the failure for eval "${evalName}" (experiment: ${experimentName}). Use the exploration tools to investigate, then call classify() with your verdict.`,
+    tools: allTools,
+    stopWhen: hasToolCall('classify'),
+  });
 
-    return classification;
-  } catch {
-    return null;
-  }
+  return classification;
 }
 
 /**
@@ -251,6 +251,7 @@ export async function classifyWithAI(
  * Requires AI_GATEWAY_API_KEY in the environment.
  *
  * Caches results in classification.json within the eval result directory.
+ * Throws if the AI gateway call itself fails — callers must handle.
  */
 export async function classifyFailure(
   evalResultDir: string,
@@ -268,7 +269,7 @@ export async function classifyFailure(
     // No cache
   }
 
-  // Classify with AI
+  // Classify with AI — let errors propagate so the caller can report them.
   const classification = await classifyWithAI(evalResultDir, evalName, experimentName);
 
   // Cache the result


### PR DESCRIPTION
When the classifier hits an AI Gateway error (insufficient funds, network, etc.) it would silently return null and write no `classification.json`. The cache reuse logic in `scanReusableResults` then refuses to reuse those failures and re-runs them on every subsequent `pnpm eval` — without ever telling the user why classification didn't take.

Removes the blanket `try/catch` in `classifyWithAI` and the implicit one in `classifyFailure`. Both now throw on gateway/network errors; only a soft semantic miss (model never called `classify()` within its tool budget) returns null. `runAllCommand` catches per-eval errors, prints a red block at the end of the classify phase listing each failed eval and the underlying message, and special-cases `Insufficient funds` with a top-up link.

Needs tests — mocking `generateText` to throw and asserting the per-eval error reporting.