### PR TITLE
feat: add experiment trend analyzer

### DIFF
--- a/.changeset/early-bags-watch.md
+++ b/.changeset/early-bags-watch.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Add experiment trend analysis for pass-rate regressions across saved results.

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -87,7 +87,13 @@ export type { Agent, ScriptResult } from './lib/agents/types.js';
 export { getAgent, listAgents, registerAgent } from './lib/agents/index.js';
 
 // Re-export results utilities
-export type { SaveResultsOptions, ReusableResult } from './lib/results.js';
+export type {
+  SaveResultsOptions,
+  ReusableResult,
+  EvalTrendPoint,
+  EvalTrend,
+  ExperimentTrendReport,
+} from './lib/results.js';
 export {
   agentResultToEvalRunData,
   createEvalSummary,
@@ -97,6 +103,7 @@ export {
   formatRunResult,
   createProgressDisplay,
   scanReusableResults,
+  analyzeExperimentTrend,
 } from './lib/results.js';
 
 // Re-export fingerprinting

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -10,6 +10,7 @@ import {
   formatResultsTable,
   formatRunResult,
   scanReusableResults,
+  analyzeExperimentTrend,
 } from './results.js';
 import type { AgentRunResult } from './agents/types.js';
 import type { EvalRunResult, EvalRunData, ResolvedExperimentConfig } from './types.js';
@@ -454,6 +455,134 @@ describe('results utilities', () => {
       const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' });
       expect(result.size).toBe(1);
       expect(result.get('eval-1')?.timestamp).toBe('2024-01-26T00-00-00.000Z');
+    });
+  });
+
+  describe('analyzeExperimentTrend', () => {
+    function writeTrendSummary(
+      experimentName: string,
+      timestamp: string,
+      evalName: string,
+      summary: Record<string, unknown>
+    ) {
+      const expDir = join(TEST_DIR, experimentName, timestamp, evalName);
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(join(expDir, 'summary.json'), JSON.stringify(summary));
+    }
+
+    it('reports degrading, improving, and stable eval trends', () => {
+      for (const [timestamp, alpha, beta, gamma] of [
+        ['2024-01-24T00-00-00.000Z', '100%', 20, '80%'],
+        ['2024-01-25T00-00-00.000Z', '70%', 50, '81%'],
+        ['2024-01-26T00-00-00.000Z', '40%', 80, '80%'],
+      ] as const) {
+        writeTrendSummary('my-exp', timestamp, 'alpha', {
+          totalRuns: 10,
+          passedRuns: Number.parseInt(alpha, 10) / 10,
+          passRate: alpha,
+        });
+        writeTrendSummary('my-exp', timestamp, 'beta', {
+          totalRuns: 10,
+          passedRuns: beta / 10,
+          passRate: beta,
+        });
+        writeTrendSummary('my-exp', timestamp, 'gamma', {
+          totalRuns: 10,
+          passedRuns: Number.parseInt(gamma, 10) / 10,
+          passRate: gamma,
+        });
+      }
+
+      const report = analyzeExperimentTrend(TEST_DIR, 'my-exp');
+
+      expect(report.experimentName).toBe('my-exp');
+      expect(report.window).toBe(10);
+      expect(report.anyRegression).toBe(true);
+      expect(report.evalTrends.map((trend) => trend.evalName)).toEqual([
+        'alpha',
+        'beta',
+        'gamma',
+      ]);
+      expect(report.evalTrends.find((trend) => trend.evalName === 'alpha')).toMatchObject({
+        direction: 'degrading',
+        firstPassRate: 100,
+        recentPassRate: 40,
+        runCount: 3,
+      });
+      expect(report.evalTrends.find((trend) => trend.evalName === 'beta')).toMatchObject({
+        direction: 'improving',
+        firstPassRate: 20,
+        recentPassRate: 80,
+      });
+      expect(report.evalTrends.find((trend) => trend.evalName === 'gamma')).toMatchObject({
+        direction: 'stable',
+        firstPassRate: 80,
+        recentPassRate: 80,
+      });
+    });
+
+    it('uses only the newest timestamps in the requested window', () => {
+      for (const [timestamp, passRate] of [
+        ['2024-01-23T00-00-00.000Z', '0%'],
+        ['2024-01-24T00-00-00.000Z', '100%'],
+        ['2024-01-25T00-00-00.000Z', '75%'],
+        ['2024-01-26T00-00-00.000Z', '50%'],
+      ] as const) {
+        writeTrendSummary('window-exp', timestamp, 'eval-1', {
+          totalRuns: 4,
+          passedRuns: 2,
+          passRate,
+        });
+      }
+
+      const report = analyzeExperimentTrend(TEST_DIR, 'window-exp', 2);
+      const trend = report.evalTrends[0];
+
+      expect(trend.points.map((point) => point.timestamp)).toEqual([
+        '2024-01-25T00-00-00.000Z',
+        '2024-01-26T00-00-00.000Z',
+      ]);
+      expect(trend.firstPassRate).toBe(75);
+      expect(trend.recentPassRate).toBe(50);
+      expect(trend.direction).toBe('degrading');
+    });
+
+    it('skips missing and malformed summaries', () => {
+      writeTrendSummary('mixed-exp', '2024-01-24T00-00-00.000Z', 'eval-1', {
+        totalRuns: 2,
+        passedRuns: 1,
+        passRate: '50%',
+      });
+      writeTrendSummary('mixed-exp', '2024-01-25T00-00-00.000Z', 'eval-1', {
+        totalRuns: 2,
+        passedRuns: 2,
+        passRate: 'not-a-number',
+      });
+      writeTrendSummary('mixed-exp', '2024-01-26T00-00-00.000Z', 'eval-1', {
+        totalRuns: 2,
+        passedRuns: 2,
+        passRate: '100%',
+      });
+
+      const report = analyzeExperimentTrend(TEST_DIR, 'mixed-exp');
+
+      expect(report.evalTrends).toHaveLength(1);
+      expect(report.evalTrends[0].points.map((point) => point.passRate)).toEqual([
+        50,
+        100,
+      ]);
+      expect(report.evalTrends[0].direction).toBe('improving');
+    });
+
+    it('returns an empty report for a missing experiment', () => {
+      const report = analyzeExperimentTrend(TEST_DIR, 'no-such-exp');
+
+      expect(report).toEqual({
+        experimentName: 'no-such-exp',
+        window: 10,
+        evalTrends: [],
+        anyRegression: false,
+      });
     });
   });
 });

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -449,6 +449,203 @@ export function createProgressDisplay(
 	);
 }
 
+export interface EvalTrendPoint {
+	timestamp: string;
+	passRate: number;
+	passedRuns: number;
+	totalRuns: number;
+}
+
+export interface EvalTrend {
+	evalName: string;
+	runCount: number;
+	firstPassRate: number;
+	recentPassRate: number;
+	slope: number;
+	direction: 'improving' | 'degrading' | 'stable';
+	points: EvalTrendPoint[];
+}
+
+export interface ExperimentTrendReport {
+	experimentName: string;
+	window: number;
+	evalTrends: EvalTrend[];
+	anyRegression: boolean;
+}
+
+interface SummarySnapshot {
+	passRate: number;
+	passedRuns: number;
+	totalRuns: number;
+}
+
+const TREND_STABLE_THRESHOLD = 0.5;
+
+function parsePassRate(passRate: unknown): number | undefined {
+	if (typeof passRate === 'number' && Number.isFinite(passRate)) {
+		return passRate;
+	}
+
+	if (typeof passRate !== 'string') {
+		return undefined;
+	}
+
+	const trimmed = passRate.trim();
+	const numeric = trimmed.endsWith('%') ? trimmed.slice(0, -1) : trimmed;
+	const parsed = Number.parseFloat(numeric);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseSummarySnapshot(summary: unknown): SummarySnapshot | undefined {
+	if (!summary || typeof summary !== 'object') {
+		return undefined;
+	}
+
+	const record = summary as Record<string, unknown>;
+	const passRate = parsePassRate(record.passRate);
+	const passedRuns = record.passedRuns;
+	const totalRuns = record.totalRuns;
+
+	if (
+		passRate === undefined ||
+		typeof passedRuns !== 'number' ||
+		typeof totalRuns !== 'number' ||
+		!Number.isFinite(passedRuns) ||
+		!Number.isFinite(totalRuns)
+	) {
+		return undefined;
+	}
+
+	return {
+		passRate,
+		passedRuns,
+		totalRuns,
+	};
+}
+
+function linearRegressionSlope(points: EvalTrendPoint[]): number {
+	const count = points.length;
+	const meanX = (count - 1) / 2;
+	const meanY =
+		points.reduce((sum, point) => sum + point.passRate, 0) / count;
+
+	let numerator = 0;
+	let denominator = 0;
+	for (let i = 0; i < count; i++) {
+		const xDelta = i - meanX;
+		numerator += xDelta * (points[i].passRate - meanY);
+		denominator += xDelta * xDelta;
+	}
+
+	return denominator === 0 ? 0 : numerator / denominator;
+}
+
+function trendDirection(slope: number): EvalTrend['direction'] {
+	if (slope > TREND_STABLE_THRESHOLD) return 'improving';
+	if (slope < -TREND_STABLE_THRESHOLD) return 'degrading';
+	return 'stable';
+}
+
+/**
+ * Analyze pass-rate trends for evals in an experiment.
+ *
+ * Reads results/<experiment>/<timestamp>/<eval>/summary.json chronologically,
+ * uses the newest `window` timestamps, and returns per-eval linear pass-rate
+ * trends. Invalid or incomplete summaries are skipped.
+ */
+export function analyzeExperimentTrend(
+	resultsDir: string,
+	experimentName: string,
+	window = 10,
+): ExperimentTrendReport {
+	const experimentDir = join(resultsDir, experimentName);
+	const report: ExperimentTrendReport = {
+		experimentName,
+		window,
+		evalTrends: [],
+		anyRegression: false,
+	};
+
+	if (!existsSync(experimentDir) || window <= 0) {
+		return report;
+	}
+
+	let timestamps: string[];
+	try {
+		timestamps = readdirSync(experimentDir)
+			.filter((timestamp) => {
+				if (timestamp.startsWith('.')) return false;
+				return statSync(join(experimentDir, timestamp)).isDirectory();
+			})
+			.sort()
+			.slice(-window);
+	} catch {
+		return report;
+	}
+
+	const evalPoints = new Map<string, EvalTrendPoint[]>();
+
+	for (const timestamp of timestamps) {
+		const timestampDir = join(experimentDir, timestamp);
+		let evalDirs: string[];
+		try {
+			evalDirs = readdirSync(timestampDir).filter((evalName) => {
+				if (evalName.startsWith('.')) return false;
+				return statSync(join(timestampDir, evalName)).isDirectory();
+			});
+		} catch {
+			continue;
+		}
+
+		for (const evalName of evalDirs) {
+			try {
+				const summary = parseSummarySnapshot(
+					JSON.parse(
+						readFileSync(
+							join(timestampDir, evalName, 'summary.json'),
+							'utf-8',
+						),
+					),
+				);
+				if (!summary) continue;
+
+				const points = evalPoints.get(evalName) ?? [];
+				points.push({
+					timestamp,
+					passRate: summary.passRate,
+					passedRuns: summary.passedRuns,
+					totalRuns: summary.totalRuns,
+				});
+				evalPoints.set(evalName, points);
+			} catch {
+				// Skip missing or malformed summaries.
+			}
+		}
+	}
+
+	for (const [evalName, points] of evalPoints) {
+		if (points.length < 2) continue;
+
+		const slope = linearRegressionSlope(points);
+		const direction = trendDirection(slope);
+		report.evalTrends.push({
+			evalName,
+			runCount: points.length,
+			firstPassRate: points[0].passRate,
+			recentPassRate: points[points.length - 1].passRate,
+			slope,
+			direction,
+			points,
+		});
+		if (direction === 'degrading') {
+			report.anyRegression = true;
+		}
+	}
+
+	report.evalTrends.sort((a, b) => a.evalName.localeCompare(b.evalName));
+	return report;
+}
+
 /**
  * A reusable result found by the scanner.
  */


### PR DESCRIPTION
## Summary
- add `analyzeExperimentTrend` for pass-rate trend analysis across saved experiment results
- parse both numeric pass rates and existing `"50%"` summary values
- expose trend result types from the package entrypoint

Closes #102.

## Verification
- `npm ci`
- `npm run test -w packages/agent-eval -- src/lib/results.test.ts`
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`
- `git diff --check`

Note: `npm ci` reports existing dependency audit findings, but installation completed and the focused checks passed.