### PR TITLE
Neutralize sandbox workspace path

### DIFF
--- a/.changeset/neutral-sandbox-workspace.md
+++ b/.changeset/neutral-sandbox-workspace.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Run agent tasks from a neutral workspace to avoid sandbox provider path leakage.

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -21,6 +21,7 @@ import {
   ANTHROPIC_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  prepareNeutralWorkspace,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -154,6 +155,7 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
       if (options.setup) {
         await options.setup(sandbox);
       }
+      const neutralWorkspace = await prepareNeutralWorkspace(sandbox);
 
       // Install dependencies
       let installResult = await sandbox.runCommand('npm', ['install']);
@@ -212,7 +214,7 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         'claude',
         cliArgs,
         {
-          env: claudeEnv,
+          env: { ...claudeEnv, ...neutralWorkspace.env },
         }
       );
 

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -21,6 +21,7 @@ import {
   OPENAI_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  prepareNeutralWorkspace,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -194,6 +195,7 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
       if (options.setup) {
         await options.setup(sandbox);
       }
+      const neutralWorkspace = await prepareNeutralWorkspace(sandbox);
 
       // Install dependencies
       let installResult = await sandbox.runCommand('npm', ['install']);
@@ -237,7 +239,7 @@ EOF`);
       // codex login sets up bearer auth for the CLI; the built-in openai provider requires it
       const codexResult = await sandbox.runShell(
         `echo '${options.apiKey}' | codex login --with-api-key && codex exec --model ${cliModel} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag} '${escapedPrompt}'`,
-        { [envVarToSet]: options.apiKey }
+        { [envVarToSet]: options.apiKey, ...neutralWorkspace.env }
       );
 
       agentOutput = codexResult.stdout + codexResult.stderr;

--- a/packages/agent-eval/src/lib/agents/cursor.ts
+++ b/packages/agent-eval/src/lib/agents/cursor.ts
@@ -20,6 +20,7 @@ import {
   CURSOR_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  prepareNeutralWorkspace,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -135,6 +136,7 @@ export function createCursorAgent(): Agent {
         if (options.setup) {
           await options.setup(sandbox);
         }
+        const neutralWorkspace = await prepareNeutralWorkspace(sandbox);
 
         // Install dependencies
         let installResult = await sandbox.runCommand('npm', ['install']);
@@ -175,6 +177,7 @@ export function createCursorAgent(): Agent {
           {
             env: {
               [CURSOR_DIRECT.apiKeyEnvVar]: options.apiKey,
+              ...neutralWorkspace.env,
             },
           }
         );

--- a/packages/agent-eval/src/lib/agents/gemini.ts
+++ b/packages/agent-eval/src/lib/agents/gemini.ts
@@ -20,6 +20,7 @@ import {
   GEMINI_DIRECT,
   initGitAndCommit,
   injectTranscriptContext,
+  prepareNeutralWorkspace,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -135,6 +136,7 @@ export function createGeminiAgent(): Agent {
         if (options.setup) {
           await options.setup(sandbox);
         }
+        const neutralWorkspace = await prepareNeutralWorkspace(sandbox);
 
         // Install dependencies
         let installResult = await sandbox.runCommand('npm', ['install']);
@@ -176,6 +178,7 @@ export function createGeminiAgent(): Agent {
           {
             env: {
               [GEMINI_DIRECT.apiKeyEnvVar]: options.apiKey,
+              ...neutralWorkspace.env,
             },
           }
         );

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -20,6 +20,7 @@ import {
   AI_GATEWAY,
   initGitAndCommit,
   injectTranscriptContext,
+  prepareNeutralWorkspace,
 } from './shared.js';
 
 /** Union type for sandbox implementations */
@@ -186,6 +187,7 @@ export function createOpenCodeAgent(): Agent {
         if (options.setup) {
           await options.setup(sandbox);
         }
+        const neutralWorkspace = await prepareNeutralWorkspace(sandbox);
 
         // Install dependencies
         let installResult = await sandbox.runCommand('npm', ['install']);
@@ -245,6 +247,7 @@ export function createOpenCodeAgent(): Agent {
           {
             env: {
               [AI_GATEWAY.apiKeyEnvVar]: options.apiKey,
+              ...neutralWorkspace.env,
             },
           }
         );

--- a/packages/agent-eval/src/lib/agents/shared.test.ts
+++ b/packages/agent-eval/src/lib/agents/shared.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { prepareNeutralWorkspace } from './shared.js';
+
+describe('prepareNeutralWorkspace', () => {
+  it('copies Vercel sandboxes into /workspace and switches the working directory', async () => {
+    const sandbox = {
+      getWorkingDirectory: vi.fn(() => '/vercel/sandbox'),
+      setWorkingDirectory: vi.fn(),
+      runShell: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    };
+
+    const result = await prepareNeutralWorkspace(sandbox as never);
+
+    expect(sandbox.runShell).toHaveBeenCalledWith('git remote remove origin 2>/dev/null || true; rm -rf .git/logs');
+    expect(sandbox.runShell).toHaveBeenCalledWith(expect.stringContaining('sudo cp -a . /workspace/'));
+    expect(sandbox.setWorkingDirectory).toHaveBeenCalledWith('/workspace');
+    expect(result).toEqual({
+      cwd: '/workspace',
+      env: { USER: 'user', LOGNAME: 'user' },
+    });
+  });
+
+  it('keeps non-Vercel sandbox working directories in place', async () => {
+    const sandbox = {
+      getWorkingDirectory: vi.fn(() => '/home/sandbox/workspace'),
+      setWorkingDirectory: vi.fn(),
+      runShell: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    };
+
+    const result = await prepareNeutralWorkspace(sandbox as never);
+
+    expect(sandbox.runShell).toHaveBeenCalledTimes(1);
+    expect(sandbox.setWorkingDirectory).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      cwd: '/home/sandbox/workspace',
+      env: { USER: 'user', LOGNAME: 'user' },
+    });
+  });
+});

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -30,6 +30,11 @@ export interface ValidationResults {
   scripts: Record<string, ScriptResult>;
 }
 
+export interface NeutralWorkspace {
+  cwd: string;
+  env: Record<string, string>;
+}
+
 /**
  * Detect which eval file exists in the sandbox (EVAL.ts or EVAL.tsx).
  * Case-sensitive: Only matches exact uppercase filenames.
@@ -104,6 +109,34 @@ export async function runValidation(
   }
 
   return results;
+}
+
+export async function prepareNeutralWorkspace(sandbox: AnySandbox): Promise<NeutralWorkspace> {
+  const neutralEnv = { USER: 'user', LOGNAME: 'user' };
+  const currentWorkingDirectory = sandbox.getWorkingDirectory();
+
+  await sandbox.runShell('git remote remove origin 2>/dev/null || true; rm -rf .git/logs');
+
+  if (!currentWorkingDirectory.includes('/vercel/')) {
+    return { cwd: currentWorkingDirectory, env: neutralEnv };
+  }
+
+  const neutralWorkspacePath = '/workspace';
+  const copyResult = await sandbox.runShell(
+    [
+      `sudo rm -rf ${neutralWorkspacePath}`,
+      `sudo mkdir -p ${neutralWorkspacePath}`,
+      `sudo cp -a . ${neutralWorkspacePath}/`,
+      `sudo chown -R "$(id -u):$(id -g)" ${neutralWorkspacePath}`,
+    ].join(' && ')
+  );
+  if (copyResult.exitCode !== 0) {
+    const output = (copyResult.stdout + copyResult.stderr).trim().split('\n').slice(-10).join('\n');
+    throw new Error(`Failed to prepare neutral workspace:\n${output}`);
+  }
+
+  sandbox.setWorkingDirectory(neutralWorkspacePath);
+  return { cwd: neutralWorkspacePath, env: neutralEnv };
 }
 
 export async function initGitAndCommit(sandbox: AnySandbox): Promise<void> {

--- a/packages/agent-eval/src/lib/docker-sandbox.ts
+++ b/packages/agent-eval/src/lib/docker-sandbox.ts
@@ -61,6 +61,7 @@ export class DockerSandboxManager implements Sandbox {
   private _containerId: string = '';
   private timeout: number;
   private runtime: string;
+  private _workingDirectory: string = CONTAINER_WORKDIR;
 
   constructor(options: DockerSandboxOptions = {}) {
     this.docker = new Docker();
@@ -179,7 +180,7 @@ export class DockerSandboxManager implements Sandbox {
   async runCommand(
     command: string,
     args: string[] = [],
-    options: { env?: Record<string, string> } = {}
+    options: { env?: Record<string, string>; cwd?: string } = {}
   ): Promise<CommandResult> {
     // Ensure npm global binaries are in PATH
     const env = {
@@ -189,6 +190,7 @@ export class DockerSandboxManager implements Sandbox {
 
     return this.execCommand(command, args, {
       env,
+      cwd: options.cwd,
       user: `${SANDBOX_UID}:${SANDBOX_GID}`,
     });
   }
@@ -200,7 +202,7 @@ export class DockerSandboxManager implements Sandbox {
   private async runCommandAsRoot(
     command: string,
     args: string[] = [],
-    options: { env?: Record<string, string> } = {}
+    options: { env?: Record<string, string>; cwd?: string } = {}
   ): Promise<CommandResult> {
     return this.execCommand(command, args, {
       ...options,
@@ -214,7 +216,7 @@ export class DockerSandboxManager implements Sandbox {
   private async execCommand(
     command: string,
     args: string[] = [],
-    options: { env?: Record<string, string>; user?: string } = {}
+    options: { env?: Record<string, string>; cwd?: string; user?: string } = {}
   ): Promise<CommandResult> {
     if (!this.container) {
       throw new Error('Container not initialized');
@@ -229,7 +231,7 @@ export class DockerSandboxManager implements Sandbox {
       Cmd: cmd,
       AttachStdout: true,
       AttachStderr: true,
-      WorkingDir: CONTAINER_WORKDIR,
+      WorkingDir: options.cwd ?? this._workingDirectory,
       Env: env,
       User: options.user,
     });
@@ -311,8 +313,8 @@ export class DockerSandboxManager implements Sandbox {
   /**
    * Run a shell command (through bash).
    */
-  async runShell(command: string, env?: Record<string, string>): Promise<CommandResult> {
-    return this.runCommand('bash', ['-c', command], { env });
+  async runShell(command: string, env?: Record<string, string>, cwd?: string): Promise<CommandResult> {
+    return this.runCommand('bash', ['-c', command], { env, cwd });
   }
 
   /**
@@ -383,7 +385,14 @@ export class DockerSandboxManager implements Sandbox {
    * Get the working directory.
    */
   getWorkingDirectory(): string {
-    return CONTAINER_WORKDIR;
+    return this._workingDirectory;
+  }
+
+  /**
+   * Set the working directory.
+   */
+  setWorkingDirectory(path: string): void {
+    this._workingDirectory = path;
   }
 
   /**

--- a/packages/agent-eval/src/lib/sandbox.ts
+++ b/packages/agent-eval/src/lib/sandbox.ts
@@ -6,7 +6,7 @@
 import { Sandbox as VercelSandbox, type Command } from '@vercel/sandbox';
 import type { Sandbox } from './types.js';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import { DockerSandboxManager } from './docker-sandbox.js';
 
 /**
@@ -174,13 +174,14 @@ export class SandboxManager implements Sandbox {
   async runCommand(
     command: string,
     args: string[] = [],
-    options: { env?: Record<string, string> } = {}
+    options: { env?: Record<string, string>; cwd?: string } = {}
   ): Promise<CommandResult> {
     return waitForDetachedCommand(
       await this.sandbox.runCommand({
         cmd: command,
         args,
         env: options.env,
+        cwd: options.cwd ?? this._workingDirectory,
         detached: true,
       })
     );
@@ -189,12 +190,13 @@ export class SandboxManager implements Sandbox {
   /**
    * Run a shell command (through bash).
    */
-  async runShell(command: string, env?: Record<string, string>): Promise<CommandResult> {
+  async runShell(command: string, env?: Record<string, string>, cwd?: string): Promise<CommandResult> {
     return waitForDetachedCommand(
       await this.sandbox.runCommand({
         cmd: 'bash',
         args: ['-c', command],
         env,
+        cwd: cwd ?? this._workingDirectory,
         detached: true,
       })
     );
@@ -227,7 +229,7 @@ export class SandboxManager implements Sandbox {
 
     for (const [path, content] of Object.entries(files)) {
       sandboxFiles.push({
-        path,
+        path: this.resolveSandboxPath(path),
         content: Buffer.from(content, 'utf-8'),
       });
     }
@@ -240,7 +242,7 @@ export class SandboxManager implements Sandbox {
    */
   async uploadFiles(files: SandboxFile[]): Promise<void> {
     const sandboxFiles = files.map((f) => ({
-      path: f.path,
+      path: this.resolveSandboxPath(f.path),
       content: typeof f.content === 'string' ? Buffer.from(f.content, 'utf-8') : f.content,
     }));
 
@@ -252,6 +254,17 @@ export class SandboxManager implements Sandbox {
    */
   getWorkingDirectory(): string {
     return this._workingDirectory;
+  }
+
+  /**
+   * Set the working directory.
+   */
+  setWorkingDirectory(path: string): void {
+    this._workingDirectory = path;
+  }
+
+  private resolveSandboxPath(path: string): string {
+    return isAbsolute(path) ? path : join(this._workingDirectory, path);
   }
 
   /**

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -45,7 +45,7 @@ export interface Sandbox {
   runCommand(
     command: string,
     args?: string[],
-    options?: { env?: Record<string, string> }
+    options?: { env?: Record<string, string>; cwd?: string }
   ): Promise<{ stdout: string; stderr: string; exitCode: number }>;
   /** Read a file from the sandbox */
   readFile(path: string): Promise<string>;
@@ -53,6 +53,8 @@ export interface Sandbox {
   writeFiles(files: Record<string, string>): Promise<void>;
   /** Get the sandbox working directory */
   getWorkingDirectory(): string;
+  /** Set the sandbox working directory for subsequent commands */
+  setWorkingDirectory(path: string): void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Run agent tasks from a neutral `/workspace` directory when using Vercel Sandbox so provider path names do not leak into transcripts.
- Remove git remote origin and git logs before task execution, and pass neutral user env vars to agent commands.
- Extend sandbox wrappers with working-directory support and cover neutral workspace preparation with unit tests.

## Test plan
- `npm run test -w packages/agent-eval -- src/lib/agents/shared.test.ts`
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`