### PR TITLE
fix: clean up Docker sandbox containers on exit

### DIFF
--- a/.changeset/fix-docker-cleanup.md
+++ b/.changeset/fix-docker-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Fix Docker sandbox containers leaking when the CLI is interrupted. Active containers are now tracked and stopped on `SIGINT`/`SIGTERM`.

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -22,6 +22,7 @@ import { computeFingerprint } from './lib/fingerprint.js';
 import { scanReusableResults } from './lib/results.js';
 import { isClassifierEnabled, classifyFailure } from './lib/classifier.js';
 import { housekeep } from './lib/housekeeping.js';
+import { cleanupActiveSandboxes } from './lib/docker-sandbox.js';
 import { spawnSync } from 'child_process';
 import { minimatch } from 'minimatch';
 import pLimit from 'p-limit';
@@ -33,6 +34,25 @@ dotenvConfig({ override: true });
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'));
+
+let shuttingDown = false;
+async function shutdownAndExit(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.error(chalk.yellow(`\nReceived ${signal}, cleaning up Docker sandboxes...`));
+  try {
+    const stopped = await cleanupActiveSandboxes();
+    if (stopped > 0) {
+      console.error(chalk.yellow(`Stopped ${stopped} sandbox container(s).`));
+    }
+  } catch {
+    // Best effort
+  }
+  process.exit(130);
+}
+
+process.on('SIGINT', shutdownAndExit);
+process.on('SIGTERM', shutdownAndExit);
 
 const program = new Command();
 program.enablePositionalOptions();

--- a/packages/agent-eval/src/lib/docker-sandbox.ts
+++ b/packages/agent-eval/src/lib/docker-sandbox.ts
@@ -52,6 +52,14 @@ export interface DockerSandboxOptions {
 }
 
 /**
+ * Set of currently active sandbox containers, used so we can stop them all
+ * on a process-level signal (SIGINT/SIGTERM) before exiting. Without this,
+ * a Ctrl-C'd run leaks running containers because the per-agent try/finally
+ * cleanup never executes.
+ */
+const activeContainers = new Set<Docker.Container>();
+
+/**
  * Docker-based sandbox manager.
  * Creates isolated containers for running evals.
  */
@@ -101,6 +109,7 @@ export class DockerSandboxManager implements Sandbox {
     });
 
     this._containerId = this.container.id;
+    activeContainers.add(this.container);
 
     // Start the container
     await this.container.start();
@@ -391,6 +400,7 @@ export class DockerSandboxManager implements Sandbox {
    */
   async stop(): Promise<void> {
     if (this.container) {
+      activeContainers.delete(this.container);
       try {
         await this.container.stop({ t: 0 }); // Immediate stop
       } catch {
@@ -399,4 +409,28 @@ export class DockerSandboxManager implements Sandbox {
       this.container = null;
     }
   }
+}
+
+/**
+ * Stop every sandbox container created by this process that hasn't already
+ * been stopped. Intended for SIGINT/SIGTERM handlers so an interrupted run
+ * doesn't leak running containers.
+ *
+ * Returns the number of containers that were stopped.
+ */
+export async function cleanupActiveSandboxes(): Promise<number> {
+  const containers = Array.from(activeContainers);
+  activeContainers.clear();
+
+  await Promise.all(
+    containers.map(async (container) => {
+      try {
+        await container.stop({ t: 0 });
+      } catch {
+        // Container may already be stopped or removed
+      }
+    })
+  );
+
+  return containers.length;
 }


### PR DESCRIPTION
Hey! Thanks so much for making agent-eval and open sourcing it. I've been using it for some of our own internal evals at Sanity and it's been great so far. Since we use Docker to run our evals, I noticed a few things that could be improved for local DX when running evals through Docker.

This PR makes it so that sandbox containers started via Docker are cleaned up (or at least cleanup is attempted) when the CLI exits. I noticed that after running `ctrl + c` while running evals locally, the sandbox containers were still running in the background. This should fix that, preventing stale Docker containers from piling up.