### PR TITLE
feat: improve names of Docker sandbox containers

### DIFF
--- a/.changeset/docker-labels.md
+++ b/.changeset/docker-labels.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Docker sandbox containers now have  names like `agent-eval_my-experiment_my-eval_run0_a1b2c3` instead of the random Docker-assigned names.

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -131,6 +131,9 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         timeout: options.timeout,
         runtime: 'node24',
         backend: options.sandbox,
+        experimentName: options.experimentName,
+        evalName: options.evalName,
+        runIndex: options.runIndex,
       });
 
       // Check for abort after sandbox creation (abort may have fired during create)

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -172,6 +172,9 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
         timeout: options.timeout,
         runtime: 'node24',
         backend: options.sandbox,
+        experimentName: options.experimentName,
+        evalName: options.evalName,
+        runIndex: options.runIndex,
       });
 
       // Check for abort after sandbox creation (abort may have fired during create)

--- a/packages/agent-eval/src/lib/agents/cursor.ts
+++ b/packages/agent-eval/src/lib/agents/cursor.ts
@@ -113,6 +113,9 @@ export function createCursorAgent(): Agent {
           timeout: options.timeout,
           runtime: 'node24',
           backend: options.sandbox,
+          experimentName: options.experimentName,
+          evalName: options.evalName,
+          runIndex: options.runIndex,
         });
 
         // Check for abort after sandbox creation (abort may have fired during create)

--- a/packages/agent-eval/src/lib/agents/gemini.ts
+++ b/packages/agent-eval/src/lib/agents/gemini.ts
@@ -113,6 +113,9 @@ export function createGeminiAgent(): Agent {
           timeout: options.timeout,
           runtime: 'node24',
           backend: options.sandbox,
+          experimentName: options.experimentName,
+          evalName: options.evalName,
+          runIndex: options.runIndex,
         });
 
         // Check for abort after sandbox creation (abort may have fired during create)

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -164,6 +164,9 @@ export function createOpenCodeAgent(): Agent {
           timeout: options.timeout,
           runtime: 'node24',
           backend: options.sandbox,
+          experimentName: options.experimentName,
+          evalName: options.evalName,
+          runIndex: options.runIndex,
         });
 
         // Check for abort after sandbox creation (abort may have fired during create)

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -28,6 +28,12 @@ export interface AgentRunOptions {
   sandbox?: SandboxBackend | 'auto';
   /** Agent-specific options (e.g., binaryUrl, extraProviders for opencode) */
   agentOptions?: Record<string, unknown>;
+  /** Experiment name (used for sandbox naming) */
+  experimentName?: string;
+  /** Eval/fixture name (used for sandbox naming) */
+  evalName?: string;
+  /** Run index (used for sandbox naming) */
+  runIndex?: number;
 }
 
 /**

--- a/packages/agent-eval/src/lib/docker-sandbox.ts
+++ b/packages/agent-eval/src/lib/docker-sandbox.ts
@@ -49,6 +49,34 @@ export interface DockerSandboxOptions {
   timeout?: number;
   /** Runtime environment */
   runtime?: 'node20' | 'node24';
+  /** Experiment name (used for container naming) */
+  experimentName?: string;
+  /** Eval/fixture name (used for container naming) */
+  evalName?: string;
+  /** Run index (used for container naming) */
+  runIndex?: number;
+}
+
+/**
+ * Sanitize a string for use in a Docker container name.
+ * Docker container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*.
+ */
+function sanitizeForContainerName(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_.-]/g, '-');
+}
+
+/**
+ * Build a human-readable container name from experiment/eval/run info,
+ * so `docker ps` is easy to skim.
+ */
+function buildContainerName(opts: DockerSandboxOptions): string {
+  const parts: string[] = ['agent-eval'];
+  if (opts.experimentName) parts.push(sanitizeForContainerName(opts.experimentName));
+  if (opts.evalName) parts.push(sanitizeForContainerName(opts.evalName));
+  if (opts.runIndex !== undefined) parts.push(`run${opts.runIndex}`);
+  // Random suffix avoids collisions across concurrent runs of the same eval
+  parts.push(Math.random().toString(36).slice(2, 8));
+  return parts.join('_');
 }
 
 /**
@@ -61,11 +89,13 @@ export class DockerSandboxManager implements Sandbox {
   private _containerId: string = '';
   private timeout: number;
   private runtime: string;
+  private options: DockerSandboxOptions;
 
   constructor(options: DockerSandboxOptions = {}) {
     this.docker = new Docker();
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
     this.runtime = options.runtime ?? 'node24';
+    this.options = options;
   }
 
   /**
@@ -92,6 +122,7 @@ export class DockerSandboxManager implements Sandbox {
     // Create the container (starts as root for setup, then switches to non-root user)
     this.container = await this.docker.createContainer({
       Image: imageName,
+      name: buildContainerName(this.options),
       Cmd: ['sleep', 'infinity'], // Keep container running
       WorkingDir: CONTAINER_WORKDIR,
       Tty: true,

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -554,6 +554,9 @@ describe('runExperiment', () => {
         signal: expect.any(AbortSignal), // Signal always passed for timeout cleanup
         sandbox: undefined,
         agentOptions: undefined,
+        experimentName: 'test-experiment',
+        evalName: 'test-eval',
+        runIndex: 0,
       });
     });
 

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -191,6 +191,9 @@ export async function runExperiment(
         signal: attemptController.signal,
         sandbox: config.sandbox,
         agentOptions: config.agentOptions,
+        experimentName,
+        evalName: fixture.name,
+        runIndex,
       }),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
@@ -404,6 +407,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		validation: options.validation,
 		sandbox: options.sandbox,
 		agentOptions: options.agentOptions,
+		evalName: fixture.name,
 	});
 
     results.push(agentResultToEvalRunData(agentResult));

--- a/packages/agent-eval/src/lib/sandbox.ts
+++ b/packages/agent-eval/src/lib/sandbox.ts
@@ -73,6 +73,12 @@ export interface SandboxOptions {
   teamId?: string;
   /** Optional explicit Vercel project ID for sandbox API auth */
   projectId?: string;
+  /** Experiment name (used by Docker backend for container naming) */
+  experimentName?: string;
+  /** Eval/fixture name (used by Docker backend for container naming) */
+  evalName?: string;
+  /** Run index (used by Docker backend for container naming) */
+  runIndex?: number;
 }
 
 /**
@@ -148,6 +154,9 @@ export class SandboxManager implements Sandbox {
   /**
    * Create a new sandbox instance.
    */
+  // TODO: When @vercel/sandbox v2 is GA, pass experimentName/evalName/runIndex
+  // through as the sandbox `name` for parity with the Docker backend.
+  // See https://vercel.com/docs/vercel-sandbox/concepts/tags
   static async create(options: SandboxOptions = {}): Promise<SandboxManager> {
     const timeout = options.timeout ?? DEFAULT_SANDBOX_TIMEOUT;
     const runtime = options.runtime ?? 'node24';
@@ -354,6 +363,9 @@ export async function createSandbox(
     return DockerSandboxManager.create({
       timeout: options.timeout,
       runtime: options.runtime,
+      experimentName: options.experimentName,
+      evalName: options.evalName,
+      runIndex: options.runIndex,
     });
   }
 


### PR DESCRIPTION
Updates the Docker sandbox backend to generate a name based on the experiment name, eval name, and eval index, instead of the randomly generated Docker container names. Makes it easier to skim through `docker ps` to try and see which evals are still running.

`@vercel/sandbox` has support for names and tags but only in beta, I'm happy to add that in if desired, but it'd mean upgrading to v2 of the package.