### PR TITLE
Add response-only harness support

### DIFF
--- a/.changeset/calm-brands-compare.md
+++ b/.changeset/calm-brands-compare.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add response-only eval support, post-run analysis hooks, brand definitions, and a0-local agent aliases.

--- a/.changeset/calm-brands-compare.md
+++ b/.changeset/calm-brands-compare.md
@@ -2,4 +2,4 @@
 "@vercel/agent-eval": minor
 ---
 
-Add response-only eval support, post-run analysis hooks, brand definitions, and a0-local agent aliases.
+Add response-only eval support, post-run analysis hooks, and brand definitions.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ const config: ExperimentConfig = {
   // npm scripts that must pass after agent finishes (default: [])
   scripts: ['build', 'lint'],
 
+  // Validation mode after the agent finishes (default: 'vitest')
+  // 'vitest' - run EVAL.ts/EVAL.tsx plus configured scripts
+  // 'none' - response-only mode; skip EVAL.ts/EVAL.tsx, run scripts if provided
+  validation: 'vitest',
+
   // Timeout per run in seconds (default: 600)
   timeout: 600,
 
@@ -204,6 +209,26 @@ const config: ExperimentConfig = {
 
   // Rewrite the prompt before running
   editPrompt: (prompt) => `Use the skill.\n\n${prompt}`,
+
+  // Custom post-run analysis hook. Can attach analysis/metadata to result.json.
+  onRunComplete: async ({ runData }) => ({
+    ...runData,
+    result: {
+      ...runData.result,
+      analysis: { mentionedBrands: ['Vercel'] },
+    },
+  }),
+
+  // Optional brands to compare in downstream analysis.
+  brands: [
+    {
+      id: 'vercel',
+      name: 'Vercel',
+      domain: 'vercel.com',
+      aliases: ['Vercel Platform'],
+      isYourBrand: true,
+    },
+  ],
 
   // Sandbox backend (default: 'auto' -- Vercel if token present, else Docker)
   sandbox: 'auto',
@@ -233,6 +258,14 @@ agent: 'gemini'       // requires GEMINI_API_KEY
 agent: 'cursor'       // requires CURSOR_API_KEY
 ```
 
+The runner also accepts these compatibility aliases:
+
+```typescript
+agent: 'anthropic/claude-code'  // alias for vercel-ai-gateway/claude-code
+agent: 'openai/codex'           // alias for codex
+agent: 'opencode/opencode'      // alias for vercel-ai-gateway/opencode
+```
+
 ### Multi-model experiments
 
 Provide an array of models to run the same experiment on each one. Results are stored under separate directories (`experiment-name/model-name`):
@@ -257,6 +290,33 @@ model: 'vercel/minimax/minimax-m2.1'
 ```
 
 The `vercel/` prefix is required. Using `anthropic/claude-sonnet-4` (without `vercel/`) will fail with a "provider not found" error.
+
+### Response-only evals
+
+Use `validation: 'none'` for tasks where the important output is the agent's
+answer rather than changed files passing `EVAL.ts`.
+
+```typescript
+const config: ExperimentConfig = {
+  agent: 'anthropic/claude-code',
+  model: 'sonnet',
+  validation: 'none',
+  runs: 10,
+  earlyExit: false,
+  brands: [
+    { id: 'vercel', name: 'Vercel', aliases: ['Vercel Platform'], isYourBrand: true },
+    { id: 'netlify', name: 'Netlify' },
+    { id: 'railway', name: 'Railway' },
+  ],
+  onRunComplete: async ({ runData }) => {
+    // Add custom brand/recommendation analysis here.
+    return runData;
+  },
+};
+```
+
+Response-only fixtures still need `PROMPT.md` and `package.json`, but they do
+not need `EVAL.ts` or `EVAL.tsx`.
 
 ## A/B Testing
 

--- a/README.md
+++ b/README.md
@@ -258,14 +258,6 @@ agent: 'gemini'       // requires GEMINI_API_KEY
 agent: 'cursor'       // requires CURSOR_API_KEY
 ```
 
-The runner also accepts these compatibility aliases:
-
-```typescript
-agent: 'anthropic/claude-code'  // alias for vercel-ai-gateway/claude-code
-agent: 'openai/codex'           // alias for codex
-agent: 'opencode/opencode'      // alias for vercel-ai-gateway/opencode
-```
-
 ### Multi-model experiments
 
 Provide an array of models to run the same experiment on each one. Results are stored under separate directories (`experiment-name/model-name`):
@@ -298,7 +290,7 @@ answer rather than changed files passing `EVAL.ts`.
 
 ```typescript
 const config: ExperimentConfig = {
-  agent: 'anthropic/claude-code',
+  agent: 'vercel-ai-gateway/claude-code',
   model: 'sonnet',
   validation: 'none',
   runs: 10,

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -83,7 +83,9 @@ async function runExperimentCommand(configInput: string, options: { dry?: boolea
     }
 
     console.log(chalk.blue(`Discovering evals in ${evalsDir}...`));
-    const { fixtures, errors } = loadAllFixtures(evalsDir);
+    const { fixtures, errors } = loadAllFixtures(evalsDir, {
+      validation: config.validation,
+    });
 
     if (errors.length > 0) {
       console.log(chalk.yellow(`\nWarning: ${errors.length} invalid fixture(s):`));

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -6,11 +6,16 @@
 
 // Re-export types
 export type {
+  BuiltInAgentType,
   AgentType,
   ModelTier,
   EvalFilter,
+  ValidationMode,
+  BrandConfig,
   Sandbox,
   SetupFunction,
+  RunCompleteContext,
+  RunCompleteHook,
   ExperimentConfig,
   ResolvedExperimentConfig,
   EvalFixture,
@@ -80,7 +85,7 @@ export { TRANSCRIPT_CONTEXT_DIR, TRANSCRIPT_CONTEXT_PATH } from './lib/agents/sh
 
 // Re-export agent registry
 export type { Agent, ScriptResult } from './lib/agents/types.js';
-export { getAgent, listAgents, registerAgent } from './lib/agents/index.js';
+export { getAgent, listAgents, registerAgent, registerAgentAlias } from './lib/agents/index.js';
 
 // Re-export results utilities
 export type { SaveResultsOptions, ReusableResult } from './lib/results.js';

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -6,7 +6,6 @@
 
 // Re-export types
 export type {
-  BuiltInAgentType,
   AgentType,
   ModelTier,
   EvalFilter,
@@ -85,7 +84,7 @@ export { TRANSCRIPT_CONTEXT_DIR, TRANSCRIPT_CONTEXT_PATH } from './lib/agents/sh
 
 // Re-export agent registry
 export type { Agent, ScriptResult } from './lib/agents/types.js';
-export { getAgent, listAgents, registerAgent, registerAgentAlias } from './lib/agents/index.js';
+export { getAgent, listAgents, registerAgent } from './lib/agents/index.js';
 
 // Re-export results utilities
 export type { SaveResultsOptions, ReusableResult } from './lib/results.js';

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -233,20 +233,22 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         };
       }
 
-      // Upload test files for validation
-      await sandbox.uploadFiles(testFiles);
-
-      // Create vitest config for EVAL.ts/tsx
-      await createVitestConfig(sandbox);
-
       // Capture transcript before validation when available
       await captureTranscriptBestEffort();
 
-      // Inject transcript context so EVAL.ts tests can assert on agent behavior
-      await injectTranscriptContext(sandbox, transcript, 'claude-code', options.model);
+      if (options.validation !== 'none') {
+        // Upload test files for validation
+        await sandbox.uploadFiles(testFiles);
+
+        // Create vitest config for EVAL.ts/tsx
+        await createVitestConfig(sandbox);
+
+        // Inject transcript context so EVAL.ts tests can assert on agent behavior
+        await injectTranscriptContext(sandbox, transcript, 'claude-code', options.model);
+      }
 
       // Run validation scripts
-      const validationResults = await runValidation(sandbox, options.scripts ?? []);
+      const validationResults = await runValidation(sandbox, options.scripts ?? [], options.validation);
 
       // Capture generated files
       const { generatedFiles, deletedFiles } = await captureGeneratedFiles(sandbox);

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -256,17 +256,19 @@ EOF`);
         };
       }
 
-      // Upload test files for validation
-      await sandbox.uploadFiles(testFiles);
+      if (options.validation !== 'none') {
+        // Upload test files for validation
+        await sandbox.uploadFiles(testFiles);
 
-      // Create vitest config for EVAL.ts/tsx
-      await createVitestConfig(sandbox);
+        // Create vitest config for EVAL.ts/tsx
+        await createVitestConfig(sandbox);
 
-      // Inject transcript context so EVAL.ts tests can assert on agent behavior
-      await injectTranscriptContext(sandbox, transcript, 'codex', options.model);
+        // Inject transcript context so EVAL.ts tests can assert on agent behavior
+        await injectTranscriptContext(sandbox, transcript, 'codex', options.model);
+      }
 
       // Run validation scripts
-      const validationResults = await runValidation(sandbox, options.scripts ?? []);
+      const validationResults = await runValidation(sandbox, options.scripts ?? [], options.validation);
 
       // Capture generated files
       const { generatedFiles, deletedFiles } = await captureGeneratedFiles(sandbox);

--- a/packages/agent-eval/src/lib/agents/index.ts
+++ b/packages/agent-eval/src/lib/agents/index.ts
@@ -2,7 +2,7 @@
  * Agent registry with built-in agents.
  */
 
-import { registerAgent, getAgent, listAgents, hasAgent } from './registry.js';
+import { registerAgent, registerAgentAlias, getAgent, listAgents, hasAgent } from './registry.js';
 import { createClaudeCodeAgent } from './claude-code.js';
 import { createCodexAgent } from './codex.js';
 import { createOpenCodeAgent } from './opencode.js';
@@ -18,8 +18,13 @@ registerAgent(createOpenCodeAgent());                                 // vercel-
 registerAgent(createGeminiAgent());                                   // gemini
 registerAgent(createCursorAgent());                                   // cursor
 
+// a0-local compatibility aliases.
+registerAgentAlias('anthropic/claude-code', 'vercel-ai-gateway/claude-code');
+registerAgentAlias('openai/codex', 'codex');
+registerAgentAlias('opencode/opencode', 'vercel-ai-gateway/opencode');
+
 // Re-export registry functions
-export { registerAgent, getAgent, listAgents, hasAgent };
+export { registerAgent, registerAgentAlias, getAgent, listAgents, hasAgent };
 
 // Re-export agent types
 export type { Agent, AgentRunOptions, AgentRunResult } from './types.js';

--- a/packages/agent-eval/src/lib/agents/index.ts
+++ b/packages/agent-eval/src/lib/agents/index.ts
@@ -2,7 +2,7 @@
  * Agent registry with built-in agents.
  */
 
-import { registerAgent, registerAgentAlias, getAgent, listAgents, hasAgent } from './registry.js';
+import { registerAgent, getAgent, listAgents, hasAgent } from './registry.js';
 import { createClaudeCodeAgent } from './claude-code.js';
 import { createCodexAgent } from './codex.js';
 import { createOpenCodeAgent } from './opencode.js';
@@ -18,13 +18,8 @@ registerAgent(createOpenCodeAgent());                                 // vercel-
 registerAgent(createGeminiAgent());                                   // gemini
 registerAgent(createCursorAgent());                                   // cursor
 
-// a0-local compatibility aliases.
-registerAgentAlias('anthropic/claude-code', 'vercel-ai-gateway/claude-code');
-registerAgentAlias('openai/codex', 'codex');
-registerAgentAlias('opencode/opencode', 'vercel-ai-gateway/opencode');
-
 // Re-export registry functions
-export { registerAgent, registerAgentAlias, getAgent, listAgents, hasAgent };
+export { registerAgent, getAgent, listAgents, hasAgent };
 
 // Re-export agent types
 export type { Agent, AgentRunOptions, AgentRunResult } from './types.js';

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -265,17 +265,19 @@ export function createOpenCodeAgent(): Agent {
           };
         }
 
-        // Upload test files for validation
-        await sandbox.uploadFiles(testFiles);
+        if (options.validation !== 'none') {
+          // Upload test files for validation
+          await sandbox.uploadFiles(testFiles);
 
-        // Create vitest config for EVAL.ts/tsx
-        await createVitestConfig(sandbox);
+          // Create vitest config for EVAL.ts/tsx
+          await createVitestConfig(sandbox);
 
-        // Inject transcript context so EVAL.ts tests can assert on agent behavior
-        await injectTranscriptContext(sandbox, transcript, 'vercel-ai-gateway/opencode', options.model);
+          // Inject transcript context so EVAL.ts tests can assert on agent behavior
+          await injectTranscriptContext(sandbox, transcript, 'vercel-ai-gateway/opencode', options.model);
+        }
 
         // Run validation scripts
-        const validationResults = await runValidation(sandbox, options.scripts ?? []);
+        const validationResults = await runValidation(sandbox, options.scripts ?? [], options.validation);
 
         // Capture generated files
         const { generatedFiles, deletedFiles } = await captureGeneratedFiles(sandbox);

--- a/packages/agent-eval/src/lib/agents/registry.ts
+++ b/packages/agent-eval/src/lib/agents/registry.ts
@@ -6,6 +6,7 @@ import type { Agent } from './types.js';
 import type { AgentType } from '../types.js';
 
 const agents = new Map<string, Agent>();
+const aliases = new Map<string, string>();
 
 /**
  * Register an agent in the registry.
@@ -14,14 +15,19 @@ export function registerAgent(agent: Agent): void {
   agents.set(agent.name, agent);
 }
 
+export function registerAgentAlias(alias: string, target: string): void {
+  aliases.set(alias, target);
+}
+
 /**
  * Get an agent by name.
  * @throws Error if agent is not found
  */
-export function getAgent(name: AgentType): Agent {
-  const agent = agents.get(name);
+export function getAgent(name: AgentType | string): Agent {
+  const resolvedName = aliases.get(name) ?? name;
+  const agent = agents.get(resolvedName);
   if (!agent) {
-    const available = Array.from(agents.keys()).join(', ');
+    const available = listAgents().join(', ');
     throw new Error(`Unknown agent: ${name}. Available agents: ${available}`);
   }
   return agent;
@@ -31,12 +37,12 @@ export function getAgent(name: AgentType): Agent {
  * List all registered agents.
  */
 export function listAgents(): string[] {
-  return Array.from(agents.keys());
+  return [...Array.from(agents.keys()), ...Array.from(aliases.keys())];
 }
 
 /**
  * Check if an agent is registered.
  */
 export function hasAgent(name: string): boolean {
-  return agents.has(name);
+  return agents.has(name) || aliases.has(name);
 }

--- a/packages/agent-eval/src/lib/agents/registry.ts
+++ b/packages/agent-eval/src/lib/agents/registry.ts
@@ -6,7 +6,6 @@ import type { Agent } from './types.js';
 import type { AgentType } from '../types.js';
 
 const agents = new Map<string, Agent>();
-const aliases = new Map<string, string>();
 
 /**
  * Register an agent in the registry.
@@ -15,17 +14,12 @@ export function registerAgent(agent: Agent): void {
   agents.set(agent.name, agent);
 }
 
-export function registerAgentAlias(alias: string, target: string): void {
-  aliases.set(alias, target);
-}
-
 /**
  * Get an agent by name.
  * @throws Error if agent is not found
  */
-export function getAgent(name: AgentType | string): Agent {
-  const resolvedName = aliases.get(name) ?? name;
-  const agent = agents.get(resolvedName);
+export function getAgent(name: AgentType): Agent {
+  const agent = agents.get(name);
   if (!agent) {
     const available = listAgents().join(', ');
     throw new Error(`Unknown agent: ${name}. Available agents: ${available}`);
@@ -37,12 +31,12 @@ export function getAgent(name: AgentType | string): Agent {
  * List all registered agents.
  */
 export function listAgents(): string[] {
-  return [...Array.from(agents.keys()), ...Array.from(aliases.keys())];
+  return Array.from(agents.keys());
 }
 
 /**
  * Check if an agent is registered.
  */
 export function hasAgent(name: string): boolean {
-  return agents.has(name) || aliases.has(name);
+  return agents.has(name);
 }

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -6,6 +6,7 @@ import type { ScriptResult } from './types.js';
 import type { SandboxManager } from '../sandbox.js';
 import type { DockerSandboxManager } from '../docker-sandbox.js';
 import { parseTranscript } from '../o11y/index.js';
+import type { ValidationMode } from '../types.js';
 
 /** Union type for sandbox implementations */
 type AnySandbox = SandboxManager | DockerSandboxManager;
@@ -64,24 +65,27 @@ async function detectEvalFile(sandbox: AnySandbox): Promise<string> {
  */
 export async function runValidation(
   sandbox: AnySandbox,
-  scripts: string[]
+  scripts: string[],
+  validation: ValidationMode = 'vitest'
 ): Promise<ValidationResults> {
   const results: ValidationResults = {
     allPassed: true,
     scripts: {},
   };
 
-  // Detect which eval file exists (EVAL.ts or EVAL.tsx)
-  const evalFile = await detectEvalFile(sandbox);
+  if (validation === 'vitest') {
+    // Detect which eval file exists (EVAL.ts or EVAL.tsx)
+    const evalFile = await detectEvalFile(sandbox);
 
-  // Always run vitest for the eval file (explicitly specify the file)
-  const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile]);
-  results.test = {
-    success: testResult.exitCode === 0,
-    output: testResult.stdout + testResult.stderr,
-  };
-  if (!results.test.success) {
-    results.allPassed = false;
+    // Always run vitest for the eval file (explicitly specify the file)
+    const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile]);
+    results.test = {
+      success: testResult.exitCode === 0,
+      output: testResult.stdout + testResult.stderr,
+    };
+    if (!results.test.success) {
+      results.allPassed = false;
+    }
   }
 
   // Run configured scripts

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -2,7 +2,7 @@
  * Agent interface and common types for all agents.
  */
 
-import type { ModelTier, SetupFunction, SandboxBackend } from '../types.js';
+import type { ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
 
 /**
  * Common options for all agents.
@@ -20,6 +20,8 @@ export interface AgentRunOptions {
   setup?: SetupFunction;
   /** npm scripts to run after agent completes */
   scripts?: string[];
+  /** Validation mode after agent completes */
+  validation?: ValidationMode;
   /** Abort signal to cancel the run */
   signal?: AbortSignal;
   /** Sandbox backend to use */

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -51,13 +51,8 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
-  it('accepts custom or aliased agents during validation', () => {
-    const config = { agent: 'custom/agent' };
-    expect(() => validateConfig(config)).not.toThrow();
-  });
-
-  it('rejects empty agent', () => {
-    const config = { agent: '' };
+  it('rejects invalid agent', () => {
+    const config = { agent: 'invalid-agent' };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
 
@@ -94,18 +89,6 @@ describe('resolveConfig', () => {
     expect(resolved.earlyExit).toBe(false);
   });
 
-  it('resolves a0-local agent aliases', () => {
-    const config = { agent: 'anthropic/claude-code' };
-    const resolved = resolveConfig(config);
-
-    expect(resolved.agent).toBe('anthropic/claude-code');
-    expect(resolved.model).toBe('opus');
-  });
-
-  it('rejects unregistered custom agents during resolution', () => {
-    const config = { agent: 'custom/agent' };
-    expect(() => resolveConfig(config)).toThrow('Unknown agent');
-  });
 });
 
 describe('resolveEvalNames', () => {

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -20,7 +20,17 @@ describe('validateConfig', () => {
       runs: 5,
       earlyExit: false,
       scripts: ['build', 'lint'],
+      validation: 'none',
       timeout: 600,
+      brands: [
+        {
+          id: 'vercel',
+          name: 'Vercel',
+          domain: 'vercel.com',
+          aliases: ['Vercel Platform'],
+          isYourBrand: true,
+        },
+      ],
     };
     expect(() => validateConfig(config)).not.toThrow();
   });
@@ -41,8 +51,13 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
-  it('rejects invalid agent', () => {
-    const config = { agent: 'invalid-agent' };
+  it('accepts custom or aliased agents during validation', () => {
+    const config = { agent: 'custom/agent' };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+
+  it('rejects empty agent', () => {
+    const config = { agent: '' };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
 
@@ -61,6 +76,7 @@ describe('resolveConfig', () => {
     expect(resolved.model).toBe('opus');
     expect(resolved.runs).toBe(CONFIG_DEFAULTS.runs);
     expect(resolved.earlyExit).toBe(CONFIG_DEFAULTS.earlyExit);
+    expect(resolved.validation).toBe(CONFIG_DEFAULTS.validation);
     expect(resolved.evals).toBe('*');
   });
 
@@ -76,6 +92,19 @@ describe('resolveConfig', () => {
     expect(resolved.model).toBe('haiku');
     expect(resolved.runs).toBe(10);
     expect(resolved.earlyExit).toBe(false);
+  });
+
+  it('resolves a0-local agent aliases', () => {
+    const config = { agent: 'anthropic/claude-code' };
+    const resolved = resolveConfig(config);
+
+    expect(resolved.agent).toBe('anthropic/claude-code');
+    expect(resolved.model).toBe('opus');
+  });
+
+  it('rejects unregistered custom agents during resolution', () => {
+    const config = { agent: 'custom/agent' };
+    expect(() => resolveConfig(config)).toThrow('Unknown agent');
   });
 });
 

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -30,7 +30,15 @@ export const CONFIG_DEFAULTS = {
  * Zod schema for validating experiment configuration.
  */
 const experimentConfigSchema = z.object({
-  agent: z.string().min(1),
+  agent: z.enum([
+    'vercel-ai-gateway/claude-code',
+    'claude-code',
+    'vercel-ai-gateway/codex',
+    'codex',
+    'vercel-ai-gateway/opencode',
+    'gemini',
+    'cursor',
+  ]),
   model: z.union([z.string(), z.array(z.string())]).optional(),
   evals: z
     .union([z.string(), z.array(z.string()), z.function().args(z.string()).returns(z.boolean())])

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -20,6 +20,7 @@ export const CONFIG_DEFAULTS = {
   runs: 1,
   earlyExit: true,
   scripts: [] as string[],
+  validation: 'vitest' as const,
   timeout: 600, // 10 minutes
   sandbox: 'auto' as const,
   copyFiles: 'none' as const,
@@ -29,15 +30,7 @@ export const CONFIG_DEFAULTS = {
  * Zod schema for validating experiment configuration.
  */
 const experimentConfigSchema = z.object({
-  agent: z.enum([
-    'vercel-ai-gateway/claude-code',
-    'claude-code',
-    'vercel-ai-gateway/codex',
-    'codex',
-    'vercel-ai-gateway/opencode',
-    'gemini',
-    'cursor',
-  ]),
+  agent: z.string().min(1),
   model: z.union([z.string(), z.array(z.string())]).optional(),
   evals: z
     .union([z.string(), z.array(z.string()), z.function().args(z.string()).returns(z.boolean())])
@@ -45,12 +38,22 @@ const experimentConfigSchema = z.object({
   runs: z.number().int().positive().optional(),
   earlyExit: z.boolean().optional(),
   scripts: z.array(z.string()).optional(),
+  validation: z.enum(['vitest', 'none']).optional(),
   timeout: z.number().positive().optional(),
   setup: z.function().optional(),
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
   copyFiles: z.enum(['none', 'changed', 'all']).optional(),
   agentOptions: z.record(z.unknown()).optional(),
+  brands: z.array(z.object({
+    id: z.string().optional(),
+    name: z.string().min(1),
+    displayName: z.string().optional(),
+    domain: z.string().optional(),
+    aliases: z.array(z.string()).optional(),
+    isYourBrand: z.boolean().optional(),
+  })).optional(),
+  onRunComplete: z.function().optional(),
 });
 
 /**
@@ -87,12 +90,15 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     runs: config.runs ?? CONFIG_DEFAULTS.runs,
     earlyExit: config.earlyExit ?? CONFIG_DEFAULTS.earlyExit,
     scripts: config.scripts ?? CONFIG_DEFAULTS.scripts,
+    validation: config.validation ?? CONFIG_DEFAULTS.validation,
     timeout: config.timeout ?? CONFIG_DEFAULTS.timeout,
     setup: config.setup,
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
     editPrompt: config.editPrompt,
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
     agentOptions: config.agentOptions,
+    brands: config.brands,
+    onRunComplete: config.onRunComplete,
   };
 }
 

--- a/packages/agent-eval/src/lib/fixture.test.ts
+++ b/packages/agent-eval/src/lib/fixture.test.ts
@@ -75,6 +75,17 @@ describe('fixture discovery and validation', () => {
       expect(missing).not.toContain('PROMPT.md');
     });
 
+    it('does not require EVAL.ts for response-only fixtures', () => {
+      const path = createTestFixture('response-only', {
+        'PROMPT.md': '# Task',
+        'package.json': JSON.stringify({ type: 'module' }),
+      });
+
+      const missing = validateFixtureFiles(path, { validation: 'none' });
+      expect(missing).not.toContain('EVAL.ts or EVAL.tsx');
+      expect(missing).toEqual([]);
+    });
+
     it('enforces case-sensitive filenames', () => {
       const path = createTestFixture('wrong-case', {
         'prompt.md': '# Task', // Wrong case
@@ -125,6 +136,19 @@ describe('fixture discovery and validation', () => {
       expect(fixture.isModule).toBe(true);
     });
 
+    it('loads response-only fixture without eval file', () => {
+      createTestFixture('response-only', {
+        'PROMPT.md': 'Recommend a deployment platform',
+        'package.json': JSON.stringify({ name: 'response-only', type: 'module' }),
+      });
+
+      const fixture = loadFixture(TEST_DIR, 'response-only', { validation: 'none' });
+
+      expect(fixture.name).toBe('response-only');
+      expect(fixture.prompt).toBe('Recommend a deployment platform');
+      expect(fixture.isModule).toBe(true);
+    });
+
     it('throws for missing required files', () => {
       createTestFixture('incomplete', {
         'PROMPT.md': 'Task',
@@ -147,6 +171,23 @@ describe('fixture discovery and validation', () => {
       });
 
       const { fixtures, errors } = loadAllFixtures(TEST_DIR);
+
+      expect(fixtures).toHaveLength(1);
+      expect(fixtures[0].name).toBe('valid');
+      expect(errors).toHaveLength(1);
+      expect(errors[0].fixtureName).toBe('invalid');
+    });
+
+    it('loads response-only fixtures and collects errors using validation none', () => {
+      createTestFixture('valid', {
+        'PROMPT.md': 'Task',
+        'package.json': JSON.stringify({ type: 'module' }),
+      });
+      createTestFixture('invalid', {
+        'PROMPT.md': 'Task',
+      });
+
+      const { fixtures, errors } = loadAllFixtures(TEST_DIR, { validation: 'none' });
 
       expect(fixtures).toHaveLength(1);
       expect(fixtures[0].name).toBe('valid');

--- a/packages/agent-eval/src/lib/fixture.ts
+++ b/packages/agent-eval/src/lib/fixture.ts
@@ -4,8 +4,12 @@
 
 import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
-import type { EvalFixture } from './types.js';
+import type { EvalFixture, ValidationMode } from './types.js';
 import { REQUIRED_EVAL_FILES, EXCLUDED_FILES } from './types.js';
+
+export interface FixtureLoadOptions {
+  validation?: ValidationMode;
+}
 
 /**
  * Error thrown when an eval fixture is invalid.
@@ -85,12 +89,19 @@ export function discoverFixtures(evalsDir: string): string[] {
  * Note: Accepts either EVAL.ts or EVAL.tsx for the eval file.
  * Case-sensitive: 'prompt.md' will fail even on Mac/Windows.
  */
-export function validateFixtureFiles(fixturePath: string): string[] {
+export function validateFixtureFiles(
+  fixturePath: string,
+  options: FixtureLoadOptions = {}
+): string[] {
   const missing: string[] = [];
+  const validation = options.validation ?? 'vitest';
 
   for (const file of REQUIRED_EVAL_FILES) {
     // Special case: Accept either EVAL.ts or EVAL.tsx (both case-sensitive)
     if (file === 'EVAL.ts') {
+      if (validation === 'none') {
+        continue;
+      }
       const hasEvalTs = existsWithExactCase(fixturePath, 'EVAL.ts');
       const hasEvalTsx = existsWithExactCase(fixturePath, 'EVAL.tsx');
       if (!hasEvalTs && !hasEvalTsx) {
@@ -139,7 +150,11 @@ export function validatePackageJson(fixturePath: string): { isModule: boolean; e
 /**
  * Loads a single eval fixture with full validation.
  */
-export function loadFixture(evalsDir: string, name: string): EvalFixture {
+export function loadFixture(
+  evalsDir: string,
+  name: string,
+  options: FixtureLoadOptions = {}
+): EvalFixture {
   const fixturePath = resolve(evalsDir, name);
 
   if (!existsSync(fixturePath)) {
@@ -147,7 +162,7 @@ export function loadFixture(evalsDir: string, name: string): EvalFixture {
   }
 
   // Validate required files
-  const missingFiles = validateFixtureFiles(fixturePath);
+  const missingFiles = validateFixtureFiles(fixturePath, options);
   if (missingFiles.length > 0) {
     throw new FixtureValidationError(
       name,
@@ -180,7 +195,10 @@ export function loadFixture(evalsDir: string, name: string): EvalFixture {
  * Discovers and loads all valid eval fixtures from a directory.
  * Returns both valid fixtures and any validation errors encountered.
  */
-export function loadAllFixtures(evalsDir: string): {
+export function loadAllFixtures(
+  evalsDir: string,
+  options: FixtureLoadOptions = {}
+): {
   fixtures: EvalFixture[];
   errors: FixtureValidationError[];
 } {
@@ -190,7 +208,7 @@ export function loadAllFixtures(evalsDir: string): {
 
   for (const name of fixtureNames) {
     try {
-      const fixture = loadFixture(evalsDir, name);
+      const fixture = loadFixture(evalsDir, name, options);
       fixtures.push(fixture);
     } catch (error) {
       if (error instanceof FixtureValidationError) {

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -550,8 +550,116 @@ describe('runExperiment', () => {
         apiKey: 'my-api-key',
         setup: mockSetup,
         scripts: ['build', 'lint'],
+        validation: undefined,
         signal: expect.any(AbortSignal), // Signal always passed for timeout cleanup
         sandbox: undefined,
+        agentOptions: undefined,
+      });
+    });
+
+    it('passes response-only validation mode to the agent', async () => {
+      const mockAgent: Agent = {
+        name: 'mock-agent',
+        displayName: 'Mock Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn().mockResolvedValue({
+          success: true,
+          output: 'Agent output',
+          duration: 1000,
+          scriptsResults: {},
+        }),
+      };
+
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+
+      const config: ResolvedExperimentConfig = {
+        agent: 'claude-code',
+        model: 'opus',
+        evals: ['response-only'],
+        runs: 1,
+        earlyExit: false,
+        scripts: [],
+        validation: 'none',
+        timeout: 600,
+      };
+
+      const fixtures: EvalFixture[] = [
+        {
+          name: 'response-only',
+          path: '/fake/path',
+          prompt: 'Recommend a hosting provider',
+          isModule: true,
+        },
+      ];
+
+      await runExperiment({
+        config,
+        fixtures,
+        apiKey: 'my-api-key',
+        resultsDir: TEST_DIR,
+        experimentName: 'test-experiment',
+      });
+
+      expect(mockAgent.run).toHaveBeenCalledWith('/fake/path', expect.objectContaining({
+        validation: 'none',
+      }));
+    });
+
+    it('runs onRunComplete hook before saving results', async () => {
+      const mockAgent: Agent = {
+        name: 'mock-agent',
+        displayName: 'Mock Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn().mockResolvedValue({
+          success: true,
+          output: 'Agent output mentioning Vercel',
+          duration: 1000,
+          scriptsResults: {},
+        }),
+      };
+
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+
+      const config: ResolvedExperimentConfig = {
+        agent: 'claude-code',
+        model: 'opus',
+        evals: ['brand-eval'],
+        runs: 1,
+        earlyExit: false,
+        scripts: [],
+        timeout: 600,
+        onRunComplete: ({ runData }) => ({
+          ...runData,
+          result: {
+            ...runData.result,
+            analysis: {
+              mentionedBrands: ['Vercel'],
+            },
+          },
+        }),
+      };
+
+      const fixtures: EvalFixture[] = [
+        {
+          name: 'brand-eval',
+          path: '/fake/path',
+          prompt: 'Where should I deploy this?',
+          isModule: true,
+        },
+      ];
+
+      const results = await runExperiment({
+        config,
+        fixtures,
+        apiKey: 'my-api-key',
+        resultsDir: TEST_DIR,
+        experimentName: 'test-experiment',
+      });
+
+      expect(results.evals[0].runs[0].result.analysis).toEqual({
+        mentionedBrands: ['Vercel'],
       });
     });
   });

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -187,6 +187,7 @@ export async function runExperiment(
         apiKey,
         setup: config.setup,
         scripts: config.scripts,
+        validation: config.validation,
         signal: attemptController.signal,
         sandbox: config.sandbox,
         agentOptions: config.agentOptions,
@@ -225,7 +226,30 @@ export async function runExperiment(
       };
     }
 
-    const runData = agentResultToEvalRunData(agentResult);
+    let runData = agentResultToEvalRunData(agentResult);
+
+    if (config.onRunComplete) {
+      try {
+        const updatedRunData = await config.onRunComplete({
+          fixture,
+          runIndex,
+          config,
+          runData,
+        });
+        if (updatedRunData) {
+          runData = updatedRunData;
+        }
+      } catch (error) {
+        runData = {
+          ...runData,
+          result: {
+            ...runData.result,
+            status: 'failed',
+            error: `onRunComplete failed: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        };
+      }
+    }
 
     return {
       fixtureName: fixture.name,
@@ -354,6 +378,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     apiKey: string;
     setup?: ResolvedExperimentConfig['setup'];
     scripts?: string[];
+    validation?: ResolvedExperimentConfig['validation'];
     sandbox?: ResolvedExperimentConfig['sandbox'];
     editPrompt?: (prompt: string) => string;
     verbose?: boolean;
@@ -376,6 +401,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		apiKey: options.apiKey,
 		setup: options.setup,
 		scripts: options.scripts,
+		validation: options.validation,
 		sandbox: options.sandbox,
 		agentOptions: options.agentOptions,
 	});

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -5,7 +5,7 @@
 /**
  * Supported AI agent types.
  */
-export type AgentType =
+export type BuiltInAgentType =
   | 'vercel-ai-gateway/claude-code'
   | 'claude-code'
   | 'vercel-ai-gateway/codex'
@@ -13,6 +13,8 @@ export type AgentType =
   | 'vercel-ai-gateway/opencode'
   | 'gemini'
   | 'cursor';
+
+export type AgentType = BuiltInAgentType | (string & {});
 
 /**
  * Model identifier - any string accepted.
@@ -24,6 +26,17 @@ export type ModelTier = string;
  * Function type for filtering evals.
  */
 export type EvalFilter = (name: string) => boolean;
+
+export type ValidationMode = 'vitest' | 'none';
+
+export interface BrandConfig {
+  id?: string;
+  name: string;
+  displayName?: string;
+  domain?: string;
+  aliases?: string[];
+  isYourBrand?: boolean;
+}
 
 /**
  * Sandbox interface for setup functions.
@@ -49,6 +62,17 @@ export interface Sandbox {
  * Receives a sandbox instance for pre-configuration.
  */
 export type SetupFunction = (sandbox: Sandbox) => Promise<void>;
+
+export interface RunCompleteContext {
+  fixture: EvalFixture;
+  runIndex: number;
+  config: RunnableExperimentConfig;
+  runData: EvalRunData;
+}
+
+export type RunCompleteHook = (
+  context: RunCompleteContext
+) => Promise<EvalRunData | void> | EvalRunData | void;
 
 /**
  * Sandbox backend type.
@@ -80,6 +104,9 @@ export interface ExperimentConfig {
   /** npm scripts that must pass after agent finishes. @default [] */
   scripts?: string[];
 
+  /** Validation mode after the agent finishes. @default 'vitest' */
+  validation?: ValidationMode;
+
   /** Maximum time in seconds for agent to complete. @default 300 (5 minutes) */
   timeout?: number;
 
@@ -102,6 +129,12 @@ export interface ExperimentConfig {
   /** Agent-specific options passed at runtime (e.g., binaryUrl, extraProviders for opencode).
    * These are forwarded to the agent's run() method. @default undefined */
   agentOptions?: Record<string, unknown>;
+
+  /** Brands to track or compare in downstream analysis. @default undefined */
+  brands?: BrandConfig[];
+
+  /** Optional hook for custom post-run analysis before results are saved. */
+  onRunComplete?: RunCompleteHook;
 }
 
 /**
@@ -114,12 +147,15 @@ export interface ResolvedExperimentConfig {
   runs: number;
   earlyExit: boolean;
   scripts: string[];
+  validation: ValidationMode;
   timeout: number;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
+  brands?: BrandConfig[];
+  onRunComplete?: RunCompleteHook;
 }
 
 /**
@@ -132,12 +168,15 @@ export interface RunnableExperimentConfig {
   runs: number;
   earlyExit: boolean;
   scripts: string[];
+  validation: ValidationMode;
   timeout: number;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
+  brands?: BrandConfig[];
+  onRunComplete?: RunCompleteHook;
 }
 
 /**
@@ -190,6 +229,10 @@ export interface EvalRunResult {
     /** Paths to npm script outputs (nested to avoid collision) */
     scripts?: Record<string, string>;
   };
+  /** Optional user-defined analysis data attached by post-run hooks */
+  analysis?: Record<string, unknown>;
+  /** Optional user-defined metadata attached by post-run hooks */
+  metadata?: Record<string, unknown>;
 }
 
 /**

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -5,7 +5,7 @@
 /**
  * Supported AI agent types.
  */
-export type BuiltInAgentType =
+export type AgentType =
   | 'vercel-ai-gateway/claude-code'
   | 'claude-code'
   | 'vercel-ai-gateway/codex'
@@ -13,8 +13,6 @@ export type BuiltInAgentType =
   | 'vercel-ai-gateway/opencode'
   | 'gemini'
   | 'cursor';
-
-export type AgentType = BuiltInAgentType | (string & {});
 
 /**
  * Model identifier - any string accepted.


### PR DESCRIPTION
## Summary
- Add response-only validation mode for evals that do not need `EVAL.ts`/`EVAL.tsx`.
- Add post-run `onRunComplete` hooks and `brands` config so downstream tools can attach brand/recommendation analysis.
- Keep agent config validation strict while documenting response-only harness extension points.

## Test plan
- `npm run test -w packages/agent-eval -- --run src/lib/config.test.ts src/lib/fixture.test.ts src/lib/runner.test.ts`
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`