### PR TITLE
fix(results): discover nested eval result dirs

### DIFF
--- a/packages/agent-eval/src/lib/housekeeping.test.ts
+++ b/packages/agent-eval/src/lib/housekeeping.test.ts
@@ -154,6 +154,33 @@ describe('housekeep', () => {
     expect(existsSync(join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1'))).toBe(true);
   });
 
+  it('keeps nested eval results with summary files', () => {
+    const evalName = 'ui-development/design-system/layout-props';
+    const evalDir = join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', evalName);
+    createResult(evalDir, {});
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    expect(stats.removedIncomplete).toBe(0);
+    expect(existsSync(evalDir)).toBe(true);
+    expect(existsSync(join(evalDir, 'summary.json'))).toBe(true);
+  });
+
+  it('removes older duplicate nested eval results', () => {
+    const evalName = 'ui-development/design-system/layout-props';
+    const newer = join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', evalName);
+    const older = join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z', evalName);
+    createResult(newer, {});
+    createResult(older, {});
+
+    const stats = housekeep(TEST_DIR, 'exp');
+
+    expect(stats.removedDuplicates).toBe(1);
+    expect(existsSync(newer)).toBe(true);
+    expect(existsSync(older)).toBe(false);
+    expect(existsSync(join(TEST_DIR, 'exp', '2024-01-25T12-00-00.000Z'))).toBe(false);
+  });
+
   it('keeps non-model failures when classifier is disabled', () => {
     const evalDir = join(TEST_DIR, 'exp', '2024-01-26T12-00-00.000Z', 'eval-1');
     createResult(evalDir, { passedRuns: 0 });

--- a/packages/agent-eval/src/lib/housekeeping.ts
+++ b/packages/agent-eval/src/lib/housekeeping.ts
@@ -18,6 +18,70 @@ interface HousekeepingStats {
   removedEmptyDirs: number;
 }
 
+function discoverEvalResultDirs(rootDir: string, relativeDir = ''): string[] {
+  const currentDir = relativeDir ? join(rootDir, relativeDir) : rootDir;
+  if (existsSync(join(currentDir, 'summary.json'))) {
+    return relativeDir ? [relativeDir] : [];
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(currentDir).filter((entry) => !entry.startsWith('.'));
+  } catch {
+    return [];
+  }
+
+  if (relativeDir && entries.some((entry) => entry.startsWith('run-'))) {
+    return [relativeDir];
+  }
+
+  const resultDirs: string[] = [];
+  for (const entry of entries) {
+    const entryRelativeDir = relativeDir ? join(relativeDir, entry) : entry;
+    const entryPath = join(rootDir, entryRelativeDir);
+    try {
+      if (statSync(entryPath).isDirectory()) {
+        resultDirs.push(...discoverEvalResultDirs(rootDir, entryRelativeDir));
+      }
+    } catch {
+      // Skip entries that disappear or cannot be read.
+    }
+  }
+  return resultDirs;
+}
+
+function removeEmptyDirs(rootDir: string, relativeDir = ''): boolean {
+  const currentDir = relativeDir ? join(rootDir, relativeDir) : rootDir;
+  let entries: string[];
+  try {
+    entries = readdirSync(currentDir).filter((entry) => !entry.startsWith('.'));
+  } catch {
+    return false;
+  }
+
+  for (const entry of entries) {
+    const entryRelativeDir = relativeDir ? join(relativeDir, entry) : entry;
+    const entryPath = join(rootDir, entryRelativeDir);
+    try {
+      if (statSync(entryPath).isDirectory()) {
+        removeEmptyDirs(rootDir, entryRelativeDir);
+      }
+    } catch {
+      // Directory may have been removed already.
+    }
+  }
+
+  if (relativeDir) {
+    const remaining = readdirSync(currentDir).filter((entry) => !entry.startsWith('.'));
+    if (remaining.length === 0) {
+      rmSync(currentDir, { recursive: true });
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Run housekeeping on a single experiment's results directory.
  *
@@ -66,12 +130,7 @@ export function housekeep(
   for (const timestamp of timestamps) {
     const tsDir = join(experimentDir, timestamp);
 
-    let evalDirs: string[];
-    try {
-      evalDirs = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
-    } catch {
-      continue;
-    }
+    const evalDirs = discoverEvalResultDirs(tsDir);
 
     for (const evalDir of evalDirs) {
       const evalResultDir = join(tsDir, evalDir);
@@ -112,6 +171,9 @@ export function housekeep(
 
     // Check if timestamp dir is now empty
     try {
+      if (!options?.dry) {
+        removeEmptyDirs(tsDir);
+      }
       const remaining = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
       if (remaining.length === 0) {
         if (!options?.dry) {

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -355,6 +355,21 @@ describe('results utilities', () => {
       expect(result.get('eval-1')?.fingerprint).toBe('abc123');
     });
 
+    it('finds reusable results in nested eval directories', () => {
+      const evalName = 'ui-development/design-system/layout-props';
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', evalName);
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 2, passedRuns: 1, passRate: '50%', meanDuration: 10, fingerprint: 'abc123' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { [evalName]: 'abc123' });
+      expect(result.size).toBe(1);
+      expect(result.get(evalName)?.evalName).toBe(evalName);
+      expect(result.get(evalName)?.fingerprint).toBe('abc123');
+    });
+
     it('skips results with mismatched fingerprint', () => {
       const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
       mkdirSync(expDir, { recursive: true });

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -459,6 +459,34 @@ export interface ReusableResult {
 	timestamp: string;
 }
 
+function discoverEvalResultDirs(rootDir: string, relativeDir = ''): string[] {
+	const currentDir = relativeDir ? join(rootDir, relativeDir) : rootDir;
+	if (existsSync(join(currentDir, 'summary.json'))) {
+		return relativeDir ? [relativeDir] : [];
+	}
+
+	let entries: string[];
+	try {
+		entries = readdirSync(currentDir).filter((entry) => !entry.startsWith('.'));
+	} catch {
+		return [];
+	}
+
+	const resultDirs: string[] = [];
+	for (const entry of entries) {
+		const entryRelativeDir = relativeDir ? join(relativeDir, entry) : entry;
+		const entryPath = join(rootDir, entryRelativeDir);
+		try {
+			if (statSync(entryPath).isDirectory()) {
+				resultDirs.push(...discoverEvalResultDirs(rootDir, entryRelativeDir));
+			}
+		} catch {
+			// Skip entries that disappear or cannot be read.
+		}
+	}
+	return resultDirs;
+}
+
 /**
  * Scan existing results for an experiment to find reusable eval results.
  *
@@ -494,12 +522,7 @@ export function scanReusableResults(
 		const tsDir = join(experimentDir, timestamp);
 		if (!statSync(tsDir).isDirectory()) continue;
 
-		let evalDirs: string[];
-		try {
-			evalDirs = readdirSync(tsDir).filter((d) => !d.startsWith('.'));
-		} catch {
-			continue;
-		}
+		const evalDirs = discoverEvalResultDirs(tsDir);
 
 		for (const evalDir of evalDirs) {
 			// Already found a reusable result for this eval


### PR DESCRIPTION
Summary
- Discover eval result directories by walking to directories that contain `summary.json` instead of only reading the first level under each timestamp.
- Preserve nested eval names such as `ui-development/design-system/layout-props` as reusable result keys.
- Update housekeeping to operate on nested eval result leaves without deleting the parent subtree as an incomplete result.
- Add regression coverage for nested reusable results and nested housekeeping dedupe.

Fixes #129.

Verification
- `npm run test -w packages/agent-eval -- src/lib/results.test.ts src/lib/housekeeping.test.ts`
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`
- `git diff --check`