### PR TITLE
fix: discover nested eval result directories

### DIFF
--- a/.changeset/recursive-eval-results.md
+++ b/.changeset/recursive-eval-results.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Discover nested eval result directories during housekeeping and result reuse.

--- a/packages/agent-eval/src/lib/housekeeping.test.ts
+++ b/packages/agent-eval/src/lib/housekeeping.test.ts
@@ -57,6 +57,18 @@ describe('housekeep', () => {
     expect(existsSync(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', 'eval-1'))).toBe(false);
   });
 
+  it('keeps nested eval results and removes older nested duplicates', () => {
+    const evalName = 'ui-development/design-system/layout-props';
+    createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', evalName), {});
+    createResult(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', evalName), {});
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    expect(stats.removedDuplicates).toBe(1);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', evalName))).toBe(true);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', evalName))).toBe(false);
+  });
+
   it('removes incomplete results (no summary)', () => {
     createResult(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'), {
       summary: false,

--- a/packages/agent-eval/src/lib/housekeeping.ts
+++ b/packages/agent-eval/src/lib/housekeeping.ts
@@ -10,6 +10,7 @@
 import { readdirSync, rmSync, existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { isClassifierEnabled, isNonModelFailure } from './classifier.js';
+import { discoverEvalResultDirs } from './result-directories.js';
 
 interface HousekeepingStats {
   removedDuplicates: number;
@@ -68,7 +69,7 @@ export function housekeep(
 
     let evalDirs: string[];
     try {
-      evalDirs = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
+      evalDirs = discoverEvalResultDirs(tsDir);
     } catch {
       continue;
     }

--- a/packages/agent-eval/src/lib/result-directories.ts
+++ b/packages/agent-eval/src/lib/result-directories.ts
@@ -1,0 +1,53 @@
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+/**
+ * Discover eval result directories under a timestamp directory.
+ *
+ * Eval names may contain slashes, so a timestamp can contain nested result
+ * directories such as ui/design/layout/summary.json. The returned names are
+ * relative to timestampDir and normalized with forward slashes to match eval
+ * ids and fingerprint keys.
+ */
+export function discoverEvalResultDirs(timestampDir: string): string[] {
+  const resultDirs: string[] = [];
+
+  function toEvalName(dir: string): string {
+    return relative(timestampDir, dir).split(sep).join('/');
+  }
+
+  function walk(dir: string): void {
+    if (existsSync(join(dir, 'summary.json'))) {
+      resultDirs.push(toEvalName(dir));
+      return;
+    }
+
+    let childDirs: string[];
+    try {
+      childDirs = readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => !entry.name.startsWith('.') && !entry.name.startsWith('run-'))
+        .filter((entry) => {
+          try {
+            return entry.isDirectory() && statSync(join(dir, entry.name)).isDirectory();
+          } catch {
+            return false;
+          }
+        })
+        .map((entry) => entry.name);
+    } catch {
+      return;
+    }
+
+    if (childDirs.length === 0 && dir !== timestampDir) {
+      resultDirs.push(toEvalName(dir));
+      return;
+    }
+
+    for (const child of childDirs) {
+      walk(join(dir, child));
+    }
+  }
+
+  walk(timestampDir);
+  return resultDirs.sort();
+}

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -355,6 +355,20 @@ describe('results utilities', () => {
       expect(result.get('eval-1')?.fingerprint).toBe('abc123');
     });
 
+    it('finds reusable results for nested eval names', () => {
+      const evalName = 'ui-development/design-system/layout-props';
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', evalName);
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 2, passedRuns: 1, passRate: '50%', meanDuration: 10, fingerprint: 'abc123' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { [evalName]: 'abc123' });
+      expect(result.size).toBe(1);
+      expect(result.get(evalName)?.fingerprint).toBe('abc123');
+    });
+
     it('skips results with mismatched fingerprint', () => {
       const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
       mkdirSync(expDir, { recursive: true });

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -24,6 +24,7 @@ import type { AgentRunResult } from './agents/types.js';
 import { parseTranscript, type Transcript } from './o11y/index.js';
 import { isNonModelFailure } from './classifier.js';
 import { readFixtureFiles } from './fixture.js';
+import { discoverEvalResultDirs } from './result-directories.js';
 
 /**
  * Convert AgentRunResult to EvalRunData (result + transcript).
@@ -496,7 +497,7 @@ export function scanReusableResults(
 
 		let evalDirs: string[];
 		try {
-			evalDirs = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
+			evalDirs = discoverEvalResultDirs(tsDir);
 		} catch {
 			continue;
 		}


### PR DESCRIPTION
## Summary

Fixes result discovery for nested eval ids such as `ui-development/design-system/layout-props`.

`saveResults` already writes nested eval result directories correctly, but housekeeping and reusable-result scanning only looked at immediate children of a timestamp directory. That caused nested results to be treated as incomplete or missed for reuse because `summary.json` lives deeper in the tree.

## Changes

- Add a shared recursive `discoverEvalResultDirs` helper.
- Use it in `housekeep` so nested eval result directories are deduped/kept by their full relative eval id.
- Use it in `scanReusableResults` so nested evals can match fingerprint keys and be reused.
- Add regression coverage for nested housekeeping and reusable-result scanning.
- Add a patch changeset.

## Validation

- `npm run test -w packages/agent-eval -- src/lib/housekeeping.test.ts src/lib/results.test.ts`
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`

Closes #129.
