### PR TITLE
[Agents] Add Mistral Vibe CLI agent with direct API and streaming-json transcript support

### DIFF
--- a/.changeset/add-mistral-vibe-agent.md
+++ b/.changeset/add-mistral-vibe-agent.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add Mistral Vibe CLI agent with direct API and streaming-json transcript support. Enables testing against Mistral models (default: `mistral-medium-3.5`) through direct API access. The agent captures detailed execution transcripts in JSONL format and is fully integrated with the eval framework sandbox infrastructure.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ agent: 'claude-code'  // requires ANTHROPIC_API_KEY
 agent: 'codex'        // requires OPENAI_API_KEY
 agent: 'gemini'       // requires GEMINI_API_KEY
 agent: 'cursor'       // requires CURSOR_API_KEY
+agent: 'mistral-vibe' // requires MISTRAL_API_KEY
 ```
 
 ### Multi-model experiments
@@ -497,6 +498,7 @@ Every run requires an API key for the agent and a token for the sandbox. Classif
 | `OPENAI_API_KEY`     | `agent: 'codex'`                       | Direct OpenAI API key                                                                        |
 | `GEMINI_API_KEY`     | `agent: 'gemini'`                      | Direct Google Gemini API key                                                                 |
 | `CURSOR_API_KEY`     | `agent: 'cursor'`                      | Direct Cursor API key                                                                        |
+| `MISTRAL_API_KEY`    | `agent: 'mistral-vibe'`                | Direct Mistral API key                                                                       |
 | `VERCEL_TOKEN`       | Always (pick one)                      | Vercel personal access token -- for local dev                                                |
 | `VERCEL_OIDC_TOKEN`  | Always (pick one) OR for classifier    | Vercel OIDC token -- for CI/CD pipelines, or enables classifier without `AI_GATEWAY_API_KEY` |
 

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -44,6 +44,7 @@ const hasAnthropicCredentials = !!process.env.ANTHROPIC_API_KEY && hasSandbox;
 const hasOpenAiCredentials = !!process.env.OPENAI_API_KEY && hasSandbox;
 const hasGeminiCredentials = !!process.env.GEMINI_API_KEY && hasSandbox;
 const hasCursorCredentials = !!process.env.CURSOR_API_KEY && hasSandbox;
+const hasMistralCredentials = !!process.env.MISTRAL_API_KEY && hasSandbox;
 // OpenCode credentials (only supports AI Gateway)
 const hasOpenCodeCredentials = hasAiGatewayCredentials;
 
@@ -968,6 +969,163 @@ test('contains greeting', () => {
         }
       }
     }, 300000); // 5 minute timeout
+  });
+
+  describe.skipIf(!hasMistralCredentials)('Mistral Vibe (Direct API) sandbox execution', () => {
+    it('can run a simple eval with Mistral Vibe', async () => {
+      // Create a simple test fixture
+      const fixtureDir = join(TEST_DIR, 'simple-eval-mistral-vibe');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Add a function called greet in src/index.ts that returns "Hello from Mistral!"'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync } from 'fs';
+
+test('greet exists', () => {
+  const content = readFileSync('src/index.ts', 'utf-8');
+  expect(content).toContain('greet');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'simple-eval-mistral-vibe',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+      writeFileSync(join(fixtureDir, 'src/index.ts'), '// TODO: implement');
+
+      const fixture = loadFixture(TEST_DIR, 'simple-eval-mistral-vibe');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'mistral-vibe',
+        model: 'mistral-medium-3.5',
+        timeout: 240,
+        apiKey: process.env.MISTRAL_API_KEY!,
+        scripts: ['build'],
+      });
+
+      // Verify result structure
+      expect(result.result.duration).toBeGreaterThan(0);
+      expect(result.result.status).toBeDefined();
+      // Agent must actually succeed - not just return a result
+      if (result.result.status === 'failed') {
+        console.error('Mistral Vibe agent failed with error:', result.result.error);
+      }
+      expect(result.result.status).toBe('passed');
+
+      // Verify output content exists (if available)
+      if (result.outputContent) {
+        expect(typeof result.outputContent).toBe('object');
+      }
+
+      // Verify transcript was captured and parsed successfully.
+      expect(result.transcript).toBeTruthy();
+    }, 420000); // 7 minute timeout — uv install + first Vibe run can be slow.
+
+    it('verifies Mistral Vibe result output structure matches expected format', async () => {
+      // Create a simple test fixture
+      const fixtureDir = join(TEST_DIR, 'result-structure-mistral-vibe');
+      mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Create src/hello.ts that exports a constant called `greeting` with a friendly message.'
+      );
+      writeFileSync(
+        join(fixtureDir, 'EVAL.ts'),
+        `
+import { test, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+
+test('hello.ts exists', () => {
+  expect(existsSync('src/hello.ts')).toBe(true);
+});
+
+test('contains greeting', () => {
+  const content = readFileSync('src/hello.ts', 'utf-8');
+  expect(content).toContain('greeting');
+});
+`
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({
+          name: 'result-structure-mistral-vibe',
+          type: 'module',
+          scripts: { build: 'tsc' },
+          devDependencies: { typescript: '^5.0.0', vitest: '^2.1.0' },
+        })
+      );
+      writeFileSync(
+        join(fixtureDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2020',
+            module: 'ESNext',
+            moduleResolution: 'bundler',
+            outDir: 'dist',
+          },
+          include: ['src'],
+        })
+      );
+
+      const fixture = loadFixture(TEST_DIR, 'result-structure-mistral-vibe');
+
+      const result = await runSingleEval(fixture, {
+        agent: 'mistral-vibe',
+        model: 'mistral-medium-3.5',
+        timeout: 240,
+        apiKey: process.env.MISTRAL_API_KEY!,
+        scripts: ['build'],
+      });
+
+      // Verify EvalRunData structure
+      expect(result).toHaveProperty('result');
+      expect(result.result).toHaveProperty('status');
+      expect(result.result).toHaveProperty('duration');
+
+      // Verify optional properties have correct types when present
+      if (result.result.error) {
+        expect(typeof result.result.error).toBe('string');
+      }
+
+      // Verify transcript structure if present
+      if (result.transcript) {
+        expect(typeof result.transcript).toBe('string');
+      }
+
+      // Verify output content structure if present
+      if (result.outputContent) {
+        if (result.outputContent.eval) {
+          expect(typeof result.outputContent.eval).toBe('string');
+        }
+        if (result.outputContent.scripts?.build) {
+          expect(typeof result.outputContent.scripts.build).toBe('string');
+        }
+      }
+    }, 420000); // 7 minute timeout — uv install can be slow on cold sandbox.
   });
 
   describe.skipIf(!hasOpenCodeCredentials)('OpenCode (Vercel AI Gateway) sandbox execution', () => {

--- a/packages/agent-eval/src/lib/agents/index.ts
+++ b/packages/agent-eval/src/lib/agents/index.ts
@@ -8,6 +8,7 @@ import { createCodexAgent } from './codex.js';
 import { createOpenCodeAgent } from './opencode.js';
 import { createGeminiAgent } from './gemini.js';
 import { createCursorAgent } from './cursor.js';
+import { createMistralVibeAgent } from './mistral-vibe.js';
 
 // Register all agent variants (Vercel AI Gateway + Direct API)
 registerAgent(createClaudeCodeAgent({ useVercelAiGateway: true }));   // vercel-ai-gateway/claude-code
@@ -17,6 +18,7 @@ registerAgent(createCodexAgent({ useVercelAiGateway: false }));       // codex
 registerAgent(createOpenCodeAgent());                                 // vercel-ai-gateway/opencode
 registerAgent(createGeminiAgent());                                   // gemini
 registerAgent(createCursorAgent());                                   // cursor
+registerAgent(createMistralVibeAgent());                              // mistral-vibe
 
 // Re-export registry functions
 export { registerAgent, getAgent, listAgents, hasAgent };

--- a/packages/agent-eval/src/lib/agents/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/agents/mistral-vibe.ts
@@ -1,0 +1,265 @@
+/**
+ * Mistral Vibe CLI agent implementation.
+ * Uses direct Mistral API access.
+ */
+
+import type { Agent, AgentRunOptions, AgentRunResult } from './types.js';
+import type { ModelTier } from '../types.js';
+import {
+  createSandbox,
+  collectLocalFiles,
+  splitTestFiles,
+  verifyNoTestFiles,
+  type SandboxManager,
+} from '../sandbox.js';
+import type { DockerSandboxManager } from '../docker-sandbox.js';
+import {
+  runValidation,
+  captureGeneratedFiles,
+  createVitestConfig,
+  MISTRAL_DIRECT,
+  initGitAndCommit,
+  injectTranscriptContext,
+  prepareNeutralWorkspace,
+} from './shared.js';
+
+/** Union type for sandbox implementations */
+type AnySandbox = SandboxManager | DockerSandboxManager;
+
+/**
+ * Extract transcript from Mistral Vibe streaming JSON output.
+ * When run with --output streaming, Vibe emits one OpenAI-compat LLMMessage per line.
+ */
+function extractTranscriptFromOutput(output: string): string | undefined {
+  if (!output || !output.trim()) {
+    return undefined;
+  }
+
+  const lines = output.split('\n').filter(line => {
+    const trimmed = line.trim();
+    return trimmed.startsWith('{') && trimmed.endsWith('}');
+  });
+
+  if (lines.length === 0) {
+    return undefined;
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Create Mistral Vibe CLI agent with direct API authentication.
+ */
+export function createMistralVibeAgent(): Agent {
+  return {
+    name: 'mistral-vibe',
+    displayName: 'Mistral Vibe CLI',
+
+    getApiKeyEnvVar(): string {
+      return MISTRAL_DIRECT.apiKeyEnvVar;
+    },
+
+    getDefaultModel(): ModelTier {
+      return 'mistral-medium-3.5';
+    },
+
+    async run(fixturePath: string, options: AgentRunOptions): Promise<AgentRunResult> {
+      const startTime = Date.now();
+      let sandbox: AnySandbox | null = null;
+      let agentOutput = '';
+      let transcript: string | undefined;
+      let aborted = false;
+      let sandboxStopped = false;
+
+      // Handle abort signal
+      const abortHandler = () => {
+        aborted = true;
+        if (sandbox && !sandboxStopped) {
+          sandboxStopped = true;
+          sandbox.stop().catch(() => {});
+        }
+      };
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted before start',
+            duration: 0,
+          };
+        }
+        options.signal.addEventListener('abort', abortHandler);
+      }
+
+      try {
+        // Collect files from fixture
+        const allFiles = await collectLocalFiles(fixturePath);
+        const { workspaceFiles, testFiles } = splitTestFiles(allFiles);
+
+        // Check for abort before expensive operations
+        if (aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+          };
+        }
+
+        // Create sandbox
+        sandbox = await createSandbox({
+          timeout: options.timeout,
+          runtime: 'node24',
+          backend: options.sandbox,
+        });
+
+        // Check for abort after sandbox creation (abort may have fired during create)
+        if (aborted) {
+          return {
+            success: false,
+            output: '',
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+            sandboxId: sandbox.sandboxId,
+          };
+        }
+
+        // Upload workspace files (excluding tests)
+        await sandbox.uploadFiles(workspaceFiles);
+
+        await initGitAndCommit(sandbox);
+
+        // Run setup function if provided
+        if (options.setup) {
+          await options.setup(sandbox);
+        }
+        const neutralWorkspace = await prepareNeutralWorkspace(sandbox);
+
+        // Install dependencies
+        let installResult = await sandbox.runCommand('npm', ['install']);
+        if (installResult.exitCode !== 0) {
+          installResult = await sandbox.runCommand('npm', ['install']);
+        }
+        if (installResult.exitCode !== 0) {
+          const output = (installResult.stdout + installResult.stderr).trim().split('\n').slice(-10).join('\n');
+          throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
+        }
+
+        // Install Mistral Vibe CLI via uv (downloads Python 3.12 if needed).
+        // uv installs to $HOME/.local/bin; we prepend it to PATH in every later runShell.
+        const cliInstall = await sandbox.runShell(
+          [
+            'set -e',
+            'curl -LsSf https://astral.sh/uv/install.sh | sh',
+            'export PATH="$HOME/.local/bin:$PATH"',
+            'uv tool install mistral-vibe',
+            'vibe --version',
+          ].join(' && ')
+        );
+        if (cliInstall.exitCode !== 0) {
+          const output = (cliInstall.stdout + cliInstall.stderr).trim().split('\n').slice(-10).join('\n');
+          throw new Error(`Mistral Vibe CLI install failed (exit code ${cliInstall.exitCode}):\n${output}`);
+        }
+
+        // Verify no test files in sandbox
+        await verifyNoTestFiles(sandbox);
+
+        // Run Mistral Vibe in programmatic mode.
+        // --prompt <text>: programmatic mode (auto-selects auto-approve profile).
+        // --trust: bypass workdir trust dialog (required for non-interactive).
+        // --max-turns N: bound runaway agents.
+        // --output streaming: newline-delimited LLMMessage JSON per turn.
+        // Model + telemetry suppression are controlled via VIBE_* env vars.
+        const escapedPrompt = JSON.stringify(options.prompt);
+        const maxTurns = (options.agentOptions?.maxTurns as number | undefined) ?? 50;
+
+        const vibeResult = await sandbox.runShell(
+          [
+            'export PATH="$HOME/.local/bin:$PATH"',
+            `vibe --prompt ${escapedPrompt} --trust --max-turns ${maxTurns} --output streaming`,
+          ].join(' && '),
+          {
+            [MISTRAL_DIRECT.apiKeyEnvVar]: options.apiKey,
+            VIBE_ACTIVE_MODEL: options.model,
+            VIBE_ENABLE_AUTO_UPDATE: 'false',
+            VIBE_ENABLE_TELEMETRY: 'false',
+            VIBE_ENABLE_OTEL: 'false',
+            ...neutralWorkspace.env,
+          }
+        );
+
+        agentOutput = vibeResult.stdout + vibeResult.stderr;
+        transcript = extractTranscriptFromOutput(agentOutput);
+
+        if (vibeResult.exitCode !== 0) {
+          const errorLines = agentOutput.trim().split('\n').slice(-5).join('\n');
+          return {
+            success: false,
+            output: agentOutput,
+            transcript,
+            error: errorLines || `Mistral Vibe CLI exited with code ${vibeResult.exitCode}`,
+            duration: Date.now() - startTime,
+            sandboxId: sandbox.sandboxId,
+          };
+        }
+
+        // Upload test files for validation
+        await sandbox.uploadFiles(testFiles);
+
+        // Create vitest config for EVAL.ts/tsx
+        await createVitestConfig(sandbox);
+
+        // Inject transcript context so EVAL.ts tests can assert on agent behavior
+        await injectTranscriptContext(sandbox, transcript, 'mistral-vibe', options.model);
+
+        // Run validation scripts
+        const validationResults = await runValidation(sandbox, options.scripts ?? []);
+
+        // Capture generated files
+        const { generatedFiles, deletedFiles } = await captureGeneratedFiles(sandbox);
+
+        return {
+          success: validationResults.allPassed,
+          output: agentOutput,
+          transcript,
+          duration: Date.now() - startTime,
+          testResult: validationResults.test,
+          scriptsResults: validationResults.scripts,
+          sandboxId: sandbox.sandboxId,
+          generatedFiles,
+          deletedFiles,
+        };
+      } catch (error) {
+        // Check if this was an abort
+        if (aborted) {
+          return {
+            success: false,
+            output: agentOutput,
+            transcript,
+            error: 'Aborted',
+            duration: Date.now() - startTime,
+            sandboxId: sandbox?.sandboxId,
+          };
+        }
+        return {
+          success: false,
+          output: agentOutput,
+          transcript,
+          error: error instanceof Error ? error.message : String(error),
+          duration: Date.now() - startTime,
+          sandboxId: sandbox?.sandboxId,
+        };
+      } finally {
+        // Clean up abort listener
+        if (options.signal) {
+          options.signal.removeEventListener('abort', abortHandler);
+        }
+        if (sandbox && !sandboxStopped) {
+          sandboxStopped = true;
+          await sandbox.stop();
+        }
+      }
+    },
+  };
+}

--- a/packages/agent-eval/src/lib/agents/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/agents/mistral-vibe.ts
@@ -154,7 +154,8 @@ export function createMistralVibeAgent(): Agent {
         // the install.
         const cliInstall = await sandbox.runShell(
           [
-            'set -e',
+            // -x traces each stage so the truncated error tail surfaces the failing step.
+            'set -ex',
             'mkdir -p "$HOME/.local/bin"',
             `node -e "const fs=require('fs');const arch=process.arch==='arm64'?'aarch64':'x86_64';fetch('https://github.com/astral-sh/uv/releases/download/0.11.15/uv-'+arch+'-unknown-linux-gnu.tar.gz').then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer()}).then(b=>fs.writeFileSync('/tmp/uv.tar.gz',Buffer.from(b)))"`,
             'tar -xzf /tmp/uv.tar.gz --strip-components=1 -C "$HOME/.local/bin"',
@@ -173,7 +174,11 @@ export function createMistralVibeAgent(): Agent {
 
         // Run Mistral Vibe in programmatic mode.
         // --prompt <text>: programmatic mode (auto-selects auto-approve profile).
-        // --trust: bypass workdir trust dialog (required for non-interactive).
+        // --trust: silences the untrusted-workdir stderr warning Vibe emits in
+        //   programmatic mode and ensures any project-level .vibe config is
+        //   honored. The interactive trust dialog is already skipped when
+        //   --prompt is set (vibe/cli/entrypoint.py:204-206), so --trust is
+        //   hygiene rather than a hang fix.
         // --max-turns N: bound runaway agents.
         // --output streaming: newline-delimited LLMMessage JSON per turn.
         // Model + telemetry suppression are controlled via VIBE_* env vars.

--- a/packages/agent-eval/src/lib/agents/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/agents/mistral-vibe.ts
@@ -146,15 +146,17 @@ export function createMistralVibeAgent(): Agent {
           throw new Error(`npm install failed (exit code ${installResult.exitCode}):\n${output}`);
         }
 
-        // Install Mistral Vibe CLI via uv (downloads Python 3.12 if needed).
+        // Install Mistral Vibe CLI via uv 0.11.15 (downloads Python 3.12 if needed).
         // uv installs to $HOME/.local/bin; we prepend it to PATH in every later runShell.
         // Fetch the uv tarball directly via Node — node:*-slim images have no curl/wget,
-        // and upstream's install.sh shells out to curl, so we bypass it entirely.
+        // and upstream's install.sh shells out to curl, so we bypass it entirely. Pinning
+        // the uv version protects against upstream tarball-layout changes silently breaking
+        // the install.
         const cliInstall = await sandbox.runShell(
           [
             'set -e',
             'mkdir -p "$HOME/.local/bin"',
-            `node -e "const fs=require('fs');const arch=process.arch==='arm64'?'aarch64':'x86_64';fetch('https://github.com/astral-sh/uv/releases/latest/download/uv-'+arch+'-unknown-linux-gnu.tar.gz').then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer()}).then(b=>fs.writeFileSync('/tmp/uv.tar.gz',Buffer.from(b)))"`,
+            `node -e "const fs=require('fs');const arch=process.arch==='arm64'?'aarch64':'x86_64';fetch('https://github.com/astral-sh/uv/releases/download/0.11.15/uv-'+arch+'-unknown-linux-gnu.tar.gz').then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer()}).then(b=>fs.writeFileSync('/tmp/uv.tar.gz',Buffer.from(b)))"`,
             'tar -xzf /tmp/uv.tar.gz --strip-components=1 -C "$HOME/.local/bin"',
             'export PATH="$HOME/.local/bin:$PATH"',
             'uv tool install mistral-vibe',

--- a/packages/agent-eval/src/lib/agents/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/agents/mistral-vibe.ts
@@ -148,10 +148,14 @@ export function createMistralVibeAgent(): Agent {
 
         // Install Mistral Vibe CLI via uv (downloads Python 3.12 if needed).
         // uv installs to $HOME/.local/bin; we prepend it to PATH in every later runShell.
+        // Fetch the uv tarball directly via Node — node:*-slim images have no curl/wget,
+        // and upstream's install.sh shells out to curl, so we bypass it entirely.
         const cliInstall = await sandbox.runShell(
           [
             'set -e',
-            'curl -LsSf https://astral.sh/uv/install.sh | sh',
+            'mkdir -p "$HOME/.local/bin"',
+            `node -e "const fs=require('fs');const arch=process.arch==='arm64'?'aarch64':'x86_64';fetch('https://github.com/astral-sh/uv/releases/latest/download/uv-'+arch+'-unknown-linux-gnu.tar.gz').then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer()}).then(b=>fs.writeFileSync('/tmp/uv.tar.gz',Buffer.from(b)))"`,
+            'tar -xzf /tmp/uv.tar.gz --strip-components=1 -C "$HOME/.local/bin"',
             'export PATH="$HOME/.local/bin:$PATH"',
             'uv tool install mistral-vibe',
             'vibe --version',

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -280,3 +280,10 @@ export const GEMINI_DIRECT = {
 export const CURSOR_DIRECT = {
   apiKeyEnvVar: 'CURSOR_API_KEY',
 } as const;
+
+/**
+ * Direct API configuration for Mistral.
+ */
+export const MISTRAL_DIRECT = {
+  apiKeyEnvVar: 'MISTRAL_API_KEY',
+} as const;

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -38,6 +38,7 @@ const experimentConfigSchema = z.object({
     'vercel-ai-gateway/opencode',
     'gemini',
     'cursor',
+    'mistral-vibe',
   ]),
   model: z.union([z.string(), z.array(z.string())]).optional(),
   evals: z

--- a/packages/agent-eval/src/lib/o11y/index.ts
+++ b/packages/agent-eval/src/lib/o11y/index.ts
@@ -24,3 +24,4 @@ export { parseCodexTranscript } from './parsers/codex.js';
 export { parseOpenCodeTranscript } from './parsers/opencode.js';
 export { parseGeminiTranscript } from './parsers/gemini.js';
 export { parseCursorTranscript } from './parsers/cursor.js';
+export { parseMistralVibeTranscript } from './parsers/mistral-vibe.js';

--- a/packages/agent-eval/src/lib/o11y/o11y.test.ts
+++ b/packages/agent-eval/src/lib/o11y/o11y.test.ts
@@ -991,6 +991,28 @@ describe('o11y', () => {
       expect(events[3].tool?.originalName).toBe('read_file');
     });
 
+    it('does not mark grep results containing the word "error" as failed', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { id: 'tc_g', type: 'function', function: { name: 'grep', arguments: '{"pattern":"error"}' } },
+          ],
+        }),
+        JSON.stringify({
+          role: 'tool',
+          content: 'src/log.ts:14: console.log("error handler installed");',
+          name: 'grep',
+          tool_call_id: 'tc_g',
+        }),
+      ].join('\n');
+
+      const { events } = parseMistralVibeTranscript(transcript);
+      const toolResult = events.find((e) => e.type === 'tool_result');
+      expect(toolResult?.tool?.success).toBe(true);
+    });
+
     it('produces a full summary from a realistic transcript', () => {
       const transcript = [
         JSON.stringify({ role: 'user', content: 'Add a greet function', message_id: 'm0' }),

--- a/packages/agent-eval/src/lib/o11y/o11y.test.ts
+++ b/packages/agent-eval/src/lib/o11y/o11y.test.ts
@@ -10,6 +10,7 @@ import { parseCodexTranscript } from './parsers/codex.js';
 import { parseOpenCodeTranscript } from './parsers/opencode.js';
 import { parseGeminiTranscript } from './parsers/gemini.js';
 import { parseCursorTranscript } from './parsers/cursor.js';
+import { parseMistralVibeTranscript } from './parsers/mistral-vibe.js';
 
 describe('o11y', () => {
   describe('parseTranscript', () => {
@@ -47,7 +48,7 @@ describe('o11y', () => {
 
       expect(result.parseSuccess).toBe(false);
       expect(result.parseErrors).toContain(
-        'No parser available for agent: unsupported-agent. Supported agents: claude-code, codex, opencode, gemini, cursor'
+        'No parser available for agent: unsupported-agent. Supported agents: claude-code, codex, opencode, gemini, cursor, mistral-vibe'
       );
       expect(result.events).toEqual([]);
       expect(result.summary.totalToolCalls).toBe(0);
@@ -734,6 +735,293 @@ describe('o11y', () => {
       expect(result.summary.toolCalls.file_read).toBe(1);
       expect(result.summary.totalToolCalls).toBe(1);
       expect(result.summary.filesRead).toContain('a.ts');
+    });
+  });
+
+  describe('Mistral Vibe parser', () => {
+    it('parses an assistant message with a tool_call', () => {
+      const transcript = JSON.stringify({
+        role: 'assistant',
+        content: 'I will write the file.',
+        tool_calls: [
+          {
+            id: 'tc_1',
+            type: 'function',
+            function: {
+              name: 'write_file',
+              arguments: '{"path":"src/index.ts","content":"export const x = 1;"}',
+            },
+          },
+        ],
+        message_id: 'm1',
+      });
+
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('message');
+      expect(events[0].role).toBe('assistant');
+      expect(events[0].content).toBe('I will write the file.');
+      expect(events[1].type).toBe('tool_call');
+      expect(events[1].tool?.name).toBe('file_write');
+      expect(events[1].tool?.originalName).toBe('write_file');
+    });
+
+    it('parses a tool result and pairs it with the pending call', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'tc_42',
+              type: 'function',
+              function: { name: 'bash', arguments: '{"command":"ls"}' },
+            },
+          ],
+          message_id: 'm1',
+        }),
+        JSON.stringify({
+          role: 'tool',
+          content: 'EVAL.ts\npackage.json\n',
+          name: 'bash',
+          tool_call_id: 'tc_42',
+        }),
+      ].join('\n');
+
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('tool_call');
+      expect(events[0].tool?.name).toBe('shell');
+      expect(events[0].tool?.originalName).toBe('bash');
+      expect(events[1].type).toBe('tool_result');
+      expect(events[1].tool?.name).toBe('shell');
+      expect(events[1].tool?.originalName).toBe('bash');
+      expect(events[1].tool?.success).toBe(true);
+    });
+
+    it('marks a tool_result as failed when the content mentions an error', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'tc_x',
+              type: 'function',
+              function: { name: 'read_file', arguments: '{"path":"missing.ts"}' },
+            },
+          ],
+        }),
+        JSON.stringify({
+          role: 'tool',
+          content: 'Error: file not found: missing.ts',
+          name: 'read_file',
+          tool_call_id: 'tc_x',
+        }),
+      ].join('\n');
+
+      const { events } = parseMistralVibeTranscript(transcript);
+      const toolResult = events.find((e) => e.type === 'tool_result');
+      expect(toolResult?.tool?.success).toBe(false);
+    });
+
+    it('emits reasoning_content as a separate thinking event before the assistant message', () => {
+      const transcript = JSON.stringify({
+        role: 'assistant',
+        content: 'Done.',
+        reasoning_content: 'Considering the request...',
+        message_id: 'm1',
+      });
+
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('thinking');
+      expect(events[0].content).toBe('Considering the request...');
+      expect(events[1].type).toBe('message');
+      expect(events[1].role).toBe('assistant');
+      expect(events[1].content).toBe('Done.');
+    });
+
+    it('skips messages with injected: true', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: 'This is a harness-injected reminder.',
+          injected: true,
+          message_id: 'm0',
+        }),
+        JSON.stringify({ role: 'assistant', content: 'Acknowledged.', message_id: 'm1' }),
+      ].join('\n');
+
+      const { events } = parseMistralVibeTranscript(transcript);
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('message');
+      expect(events[0].content).toBe('Acknowledged.');
+    });
+
+    it('parses JSON-encoded function.arguments', () => {
+      const transcript = JSON.stringify({
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'tc_1',
+            type: 'function',
+            function: {
+              name: 'search_replace',
+              arguments: '{"file_path":"src/app.ts","content":"new"}',
+            },
+          },
+        ],
+      });
+
+      const { events } = parseMistralVibeTranscript(transcript);
+      expect(events[0].type).toBe('tool_call');
+      expect(events[0].tool?.name).toBe('file_edit');
+      expect(events[0].tool?.originalName).toBe('search_replace');
+      expect(events[0].tool?.args?.file_path).toBe('src/app.ts');
+    });
+
+    it('normalizes Vibe tool names', () => {
+      const tools = [
+        { native: 'read_file', expected: 'file_read' as const },
+        { native: 'write_file', expected: 'file_write' as const },
+        { native: 'search_replace', expected: 'file_edit' as const },
+        { native: 'bash', expected: 'shell' as const },
+        { native: 'grep', expected: 'grep' as const },
+        { native: 'web_fetch', expected: 'web_fetch' as const },
+        { native: 'web_search', expected: 'web_search' as const },
+        { native: 'todo', expected: 'agent_task' as const },
+        { native: 'task', expected: 'agent_task' as const },
+        { native: 'skill', expected: 'unknown' as const },
+        { native: 'unknown_tool', expected: 'unknown' as const },
+      ];
+
+      for (const { native, expected } of tools) {
+        const transcript = JSON.stringify({
+          role: 'assistant',
+          content: null,
+          tool_calls: [{ id: `tc_${native}`, type: 'function', function: { name: native, arguments: '{}' } }],
+        });
+        const { events } = parseMistralVibeTranscript(transcript);
+        expect(events[0].tool?.name).toBe(expected);
+        expect(events[0].tool?.originalName).toBe(native);
+      }
+    });
+
+    it('extracts file paths from tool args', () => {
+      const transcript = JSON.stringify({
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'tc_1',
+            type: 'function',
+            function: { name: 'read_file', arguments: '{"path":"src/utils.ts"}' },
+          },
+        ],
+      });
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events[0].tool?.args?._extractedPath).toBe('src/utils.ts');
+    });
+
+    it('extracts commands from shell tool args', () => {
+      const transcript = JSON.stringify({
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'tc_1',
+            type: 'function',
+            function: { name: 'bash', arguments: '{"command":"npm install"}' },
+          },
+        ],
+      });
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events[0].tool?.args?._extractedCommand).toBe('npm install');
+    });
+
+    it('extracts URLs from web fetch args', () => {
+      const transcript = JSON.stringify({
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'tc_1',
+            type: 'function',
+            function: { name: 'web_fetch', arguments: '{"url":"https://api.example.com/data"}' },
+          },
+        ],
+      });
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events[0].tool?.args?._extractedUrl).toBe('https://api.example.com/data');
+    });
+
+    it('produces a full summary from a realistic transcript', () => {
+      const transcript = [
+        JSON.stringify({ role: 'user', content: 'Add a greet function', message_id: 'm0' }),
+        JSON.stringify({
+          role: 'assistant',
+          content: 'Reading the file first.',
+          tool_calls: [
+            {
+              id: 'tc_1',
+              type: 'function',
+              function: { name: 'read_file', arguments: '{"path":"src/index.ts"}' },
+            },
+          ],
+          message_id: 'm1',
+        }),
+        JSON.stringify({ role: 'tool', content: '// empty', name: 'read_file', tool_call_id: 'tc_1' }),
+        JSON.stringify({
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'tc_2',
+              type: 'function',
+              function: { name: 'bash', arguments: '{"command":"mkdir -p src"}' },
+            },
+          ],
+          message_id: 'm2',
+        }),
+        JSON.stringify({ role: 'tool', content: '', name: 'bash', tool_call_id: 'tc_2' }),
+        JSON.stringify({
+          role: 'assistant',
+          content: 'Writing the new file.',
+          tool_calls: [
+            {
+              id: 'tc_3',
+              type: 'function',
+              function: {
+                name: 'write_file',
+                arguments: '{"path":"src/index.ts","content":"export function greet(){return \\"hi\\";}"}',
+              },
+            },
+          ],
+          message_id: 'm3',
+        }),
+        JSON.stringify({ role: 'tool', content: 'File written', name: 'write_file', tool_call_id: 'tc_3' }),
+      ].join('\n');
+
+      const result = parseTranscript(transcript, 'mistral-vibe');
+
+      expect(result.parseSuccess).toBe(true);
+      expect(result.summary.totalTurns).toBe(2);
+      expect(result.summary.toolCalls.file_read).toBe(1);
+      expect(result.summary.toolCalls.shell).toBe(1);
+      expect(result.summary.toolCalls.file_write).toBe(1);
+      expect(result.summary.totalToolCalls).toBe(3);
+      expect(result.summary.filesRead).toContain('src/index.ts');
+      expect(result.summary.filesModified).toContain('src/index.ts');
+      expect(result.summary.shellCommands).toHaveLength(1);
+      expect(result.summary.shellCommands[0].command).toBe('mkdir -p src');
     });
   });
 

--- a/packages/agent-eval/src/lib/o11y/o11y.test.ts
+++ b/packages/agent-eval/src/lib/o11y/o11y.test.ts
@@ -963,6 +963,34 @@ describe('o11y', () => {
       expect(events[0].tool?.args?._extractedUrl).toBe('https://api.example.com/data');
     });
 
+    it('pairs out-of-order tool results from parallel tool_calls in one assistant turn', () => {
+      const transcript = [
+        JSON.stringify({
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { id: 'a', type: 'function', function: { name: 'read_file', arguments: '{"path":"a.ts"}' } },
+            { id: 'b', type: 'function', function: { name: 'read_file', arguments: '{"path":"b.ts"}' } },
+          ],
+          message_id: 'm1',
+        }),
+        JSON.stringify({ role: 'tool', content: 'b contents', name: 'read_file', tool_call_id: 'b' }),
+        JSON.stringify({ role: 'tool', content: 'a contents', name: 'read_file', tool_call_id: 'a' }),
+      ].join('\n');
+
+      const { events } = parseMistralVibeTranscript(transcript);
+
+      expect(events).toHaveLength(4);
+      expect(events[0].type).toBe('tool_call');
+      expect(events[0].tool?.args?.path).toBe('a.ts');
+      expect(events[1].type).toBe('tool_call');
+      expect(events[1].tool?.args?.path).toBe('b.ts');
+      expect(events[2].type).toBe('tool_result');
+      expect(events[2].tool?.originalName).toBe('read_file');
+      expect(events[3].type).toBe('tool_result');
+      expect(events[3].tool?.originalName).toBe('read_file');
+    });
+
     it('produces a full summary from a realistic transcript', () => {
       const transcript = [
         JSON.stringify({ role: 'user', content: 'Add a greet function', message_id: 'm0' }),

--- a/packages/agent-eval/src/lib/o11y/parsers/index.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/index.ts
@@ -16,6 +16,7 @@ import { parseCodexTranscript } from './codex.js';
 import { parseOpenCodeTranscript } from './opencode.js';
 import { parseGeminiTranscript } from './gemini.js';
 import { parseCursorTranscript } from './cursor.js';
+import { parseMistralVibeTranscript } from './mistral-vibe.js';
 
 /**
  * Supported agent types for parsing.
@@ -27,7 +28,8 @@ export type ParseableAgent =
   | 'codex'
   | 'vercel-ai-gateway/opencode'
   | 'gemini'
-  | 'cursor';
+  | 'cursor'
+  | 'mistral-vibe';
 
 /**
  * Parser registry mapping agent key patterns to their parsers.
@@ -38,6 +40,7 @@ const AGENT_PARSERS = {
   'opencode': parseOpenCodeTranscript,
   'gemini': parseGeminiTranscript,
   'cursor': parseCursorTranscript,
+  'mistral-vibe': parseMistralVibeTranscript,
 } as const;
 
 /**

--- a/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
@@ -23,6 +23,10 @@ import type { TranscriptEvent, ToolName } from '../types.js';
 
 /**
  * Map Vibe native tool names to canonical tool names.
+ *
+ * Vibe ships no `glob` or `list_dir` tool — models use `bash` for directory
+ * ops. `skill` (Vibe's meta-tool that varies in shape per skill) falls through
+ * to `'unknown'` deliberately. Regenerate this map per Vibe minor release.
  */
 const VIBE_TOOL_MAP: Record<string, ToolName> = {
   read_file: 'file_read',

--- a/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
@@ -25,8 +25,10 @@ import type { TranscriptEvent, ToolName } from '../types.js';
  * Map Vibe native tool names to canonical tool names.
  *
  * Vibe ships no `glob` or `list_dir` tool — models use `bash` for directory
- * ops. `skill` (Vibe's meta-tool that varies in shape per skill) falls through
- * to `'unknown'` deliberately. Regenerate this map per Vibe minor release.
+ * ops. `skill` (Vibe's skill-loading tool) is explicitly mapped to `'unknown'`
+ * because the canonical `ToolName` union has no skill equivalent — Claude
+ * Code's parser handles its `Skill` tool the same way. Regenerate this map
+ * per Vibe minor release.
  */
 const VIBE_TOOL_MAP: Record<string, ToolName> = {
   read_file: 'file_read',
@@ -38,6 +40,7 @@ const VIBE_TOOL_MAP: Record<string, ToolName> = {
   web_search: 'web_search',
   todo: 'agent_task',
   task: 'agent_task',
+  skill: 'unknown',
 };
 
 function canonicalToolName(rawName: string): ToolName {

--- a/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
@@ -1,0 +1,240 @@
+/**
+ * Parser for Mistral Vibe transcript format.
+ *
+ * Vibe (>=2.10) emits OpenAI-compatible JSONL when invoked with
+ * `vibe --prompt ... --output streaming`. Each row is an `LLMMessage`
+ * (see `vibe/core/types.py`) with shape:
+ *
+ *   {"role":"user","content":"...","message_id":"...","injected":false}
+ *   {"role":"assistant","content":"...","reasoning_content":"...","tool_calls":[
+ *      {"id":"...","type":"function","function":{"name":"write_file","arguments":"<json-string>"}}
+ *   ],"message_id":"..."}
+ *   {"role":"tool","content":"...","name":"write_file","tool_call_id":"..."}
+ *
+ * Notes:
+ *  - `function.arguments` is a JSON-encoded STRING.
+ *  - `content` may be null/empty when the assistant only emits tool calls.
+ *  - `reasoning_content` lives as a sibling field on `role:"assistant"` rows.
+ *  - `injected:true` marks harness-inserted rows (skip them).
+ *  - `role:"user"` / `role:"system"` rows only echo the prompt and are ignored.
+ */
+
+import type { TranscriptEvent, ToolName } from '../types.js';
+
+/**
+ * Map Vibe native tool names to canonical tool names.
+ */
+const VIBE_TOOL_MAP: Record<string, ToolName> = {
+  read_file: 'file_read',
+  write_file: 'file_write',
+  search_replace: 'file_edit',
+  bash: 'shell',
+  grep: 'grep',
+  web_fetch: 'web_fetch',
+  web_search: 'web_search',
+  todo: 'agent_task',
+  task: 'agent_task',
+};
+
+function canonicalToolName(rawName: string): ToolName {
+  // Defensive: strip a `functions.` prefix in case an upstream gateway adds it.
+  const stripped = rawName.replace(/^functions\./, '');
+  return VIBE_TOOL_MAP[stripped] || 'unknown';
+}
+
+/**
+ * Parse the JSON-encoded `function.arguments` string into an object.
+ */
+function parseToolArgs(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string') {
+    if (raw && typeof raw === 'object') return raw as Record<string, unknown>;
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Extract file path from Vibe tool arguments.
+ * `search_replace` uses `file_path`; `read_file`/`write_file` use `path`.
+ */
+function extractFilePath(args: Record<string, unknown>): string | undefined {
+  return (args.path || args.file_path || args.filePath || args.file) as string | undefined;
+}
+
+/**
+ * Extract command from shell tool arguments.
+ */
+function extractCommand(args: Record<string, unknown>): string | undefined {
+  if (typeof args.command === 'string') return args.command;
+  if (typeof args.cmd === 'string') return args.cmd;
+  return undefined;
+}
+
+/**
+ * Extract URL from web_fetch tool arguments.
+ */
+function extractUrl(args: Record<string, unknown>): string | undefined {
+  return (args.url || args.uri) as string | undefined;
+}
+
+interface PendingToolCall {
+  originalName: string;
+  canonicalName: ToolName;
+}
+
+/**
+ * Parse a single JSONL line from a Vibe transcript.
+ */
+function parseVibeLine(
+  line: string,
+  pending: Map<string, PendingToolCall>
+): TranscriptEvent[] {
+  const events: TranscriptEvent[] = [];
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(line);
+  } catch {
+    return events;
+  }
+
+  // Skip harness-injected rows.
+  if (data.injected === true) return events;
+
+  const role = data.role as string | undefined;
+
+  if (role === 'assistant') {
+    // Reasoning content emitted as a separate `thinking` event (matches Claude Code/Codex convention).
+    const reasoning = data.reasoning_content;
+    if (typeof reasoning === 'string' && reasoning.trim()) {
+      events.push({
+        type: 'thinking',
+        content: reasoning,
+        raw: data,
+      });
+    }
+
+    // Assistant message may carry both content and tool_calls. Emit message first, then each tool_call.
+    const content = data.content;
+    if (typeof content === 'string' && content.trim()) {
+      events.push({
+        type: 'message',
+        role: 'assistant',
+        content,
+        raw: data,
+      });
+    }
+
+    const toolCalls = data.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      for (const call of toolCalls) {
+        if (!call || typeof call !== 'object') continue;
+        const c = call as Record<string, unknown>;
+        const id = typeof c.id === 'string' ? c.id : undefined;
+        const fn = c.function as Record<string, unknown> | undefined;
+        const rawName = typeof fn?.name === 'string' ? fn.name : 'unknown';
+        const canonicalName = canonicalToolName(rawName);
+        const args = parseToolArgs(fn?.arguments);
+
+        events.push({
+          type: 'tool_call',
+          tool: {
+            name: canonicalName,
+            originalName: rawName,
+            args,
+          },
+          raw: call,
+        });
+
+        if (id) pending.set(id, { originalName: rawName, canonicalName });
+      }
+    }
+    return events;
+  }
+
+  if (role === 'tool') {
+    const id = typeof data.tool_call_id === 'string' ? data.tool_call_id : undefined;
+    const pendingCall = id ? pending.get(id) : undefined;
+    const fallbackName = typeof data.name === 'string' ? data.name : 'unknown';
+    const content = typeof data.content === 'string' ? data.content : '';
+
+    // Vibe's role:"tool" rows have no explicit error field; use a content heuristic.
+    const lower = content.toLowerCase();
+    const success = !(lower.includes('error') || lower.includes('failed'));
+
+    events.push({
+      type: 'tool_result',
+      tool: {
+        name: pendingCall?.canonicalName || canonicalToolName(fallbackName),
+        originalName: pendingCall?.originalName || fallbackName,
+        result: content,
+        success,
+      },
+      raw: data,
+    });
+
+    if (id) pending.delete(id);
+    return events;
+  }
+
+  // Ignore user/system rows — they only echo the prompt.
+  return events;
+}
+
+/**
+ * Parse Mistral Vibe JSONL transcript into normalized events.
+ */
+export function parseMistralVibeTranscript(raw: string): {
+  events: TranscriptEvent[];
+  errors: string[];
+} {
+  const events: TranscriptEvent[] = [];
+  const errors: string[] = [];
+  const pending = new Map<string, PendingToolCall>();
+
+  const lines = raw.split('\n').filter((line) => line.trim());
+
+  for (const line of lines) {
+    try {
+      const lineEvents = parseVibeLine(line, pending);
+      events.push(...lineEvents);
+    } catch (e) {
+      errors.push(`Failed to parse line: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // Post-process: extract metadata into tool args for the summary generator.
+  for (const event of events) {
+    if (event.type === 'tool_call' && event.tool) {
+      const args = event.tool.args || {};
+
+      if (['file_read', 'file_write', 'file_edit'].includes(event.tool.name)) {
+        const path = extractFilePath(args);
+        if (path) {
+          event.tool.args = { ...args, _extractedPath: path };
+        }
+      }
+
+      if (event.tool.name === 'web_fetch') {
+        const url = extractUrl(args);
+        if (url) {
+          event.tool.args = { ...args, _extractedUrl: url };
+        }
+      }
+
+      if (event.tool.name === 'shell') {
+        const command = extractCommand(args);
+        if (command) {
+          event.tool.args = { ...args, _extractedCommand: command };
+        }
+      }
+    }
+  }
+
+  return { events, errors };
+}

--- a/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/mistral-vibe.ts
@@ -163,9 +163,12 @@ function parseVibeLine(
     const fallbackName = typeof data.name === 'string' ? data.name : 'unknown';
     const content = typeof data.content === 'string' ? data.content : '';
 
-    // Vibe's role:"tool" rows have no explicit error field; use a content heuristic.
-    const lower = content.toLowerCase();
-    const success = !(lower.includes('error') || lower.includes('failed'));
+    // Vibe's role:"tool" rows have no explicit error field. Match common error
+    // prefixes after trimming leading whitespace; substring-match would false-positive
+    // on legitimate output containing the words "error" or "failed".
+    const lower = content.toLowerCase().trimStart();
+    const errorPrefixes = ['error:', 'error ', 'failed:', 'failed ', 'traceback', 'exception:', 'fatal:'];
+    const success = !errorPrefixes.some((p) => lower.startsWith(p));
 
     events.push({
       type: 'tool_result',

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -12,7 +12,8 @@ export type AgentType =
   | 'codex'
   | 'vercel-ai-gateway/opencode'
   | 'gemini'
-  | 'cursor';
+  | 'cursor'
+  | 'mistral-vibe';
 
 /**
  * Model identifier - any string accepted.


### PR DESCRIPTION
Closes #90.

Adds Mistral Vibe as a new eval agent using direct API access via `MISTRAL_API_KEY`. The implementation follows the same pattern as the Cursor and Gemini agents, with a dedicated transcript parser that normalizes Vibe's `--output streaming` JSONL (OpenAI-compatible `LLMMessage` rows) into the canonical o11y schema.

Vibe CLI requires `--prompt` to enter programmatic mode (which auto-selects the `auto-approve` profile and bypasses tool-permission prompts that would otherwise hang in sandboxed environments), `--max-turns` to bound runaway agents (defaulted to 50, overridable per-experiment via `agentOptions.maxTurns`), and `--output streaming` to emit newline-delimited JSON per message for transcript parsing. We also pass `--trust` to silence Vibe's untrusted-workdir stderr warning and honor any project-level `.vibe` config — the interactive trust dialog is already skipped when `--prompt` is set (`vibe/cli/entrypoint.py:204-206`), so this is hygiene rather than a hang fix. The model is configured via the `VIBE_ACTIVE_MODEL` env var rather than a CLI flag — Vibe overrides any config field through `VIBE_*` env vars — and telemetry, OTEL exporters, and auto-update are all disabled the same way so the sandbox stays quiet.

Installation downloads the `uv` binary directly from GitHub releases (pinned to `0.11.15`) via Node's built-in `fetch` and extracts with `tar`, rather than using upstream's `curl | sh` installer. This lets the same install chain work on both the Vercel sandbox (which has curl) and `node:*-slim` (which doesn't, and which the local Docker sandbox uses); both backends are exercised in local integration testing. `uv tool install mistral-vibe` then handles the Python 3.12 + Vibe install in one step. The install chain runs under `set -ex` so the truncated error tail identifies which stage failed if anything breaks. The default model is `mistral-medium-3.5`, which became Vibe's default in v2.9.1 (replacing the previous `devstral-2` alias).

The parser maps Vibe's native tool names (`read_file`, `write_file`, `search_replace`, `bash`, `grep`, `web_fetch`, `web_search`, `todo`, `task`) to the canonical o11y tool union, extracts file paths, shell commands, and URLs into `_extracted*` keys, emits `reasoning_content` as a separate `thinking` event, skips harness-injected (`injected: true`) rows, and pairs `role: 'tool'` results with their originating tool calls via `tool_call_id`. The tool map has been verified against a captured streaming transcript from a real run; Vibe ships no `glob` or `list_dir` tool (models use `bash` for directory ops) and `skill` falls through to `'unknown'` as a meta-tool with variable shape. The `role: 'tool'` success heuristic uses a prefix match against common error indicators (`error:`, `failed:`, `traceback`, etc.) so legitimate output mentioning those words mid-stream is not misclassified. Integration tests run end-to-end against the real Mistral API on the Docker sandbox.