### PR TITLE
Skip npm install when package.json is absent

### DIFF
--- a/.changeset/skip-install-without-package.md
+++ b/.changeset/skip-install-without-package.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Skip fixture dependency installation when `package.json` is absent.

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -21,6 +21,7 @@ import {
   ANTHROPIC_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  installDependenciesIfPackageJsonExists,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -155,15 +156,7 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         await options.setup(sandbox);
       }
 
-      // Install dependencies
-      let installResult = await sandbox.runCommand('npm', ['install']);
-      if (installResult.exitCode !== 0) {
-        installResult = await sandbox.runCommand('npm', ['install']);
-      }
-      if (installResult.exitCode !== 0) {
-        const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
-        throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
-      }
+      await installDependenciesIfPackageJsonExists(sandbox);
 
       // Install Claude Code CLI globally
       const cliPackage = (options.agentOptions?.cliPackage as string) || '@anthropic-ai/claude-code';

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -21,6 +21,7 @@ import {
   OPENAI_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  installDependenciesIfPackageJsonExists,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -195,15 +196,7 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
         await options.setup(sandbox);
       }
 
-      // Install dependencies
-      let installResult = await sandbox.runCommand('npm', ['install']);
-      if (installResult.exitCode !== 0) {
-        installResult = await sandbox.runCommand('npm', ['install']);
-      }
-      if (installResult.exitCode !== 0) {
-        const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
-        throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
-      }
+      await installDependenciesIfPackageJsonExists(sandbox);
 
       // Install Codex CLI globally
       const cliInstall = await sandbox.runCommand('npm', [

--- a/packages/agent-eval/src/lib/agents/cursor.ts
+++ b/packages/agent-eval/src/lib/agents/cursor.ts
@@ -20,6 +20,7 @@ import {
   CURSOR_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  installDependenciesIfPackageJsonExists,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -136,15 +137,7 @@ export function createCursorAgent(): Agent {
           await options.setup(sandbox);
         }
 
-        // Install dependencies
-        let installResult = await sandbox.runCommand('npm', ['install']);
-        if (installResult.exitCode !== 0) {
-          installResult = await sandbox.runCommand('npm', ['install']);
-        }
-        if (installResult.exitCode !== 0) {
-          const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
-          throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
-        }
+        await installDependenciesIfPackageJsonExists(sandbox);
 
         // Install Cursor CLI globally using official installation script
         const cliInstall = await sandbox.runShell(

--- a/packages/agent-eval/src/lib/agents/gemini.ts
+++ b/packages/agent-eval/src/lib/agents/gemini.ts
@@ -20,6 +20,7 @@ import {
   GEMINI_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  installDependenciesIfPackageJsonExists,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -136,15 +137,7 @@ export function createGeminiAgent(): Agent {
           await options.setup(sandbox);
         }
 
-        // Install dependencies
-        let installResult = await sandbox.runCommand('npm', ['install']);
-        if (installResult.exitCode !== 0) {
-          installResult = await sandbox.runCommand('npm', ['install']);
-        }
-        if (installResult.exitCode !== 0) {
-          const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
-          throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
-        }
+        await installDependenciesIfPackageJsonExists(sandbox);
 
         // Install Gemini CLI globally
         const cliInstall = await sandbox.runCommand('npm', [

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -20,6 +20,7 @@ import {
   AI_GATEWAY,
   initGitAndCommit,
   injectTranscriptContext,
+  installDependenciesIfPackageJsonExists,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -187,15 +188,7 @@ export function createOpenCodeAgent(): Agent {
           await options.setup(sandbox);
         }
 
-        // Install dependencies
-        let installResult = await sandbox.runCommand('npm', ['install']);
-        if (installResult.exitCode !== 0) {
-          installResult = await sandbox.runCommand('npm', ['install']);
-        }
-        if (installResult.exitCode !== 0) {
-          const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
-          throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
-        }
+        await installDependenciesIfPackageJsonExists(sandbox);
 
         // Install OpenCode CLI
         const binaryUrl = options.agentOptions?.binaryUrl as string | undefined;

--- a/packages/agent-eval/src/lib/agents/shared.test.ts
+++ b/packages/agent-eval/src/lib/agents/shared.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { installDependenciesIfPackageJsonExists } from './shared.js';
+
+describe('installDependenciesIfPackageJsonExists', () => {
+  it('skips npm install when package.json is missing', async () => {
+    const sandbox = {
+      fileExists: vi.fn(async () => false),
+      runCommand: vi.fn(),
+    };
+
+    await installDependenciesIfPackageJsonExists(sandbox as never);
+
+    expect(sandbox.fileExists).toHaveBeenCalledWith('package.json');
+    expect(sandbox.runCommand).not.toHaveBeenCalled();
+  });
+
+  it('runs npm install when package.json exists', async () => {
+    const sandbox = {
+      fileExists: vi.fn(async () => true),
+      runCommand: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    };
+
+    await installDependenciesIfPackageJsonExists(sandbox as never);
+
+    expect(sandbox.runCommand).toHaveBeenCalledWith('npm', ['install']);
+  });
+
+  it('retries npm install once before failing', async () => {
+    const sandbox = {
+      fileExists: vi.fn(async () => true),
+      runCommand: vi
+        .fn()
+        .mockResolvedValueOnce({ stdout: 'first failure', stderr: '', exitCode: 1 })
+        .mockResolvedValueOnce({ stdout: '', stderr: 'second failure', exitCode: 1 }),
+    };
+
+    await expect(installDependenciesIfPackageJsonExists(sandbox as never)).rejects.toThrow(
+      'npm install failed (exit code 1)'
+    );
+    expect(sandbox.runCommand).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -106,6 +106,21 @@ export async function runValidation(
   return results;
 }
 
+export async function installDependenciesIfPackageJsonExists(sandbox: AnySandbox): Promise<void> {
+  if (!(await sandbox.fileExists('package.json'))) {
+    return;
+  }
+
+  let installResult = await sandbox.runCommand('npm', ['install']);
+  if (installResult.exitCode !== 0) {
+    installResult = await sandbox.runCommand('npm', ['install']);
+  }
+  if (installResult.exitCode !== 0) {
+    const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
+    throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
+  }
+}
+
 export async function initGitAndCommit(sandbox: AnySandbox): Promise<void> {
   await sandbox.writeFiles({
     ".gitignore": "node_modules/\n",


### PR DESCRIPTION
## Summary
- Add a shared dependency install helper that skips `npm install` when fixtures do not include `package.json`.
- Use the helper across Claude Code, Codex, OpenCode, Cursor, and Gemini adapters.
- Add unit coverage for skip/install/retry behavior and a patch changeset.

## Test plan
- `npm run test -w packages/agent-eval -- src/lib/agents/shared.test.ts`
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`