### PR TITLE
Enable source-capable web tools for agent runs

### DIFF
--- a/.changeset/witty-cups-think.md
+++ b/.changeset/witty-cups-think.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Enable source-capable web tools for recommendation eval agent runs.

--- a/packages/agent-eval/src/lib/agents/claude-code.test.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createClaudeCodeAgent } from './claude-code.js';
+import { buildClaudeCodeCliArgs, createClaudeCodeAgent } from './claude-code.js';
 
 describe('createClaudeCodeAgent', () => {
   const originalEnv = process.env;
@@ -34,6 +34,29 @@ describe('createClaudeCodeAgent', () => {
       process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
       const agent = createClaudeCodeAgent({ useVercelAiGateway: true });
       expect(agent.getApiKeyEnvVar()).toBe('AI_GATEWAY_API_KEY');
+    });
+  });
+
+  describe('buildClaudeCodeCliArgs', () => {
+    it('allows web search and fetch tools for source collection', () => {
+      const args = buildClaudeCodeCliArgs({
+        model: 'opus',
+        prompt: 'where should this run?',
+        timeout: 60_000,
+        apiKey: 'test-key',
+        validation: 'none',
+      });
+
+      expect(args).toEqual([
+        '--print',
+        '--model',
+        'opus',
+        '--dangerously-skip-permissions',
+        '--allowedTools',
+        'WebSearch',
+        'WebFetch',
+        'where should this run?',
+      ]);
     });
   });
 });

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -27,6 +27,22 @@ import {
 /** Union type for sandbox implementations */
 type AnySandbox = SandboxManager | DockerSandboxManager;
 
+export function buildClaudeCodeCliArgs(options: AgentRunOptions): string[] {
+  const cliArgs = [
+    '--print',
+    '--model',
+    options.model,
+    '--dangerously-skip-permissions',
+    '--allowedTools',
+    'WebSearch',
+    'WebFetch',
+  ];
+  const effort = options.agentOptions?.effort as string | undefined;
+  if (effort) cliArgs.push('--effort', effort);
+  cliArgs.push(options.prompt);
+  return cliArgs;
+}
+
 /**
  * Capture the Claude Code transcript from the sandbox.
  * Claude Code stores transcripts at ~/.claude/projects/-{workdir}/{session-id}.jsonl
@@ -201,13 +217,9 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         };
       }
 
-      // Build CLI arguments
-      const cliArgs = ['--print', '--model', options.model, '--dangerously-skip-permissions'];
-      const effort = options.agentOptions?.effort as string | undefined;
-      if (effort) {
-        cliArgs.push('--effort', effort);
-      }
-      cliArgs.push(options.prompt);
+      // Build CLI arguments. Recommendation evals need source visibility, so
+      // allow Claude Code's native web search/fetch tools explicitly.
+      const cliArgs = buildClaudeCodeCliArgs(options);
 
       // Run Claude Code with appropriate authentication
       const claudeResult = await sandbox.runCommand(

--- a/packages/agent-eval/src/lib/agents/codex.test.ts
+++ b/packages/agent-eval/src/lib/agents/codex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateCodexConfig } from './codex.js';
+import { buildCodexExecCommand, generateCodexConfig } from './codex.js';
 
 describe('generateCodexConfig', () => {
   it('writes AI Gateway settings as a Codex profile config', () => {
@@ -20,5 +20,15 @@ describe('generateCodexConfig', () => {
     expect(config).toContain('model = "gpt-5.2-codex"');
     expect(config).not.toContain('profile = "default"');
     expect(config).not.toContain('[profiles.default]');
+  });
+
+  it('enables web search in non-interactive runs', () => {
+    const command = buildCodexExecCommand({
+      apiKey: 'test-key',
+      cliModel: 'openai/gpt-5.2-codex',
+      prompt: 'where should this run?',
+    });
+
+    expect(command).toContain('codex exec --search --profile default');
   });
 });

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -75,6 +75,17 @@ function extractTranscriptFromOutput(output: string): string | undefined {
   return lines.join('\n');
 }
 
+export function buildCodexExecCommand(input: {
+  apiKey: string;
+  cliModel: string;
+  prompt: string;
+  reasoningEffort?: string;
+}): string {
+  const escapedPrompt = input.prompt.replace(/'/g, "'\\''");
+  const reasoningFlag = input.reasoningEffort ? ` -c model_reasoning_effort="${input.reasoningEffort}"` : '';
+  return `echo '${input.apiKey}' | codex login --with-api-key && codex exec --search --profile default --model ${input.cliModel} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag} '${escapedPrompt}'`;
+}
+
 /**
  * Generate Codex profile config content.
  */
@@ -228,13 +239,11 @@ EOF`);
 
       // Build Codex CLI command
       const envVarToSet = useVercelAiGateway ? AI_GATEWAY.apiKeyEnvVar : OPENAI_DIRECT.apiKeyEnvVar;
-      const escapedPrompt = options.prompt.replace(/'/g, "'\\''");
-      const reasoningFlag = reasoningEffort ? ` -c model_reasoning_effort="${reasoningEffort}"` : '';
       // Direct OpenAI API needs unprefixed model names (e.g. "gpt-5.2-codex" not "openai/gpt-5.2-codex")
       const cliModel = useVercelAiGateway ? baseModel : (baseModel.includes('/') ? baseModel.split('/').pop()! : baseModel);
       // codex login sets up bearer auth for the CLI; the built-in openai provider requires it
       const codexResult = await sandbox.runShell(
-        `echo '${options.apiKey}' | codex login --with-api-key && codex exec --profile default --model ${cliModel} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag} '${escapedPrompt}'`,
+        buildCodexExecCommand({ apiKey: options.apiKey, cliModel, prompt: options.prompt, reasoningEffort }),
         { [envVarToSet]: options.apiKey, ...neutralWorkspace.env }
       );
 

--- a/packages/agent-eval/src/lib/agents/opencode.test.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { generateOpenCodeConfig } from './opencode.js';
+
+describe('generateOpenCodeConfig', () => {
+  it('allows web fetch and web search tools for source collection', () => {
+    const config = JSON.parse(generateOpenCodeConfig(undefined, 'test-key'));
+
+    expect(config.permission.webfetch).toBe('allow');
+    expect(config.permission.websearch).toBe('allow');
+  });
+});

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -70,7 +70,7 @@ export interface OpenCodeProviderConfig {
  * Generate OpenCode config file content.
  * Configures the Vercel AI Gateway provider, plus any additional providers.
  */
-function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>, apiKey?: string, timeoutMs?: number): string {
+export function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>, apiKey?: string, timeoutMs?: number): string {
   const vercelBase: Record<string, unknown> = {
     options: {
       apiKey: apiKey || '{env:AI_GATEWAY_API_KEY}',
@@ -95,6 +95,8 @@ function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProvider
       write: 'allow',
       edit: 'allow',
       bash: 'allow',
+      webfetch: 'allow',
+      websearch: 'allow',
     },
   }, null, 2);
 }
@@ -247,6 +249,7 @@ export function createOpenCodeAgent(): Agent {
           {
             env: {
               [AI_GATEWAY.apiKeyEnvVar]: options.apiKey,
+              OPENCODE_ENABLE_EXA: '1',
               ...neutralWorkspace.env,
             },
           }


### PR DESCRIPTION
Enables source-capable web tools during agent eval runs so recommendation answers can produce useful citation/source data.
- Claude Code: allow `WebSearch` and `WebFetch`
- Codex: pass `--search` to `codex exec`
- OpenCode: enable Exa web search with `OPENCODE_ENABLE_EXA=1` and allow `webfetch`/`websearch`
- Add focused adapter tests for the source-tool settings
- Add a patch changeset
## Why
`a0-local` source extraction depends on agents actually using web/search/fetch tools or emitting cited URLs. Current eval runs show very sparse source data, especially for Codex and OpenCode. This makes the source/citation signal too weak for content diagnosis and trend analysis.