### PR TITLE
Fix Codex profile reasoning_effort and verbosity defaults

### DIFF
--- a/.changeset/codex-medium-reasoning-default.md
+++ b/.changeset/codex-medium-reasoning-default.md
@@ -1,0 +1,13 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Default the Codex profile's `model_reasoning_effort` to `"medium"`.
+
+The Codex CLI's own default is `"low"`, which `gpt-5.2-codex` (the default
+Codex model) rejects with `Unsupported value: 'low' is not supported with
+the 'gpt-5.2-codex' model. Supported values are: 'medium'.`. The Codex
+adapter now writes `model_reasoning_effort` into the generated profile so
+fresh `codex exec` runs against the AI Gateway succeed out of the box.
+Callers can still override per-run via
+`model: "gpt-5.2-codex?reasoningEffort=high"`.

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ out/
 coverage/
 .vercel
 .env*.local
-vercel-agent-eval-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out/
 coverage/
 .vercel
 .env*.local
+vercel-agent-eval-*.tgz

--- a/packages/agent-eval/src/lib/agents/codex.test.ts
+++ b/packages/agent-eval/src/lib/agents/codex.test.ts
@@ -21,4 +21,39 @@ describe('generateCodexConfig', () => {
     expect(config).not.toContain('profile = "default"');
     expect(config).not.toContain('[profiles.default]');
   });
+
+  it('defaults model_reasoning_effort and verbosity to "medium" for AI Gateway', () => {
+    // gpt-5.2-codex rejects the Codex CLI's "low" defaults for both
+    // reasoning.effort and text.verbosity — see comment on
+    // DEFAULT_REASONING_EFFORT / DEFAULT_MODEL_VERBOSITY in codex.ts.
+    const config = generateCodexConfig('openai/gpt-5.2-codex', true);
+
+    expect(config).toContain('model_reasoning_effort = "medium"');
+    expect(config).toContain('model_verbosity = "medium"');
+    expect(config).not.toContain('model_reasoning_effort = "low"');
+    expect(config).not.toContain('model_verbosity = "low"');
+  });
+
+  it('defaults model_reasoning_effort and verbosity to "medium" for direct OpenAI', () => {
+    const config = generateCodexConfig('openai/gpt-5.2-codex', false);
+
+    expect(config).toContain('model_reasoning_effort = "medium"');
+    expect(config).toContain('model_verbosity = "medium"');
+    expect(config).not.toContain('model_reasoning_effort = "low"');
+    expect(config).not.toContain('model_verbosity = "low"');
+  });
+
+  it('honors caller-provided reasoning effort for AI Gateway', () => {
+    const config = generateCodexConfig('openai/gpt-5.2-codex', true, 'high');
+
+    expect(config).toContain('model_reasoning_effort = "high"');
+    expect(config).not.toContain('model_reasoning_effort = "medium"');
+  });
+
+  it('honors caller-provided reasoning effort for direct OpenAI', () => {
+    const config = generateCodexConfig('openai/gpt-5.2-codex', false, 'low');
+
+    expect(config).toContain('model_reasoning_effort = "low"');
+    expect(config).not.toContain('model_reasoning_effort = "medium"');
+  });
 });

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -76,15 +76,46 @@ function extractTranscriptFromOutput(output: string): string | undefined {
 }
 
 /**
- * Generate Codex profile config content.
+ * Default reasoning effort and verbosity baked into the generated Codex
+ * profile.
+ *
+ * The Codex CLI itself defaults both `model_reasoning_effort` and
+ * `model_verbosity` to `"low"`, but the default Codex model
+ * (`gpt-5.2-codex`) only accepts `"medium"` for both — so an out-of-the-box
+ * `codex exec` against the AI Gateway fails with:
+ *   "Unsupported value: 'low' is not supported with the 'gpt-5.2-codex'
+ *    model. Supported values are: 'medium'."
+ * (the error covers both the `reasoning.effort` and `text.verbosity` request
+ * parameters, depending on which the model rejected first).
+ *
+ * `"medium"` is also a valid value for the non-codex GPT-5.x models, so it's
+ * a safe default. Callers can override reasoning effort per-run via
+ * `model: "gpt-5.2-codex?reasoningEffort=high"`.
  */
-export function generateCodexConfig(model: string, useVercelAiGateway: boolean): string {
+const DEFAULT_REASONING_EFFORT = 'medium';
+const DEFAULT_MODEL_VERBOSITY = 'medium';
+
+/**
+ * Generate Codex profile config content.
+ *
+ * `reasoningEffort` and `model_verbosity` are written into the profile so a
+ * fresh `codex exec` doesn't pick up the CLI defaults of `"low"`, which are
+ * rejected by `gpt-5.2-codex`. Defaults to `"medium"` when `reasoningEffort`
+ * is omitted.
+ */
+export function generateCodexConfig(
+  model: string,
+  useVercelAiGateway: boolean,
+  reasoningEffort: string = DEFAULT_REASONING_EFFORT,
+): string {
   if (useVercelAiGateway) {
     // AI Gateway uses prefixed model names like "openai/gpt-5.2-codex"
     const fullModel = model.includes('/') ? model : `openai/${model}`;
     return `# Codex configuration for Vercel AI Gateway
 model_provider = "vercel"
 model = "${fullModel}"
+model_reasoning_effort = "${reasoningEffort}"
+model_verbosity = "${DEFAULT_MODEL_VERBOSITY}"
 
 [model_providers.vercel]
 name = "Vercel AI Gateway"
@@ -98,6 +129,8 @@ wire_api = "responses"
     return `# Direct OpenAI API configuration
 model_provider = "openai"
 model = "${directModel}"
+model_reasoning_effort = "${reasoningEffort}"
+model_verbosity = "${DEFAULT_MODEL_VERBOSITY}"
 `;
   }
 }
@@ -217,8 +250,11 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
       // Create Codex profile config. Recent Codex CLI versions reject the old
       // top-level `profile = "default"` key in config.toml and instead load
       // `$CODEX_HOME/<profile>.config.toml` when `--profile <profile>` is set.
+      // The reasoning_effort is baked into the profile (rather than passed via
+      // -c at runtime) so the value is visible in saved configs and so the
+      // CLI's own default of "low" can't sneak through.
       await sandbox.runShell('mkdir -p ~/.codex');
-      const configContent = generateCodexConfig(baseModel, useVercelAiGateway);
+      const configContent = generateCodexConfig(baseModel, useVercelAiGateway, reasoningEffort);
       await sandbox.runShell(`cat > ~/.codex/default.config.toml << 'EOF'
 ${configContent}
 EOF`);
@@ -229,12 +265,18 @@ EOF`);
       // Build Codex CLI command
       const envVarToSet = useVercelAiGateway ? AI_GATEWAY.apiKeyEnvVar : OPENAI_DIRECT.apiKeyEnvVar;
       const escapedPrompt = options.prompt.replace(/'/g, "'\\''");
-      const reasoningFlag = reasoningEffort ? ` -c model_reasoning_effort="${reasoningEffort}"` : '';
       // Direct OpenAI API needs unprefixed model names (e.g. "gpt-5.2-codex" not "openai/gpt-5.2-codex")
       const cliModel = useVercelAiGateway ? baseModel : (baseModel.includes('/') ? baseModel.split('/').pop()! : baseModel);
+      // Pass reasoning effort and verbosity via -c too; CLI flags have the
+      // highest precedence and we've observed Codex CLI silently falling back
+      // to its "low" defaults for both fields even when the profile sets them.
+      // Both default to "medium" for compatibility with gpt-5.2-codex.
+      const effectiveReasoningEffort = reasoningEffort ?? DEFAULT_REASONING_EFFORT;
+      const reasoningFlag = ` -c model_reasoning_effort="${effectiveReasoningEffort}"`;
+      const verbosityFlag = ` -c model_verbosity="${DEFAULT_MODEL_VERBOSITY}"`;
       // codex login sets up bearer auth for the CLI; the built-in openai provider requires it
       const codexResult = await sandbox.runShell(
-        `echo '${options.apiKey}' | codex login --with-api-key && codex exec --profile default --model ${cliModel} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag} '${escapedPrompt}'`,
+        `echo '${options.apiKey}' | codex login --with-api-key && codex exec --profile default --model ${cliModel} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag}${verbosityFlag} '${escapedPrompt}'`,
         { [envVarToSet]: options.apiKey, ...neutralWorkspace.env }
       );
 


### PR DESCRIPTION
## Summary

The Codex CLI defaults both `model_reasoning_effort` and `model_verbosity`
to `"low"`, but `gpt-5.2-codex` (the default Codex model) only accepts
`"medium"` for both. Out-of-the-box `codex exec` against the AI Gateway
fails with:

> Unsupported value: 'low' is not supported with the 'gpt-5.2-codex' model. Supported values are: 'medium'.

The error covers both the `reasoning.effort` and `text.verbosity` request
parameters, depending on which the model rejects first.

This PR sets both fields to `"medium"` in two places:

1. The generated profile config in `~/.codex/default.config.toml` —
   ensures the value is captured for any tool that inspects the config.
2. Explicit `-c` flags on `codex exec` — CLI flags have the highest
   precedence and we observed the profile-only setting being silently
   overridden by the CLI's `"low"` default in some Codex versions.

`generateCodexConfig` now accepts an optional `reasoningEffort` argument
so callers can still override per-run via
`model: "gpt-5.2-codex?reasoningEffort=high"`.

## Test plan

- [x] Unit tests cover `"medium"` defaults and explicit-override paths
      for both AI Gateway and direct OpenAI configs (6 cases in
      `src/lib/agents/codex.test.ts`).
- [x] `npm test` — 184 passed | 14 skipped.
- [x] `npm run lint` clean.
- [x] **End-to-end against the Vercel AI Gateway**: verified by linking
      the patched build into [`a0-local`](https://github.com/vercel-labs/a0-local)
      and running a one-prompt Codex smoke. Without the fix, `turn.failed`
      with the `Unsupported value: 'low'` error within ~10s. With the fix,
      a real response is produced in ~31s.

## Notes

- Adds `vercel-agent-eval-*.tgz` to `.gitignore` so local `npm pack`
  artifacts don't leak into commits.
- Stacks well with the recent
  [#138 / #139 Codex profile-config fix](https://github.com/vercel-labs/agent-eval/pull/138)
  — that PR fixed the legacy `profile = "default"` rejection; this one
  fixes the next layer (reasoning effort + verbosity defaults) so Codex
  actually completes a turn.