### PR TITLE
Use native model defaults when model is omitted

### DIFF
--- a/.changeset/native-default-model-policy.md
+++ b/.changeset/native-default-model-policy.md
@@ -1,5 +1,5 @@
 ---
-"@vercel/agent-eval": minor
+"@vercel/agent-eval": major
 ---
 
-Add an opt-in `modelPolicy: "native-default"` mode that runs agent CLIs without passing a model override and records observed runtime model metadata when available.
+Change omitted `model` config to use the underlying agent CLI's native default instead of agent-eval's hardcoded adapter defaults, and record observed runtime model metadata when available.

--- a/.changeset/native-default-model-policy.md
+++ b/.changeset/native-default-model-policy.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add an opt-in `modelPolicy: "native-default"` mode that runs agent CLIs without passing a model override and records observed runtime model metadata when available.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ const config: ExperimentConfig = {
   // Provide an array to run the same experiment across multiple models.
   model: 'opus',
 
+  // Model selection policy (default: 'agent-default')
+  // 'agent-default' preserves agent-eval's adapter defaults.
+  // 'native-default' does not pass --model and lets the underlying CLI choose.
+  modelPolicy: 'agent-default',
+
   // How many times to run each eval (default: 1)
   runs: 10,
 
@@ -269,6 +274,25 @@ const config: ExperimentConfig = {
   runs: 10,
 };
 ```
+
+### Native agent defaults
+
+By default, omitted `model` preserves existing agent-eval behavior: each adapter
+resolves its configured default model. To run the agent the way a user would when
+they do not pass a model, opt into native CLI defaults:
+
+```typescript
+const config: ExperimentConfig = {
+  agent: 'vercel-ai-gateway/claude-code',
+  modelPolicy: 'native-default',
+  runs: 10,
+};
+```
+
+With `modelPolicy: 'native-default'`, omit `model`. Agent Eval does not pass a
+model override to the CLI. Results use `modelPolicy: 'native-default'`,
+`requestedModel` is omitted, and `observedModel` is populated when the agent CLI
+exposes the runtime model in its transcript or logs.
 
 ### OpenCode model format
 

--- a/README.md
+++ b/README.md
@@ -175,14 +175,9 @@ const config: ExperimentConfig = {
   // Required: which agent to use
   agent: 'vercel-ai-gateway/claude-code',
 
-  // Model to use (defaults vary by agent)
+  // Model to use. Omit this to use the underlying agent CLI's native default.
   // Provide an array to run the same experiment across multiple models.
   model: 'opus',
-
-  // Model selection policy (default: 'agent-default')
-  // 'agent-default' preserves agent-eval's adapter defaults.
-  // 'native-default' does not pass --model and lets the underlying CLI choose.
-  modelPolicy: 'agent-default',
 
   // How many times to run each eval (default: 1)
   runs: 10,
@@ -277,22 +272,20 @@ const config: ExperimentConfig = {
 
 ### Native agent defaults
 
-By default, omitted `model` preserves existing agent-eval behavior: each adapter
-resolves its configured default model. To run the agent the way a user would when
-they do not pass a model, opt into native CLI defaults:
+When `model` is omitted, Agent Eval does not pass a model override. The
+underlying agent CLI chooses the same native default it would use for a normal
+user run:
 
 ```typescript
 const config: ExperimentConfig = {
   agent: 'vercel-ai-gateway/claude-code',
-  modelPolicy: 'native-default',
   runs: 10,
 };
 ```
 
-With `modelPolicy: 'native-default'`, omit `model`. Agent Eval does not pass a
-model override to the CLI. Results use `modelPolicy: 'native-default'`,
-`requestedModel` is omitted, and `observedModel` is populated when the agent CLI
-exposes the runtime model in its transcript or logs.
+Results use `modelPolicy: 'native-default'`, `requestedModel` is omitted, and
+`observedModel` is populated when the agent CLI exposes the runtime model in its
+transcript or logs. Provide `model` to force a specific model.
 
 ### OpenCode model format
 

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -8,6 +8,7 @@
 export type {
   AgentType,
   ModelTier,
+  ModelPolicy,
   EvalFilter,
   ValidationMode,
   BrandConfig,
@@ -28,7 +29,7 @@ export type {
 } from './lib/types.js';
 
 // Re-export constants
-export { REQUIRED_EVAL_FILES, EXCLUDED_FILES } from './lib/types.js';
+export { REQUIRED_EVAL_FILES, EXCLUDED_FILES, NATIVE_DEFAULT_MODEL } from './lib/types.js';
 
 // Re-export config utilities
 export {

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -112,7 +112,8 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
       const config = await loadConfig(configPath);
 
       expect(config.agent).toBe('vercel-ai-gateway/claude-code');
-      expect(config.model).toBe('opus');
+      expect(config.model).toBe('native-default');
+      expect(config.modelPolicy).toBe('native-default');
     });
 
     it('can load Codex experiment config from generated project', async () => {
@@ -122,7 +123,8 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
       const config = await loadConfig(configPath);
 
       expect(config.agent).toBe('vercel-ai-gateway/codex');
-      expect(config.model).toBe('openai/gpt-5.2-codex');
+      expect(config.model).toBe('native-default');
+      expect(config.modelPolicy).toBe('native-default');
     });
   });
 
@@ -1386,7 +1388,7 @@ test('greet exists', () => {
       expect(result).toContain('DRY RUN');
       expect(result).toContain('add-greeting');
       expect(result).toContain('Agent: vercel-ai-gateway/codex');
-      expect(result).toContain('Model: openai/gpt-5.2-codex');
+      expect(result).toContain('Model: native-default');
     });
   });
 });

--- a/packages/agent-eval/src/lib/agents/claude-code.test.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createClaudeCodeAgent } from './claude-code.js';
+import { createClaudeCodeAgent, extractObservedModelFromClaudeTranscript } from './claude-code.js';
 
 describe('createClaudeCodeAgent', () => {
   const originalEnv = process.env;
@@ -34,6 +34,18 @@ describe('createClaudeCodeAgent', () => {
       process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token';
       const agent = createClaudeCodeAgent({ useVercelAiGateway: true });
       expect(agent.getApiKeyEnvVar()).toBe('AI_GATEWAY_API_KEY');
+    });
+  });
+
+  describe('observed model extraction', () => {
+    it('extracts the last assistant model from the transcript', () => {
+      const transcript = [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+        JSON.stringify({ type: 'assistant', message: { model: 'claude-sonnet-4-6' } }),
+        JSON.stringify({ type: 'assistant', message: { model: 'claude-opus-4-7' } }),
+      ].join('\n');
+
+      expect(extractObservedModelFromClaudeTranscript(transcript)).toBe('claude-opus-4-7');
     });
   });
 });

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -57,6 +57,25 @@ async function captureTranscript(sandbox: AnySandbox): Promise<string | undefine
   }
 }
 
+export function extractObservedModelFromClaudeTranscript(transcript: string | undefined): string | undefined {
+  if (!transcript) return undefined;
+
+  let observedModel: string | undefined;
+  for (const line of transcript.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line) as { message?: { model?: unknown } };
+      if (typeof event.message?.model === 'string') {
+        observedModel = event.message.model;
+      }
+    } catch {
+      // Ignore non-JSON transcript lines.
+    }
+  }
+
+  return observedModel;
+}
+
 /**
  * Create Claude Code agent with specified authentication method.
  */
@@ -202,7 +221,11 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
       }
 
       // Build CLI arguments
-      const cliArgs = ['--print', '--model', options.model, '--dangerously-skip-permissions'];
+      const cliArgs = ['--print'];
+      if (options.model) {
+        cliArgs.push('--model', options.model);
+      }
+      cliArgs.push('--dangerously-skip-permissions');
       const effort = options.agentOptions?.effort as string | undefined;
       if (effort) {
         cliArgs.push('--effort', effort);
@@ -222,6 +245,7 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
 
       if (claudeResult.exitCode !== 0) {
         await captureTranscriptBestEffort();
+        const observedModel = extractObservedModelFromClaudeTranscript(transcript);
         // Extract meaningful error from output (last few lines usually contain the error)
         const errorLines = agentOutput.trim().split('\n').slice(-5).join('\n');
         hasReturned = true;
@@ -232,11 +256,13 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
           error: errorLines || `Claude Code exited with code ${claudeResult.exitCode}`,
           duration: Date.now() - startTime,
           sandboxId: sandbox.sandboxId,
+          observedModel,
         };
       }
 
       // Capture transcript before validation when available
       await captureTranscriptBestEffort();
+      const observedModel = extractObservedModelFromClaudeTranscript(transcript);
 
       if (options.validation !== 'none') {
         // Upload test files for validation
@@ -266,6 +292,7 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
         sandboxId: sandbox.sandboxId,
         generatedFiles,
         deletedFiles,
+        observedModel,
       };
     } catch (error) {
       await captureTranscriptBestEffort();

--- a/packages/agent-eval/src/lib/agents/codex.test.ts
+++ b/packages/agent-eval/src/lib/agents/codex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateCodexConfig } from './codex.js';
+import { extractCodexThreadId, extractObservedModelFromCodexSession, generateCodexConfig } from './codex.js';
 
 describe('generateCodexConfig', () => {
   it('writes AI Gateway settings as a Codex profile config', () => {
@@ -55,5 +55,43 @@ describe('generateCodexConfig', () => {
 
     expect(config).toContain('model_reasoning_effort = "low"');
     expect(config).not.toContain('model_reasoning_effort = "medium"');
+  });
+
+  it('omits model and reasoning overrides for native-default AI Gateway runs', () => {
+    const config = generateCodexConfig(undefined, true);
+
+    expect(config).toContain('model_provider = "vercel"');
+    expect(config).not.toMatch(/^model =/m);
+    expect(config).not.toContain('model_reasoning_effort');
+    expect(config).not.toContain('model_verbosity');
+  });
+
+  it('omits model and reasoning overrides for native-default direct OpenAI runs', () => {
+    const config = generateCodexConfig(undefined, false);
+
+    expect(config).toContain('model_provider = "openai"');
+    expect(config).not.toMatch(/^model =/m);
+    expect(config).not.toContain('model_reasoning_effort');
+    expect(config).not.toContain('model_verbosity');
+  });
+});
+
+describe('Codex observed model extraction', () => {
+  it('extracts the thread id from Codex JSON output', () => {
+    const output = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-123' }),
+      JSON.stringify({ type: 'turn.started' }),
+    ].join('\n');
+
+    expect(extractCodexThreadId(output)).toBe('thread-123');
+  });
+
+  it('extracts the observed model from the Codex session transcript', () => {
+    const transcript = [
+      JSON.stringify({ type: 'session_meta', payload: { model_provider: 'vercel' } }),
+      JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.5' } }),
+    ].join('\n');
+
+    expect(extractObservedModelFromCodexSession(transcript)).toBe('gpt-5.5');
   });
 });

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -75,6 +75,62 @@ function extractTranscriptFromOutput(output: string): string | undefined {
   return lines.join('\n');
 }
 
+export function extractCodexThreadId(output: string): string | undefined {
+  for (const line of output.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line) as { type?: string; thread_id?: unknown };
+      if (event.type === 'thread.started' && typeof event.thread_id === 'string') {
+        return event.thread_id;
+      }
+    } catch {
+      // Ignore non-JSON output lines.
+    }
+  }
+
+  return undefined;
+}
+
+export function extractObservedModelFromCodexSession(transcript: string | undefined): string | undefined {
+  if (!transcript) return undefined;
+
+  let observedModel: string | undefined;
+  for (const line of transcript.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line) as {
+        type?: string;
+        payload?: { model?: unknown; collaboration_mode?: { settings?: { model?: unknown } } };
+      };
+      const model = event.payload?.model ?? event.payload?.collaboration_mode?.settings?.model;
+      if (event.type === 'turn_context' && typeof model === 'string') {
+        observedModel = model;
+      }
+    } catch {
+      // Ignore non-JSON transcript lines.
+    }
+  }
+
+  return observedModel;
+}
+
+async function captureCodexSessionTranscript(sandbox: AnySandbox, threadId: string | undefined): Promise<string | undefined> {
+  try {
+    const escapedThreadId = threadId?.replace(/'/g, "'\\''");
+    const command = escapedThreadId
+      ? `find ~/.codex/sessions -type f -name '*${escapedThreadId}*.jsonl' -print 2>/dev/null | head -1`
+      : `find ~/.codex/sessions -type f -name '*.jsonl' -print 2>/dev/null | sort | tail -1`;
+    const findResult = await sandbox.runShell(command);
+    if (findResult.exitCode !== 0 || !findResult.stdout.trim()) {
+      return undefined;
+    }
+
+    return await sandbox.readFile(findResult.stdout.trim());
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Default reasoning effort and verbosity baked into the generated Codex
  * profile.
@@ -104,19 +160,17 @@ const DEFAULT_MODEL_VERBOSITY = 'medium';
  * is omitted.
  */
 export function generateCodexConfig(
-  model: string,
+  model: string | undefined,
   useVercelAiGateway: boolean,
-  reasoningEffort: string = DEFAULT_REASONING_EFFORT,
+  reasoningEffort?: string,
 ): string {
   if (useVercelAiGateway) {
-    // AI Gateway uses prefixed model names like "openai/gpt-5.2-codex"
-    const fullModel = model.includes('/') ? model : `openai/${model}`;
+    // AI Gateway uses prefixed model names like "openai/gpt-5.2-codex".
+    // Native-default runs intentionally omit model and reasoning overrides.
+    const fullModel = model ? (model.includes('/') ? model : `openai/${model}`) : undefined;
     return `# Codex configuration for Vercel AI Gateway
 model_provider = "vercel"
-model = "${fullModel}"
-model_reasoning_effort = "${reasoningEffort}"
-model_verbosity = "${DEFAULT_MODEL_VERBOSITY}"
-
+${fullModel ? `model = "${fullModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}
 [model_providers.vercel]
 name = "Vercel AI Gateway"
 base_url = "${AI_GATEWAY.openAiBaseUrl}"
@@ -124,14 +178,12 @@ env_key = "${AI_GATEWAY.apiKeyEnvVar}"
 wire_api = "responses"
 `;
   } else {
-    // Direct OpenAI API — use the built-in "openai" provider (no custom provider needed)
-    const directModel = model.includes('/') ? model.split('/').pop()! : model;
+    // Direct OpenAI API — use the built-in "openai" provider (no custom provider needed).
+    // Native-default runs intentionally omit model and reasoning overrides.
+    const directModel = model ? (model.includes('/') ? model.split('/').pop()! : model) : undefined;
     return `# Direct OpenAI API configuration
 model_provider = "openai"
-model = "${directModel}"
-model_reasoning_effort = "${reasoningEffort}"
-model_verbosity = "${DEFAULT_MODEL_VERBOSITY}"
-`;
+${directModel ? `model = "${directModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}`;
   }
 }
 
@@ -244,15 +296,18 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
         throw new Error(`Codex CLI install failed: ${cliInstall.stderr}`);
       }
 
-      // Parse model string for query parameters (e.g. "gpt-5.2-codex?reasoningEffort=high")
-      const { model: baseModel, reasoningEffort } = parseModelString(options.model);
+      // Parse model string for query parameters (e.g. "gpt-5.2-codex?reasoningEffort=high").
+      // Native-default runs intentionally leave the model undefined.
+      const parsedModel = options.model ? parseModelString(options.model) : { model: undefined, reasoningEffort: undefined };
+      const { model: baseModel, reasoningEffort } = parsedModel;
 
       // Create Codex profile config. Recent Codex CLI versions reject the old
       // top-level `profile = "default"` key in config.toml and instead load
       // `$CODEX_HOME/<profile>.config.toml` when `--profile <profile>` is set.
-      // The reasoning_effort is baked into the profile (rather than passed via
-      // -c at runtime) so the value is visible in saved configs and so the
-      // CLI's own default of "low" can't sneak through.
+      // For explicit models, reasoning_effort is baked into the profile (rather
+      // than passed via -c at runtime) so the value is visible in saved configs
+      // and so the CLI's own default of "low" can't sneak through. For
+      // native-default runs we omit these settings to match the CLI's behavior.
       await sandbox.runShell('mkdir -p ~/.codex');
       const configContent = generateCodexConfig(baseModel, useVercelAiGateway, reasoningEffort);
       await sandbox.runShell(`cat > ~/.codex/default.config.toml << 'EOF'
@@ -266,22 +321,28 @@ EOF`);
       const envVarToSet = useVercelAiGateway ? AI_GATEWAY.apiKeyEnvVar : OPENAI_DIRECT.apiKeyEnvVar;
       const escapedPrompt = options.prompt.replace(/'/g, "'\\''");
       // Direct OpenAI API needs unprefixed model names (e.g. "gpt-5.2-codex" not "openai/gpt-5.2-codex")
-      const cliModel = useVercelAiGateway ? baseModel : (baseModel.includes('/') ? baseModel.split('/').pop()! : baseModel);
+      const cliModel = baseModel
+        ? (useVercelAiGateway ? baseModel : (baseModel.includes('/') ? baseModel.split('/').pop()! : baseModel))
+        : undefined;
+      const modelFlag = cliModel ? ` --model ${cliModel}` : '';
       // Pass reasoning effort and verbosity via -c too; CLI flags have the
       // highest precedence and we've observed Codex CLI silently falling back
       // to its "low" defaults for both fields even when the profile sets them.
       // Both default to "medium" for compatibility with gpt-5.2-codex.
-      const effectiveReasoningEffort = reasoningEffort ?? DEFAULT_REASONING_EFFORT;
-      const reasoningFlag = ` -c model_reasoning_effort="${effectiveReasoningEffort}"`;
-      const verbosityFlag = ` -c model_verbosity="${DEFAULT_MODEL_VERBOSITY}"`;
+      const effectiveReasoningEffort = baseModel ? (reasoningEffort ?? DEFAULT_REASONING_EFFORT) : undefined;
+      const reasoningFlag = effectiveReasoningEffort ? ` -c model_reasoning_effort="${effectiveReasoningEffort}"` : '';
+      const verbosityFlag = baseModel ? ` -c model_verbosity="${DEFAULT_MODEL_VERBOSITY}"` : '';
       // codex login sets up bearer auth for the CLI; the built-in openai provider requires it
       const codexResult = await sandbox.runShell(
-        `echo '${options.apiKey}' | codex login --with-api-key && codex exec --profile default --model ${cliModel} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag}${verbosityFlag} '${escapedPrompt}'`,
+        `echo '${options.apiKey}' | codex login --with-api-key && codex exec --profile default${modelFlag} --dangerously-bypass-approvals-and-sandbox --json --skip-git-repo-check${reasoningFlag}${verbosityFlag} '${escapedPrompt}'`,
         { [envVarToSet]: options.apiKey, ...neutralWorkspace.env }
       );
 
       agentOutput = codexResult.stdout + codexResult.stderr;
       transcript = extractTranscriptFromOutput(agentOutput);
+      const threadId = extractCodexThreadId(agentOutput);
+      const sessionTranscript = await captureCodexSessionTranscript(sandbox, threadId);
+      const observedModel = extractObservedModelFromCodexSession(sessionTranscript);
 
       if (codexResult.exitCode !== 0) {
         // Extract meaningful error from output (last few lines usually contain the error)
@@ -293,6 +354,7 @@ EOF`);
           error: errorLines || `Codex CLI exited with code ${codexResult.exitCode}`,
           duration: Date.now() - startTime,
           sandboxId: sandbox.sandboxId,
+          observedModel,
         };
       }
 
@@ -323,6 +385,7 @@ EOF`);
         sandboxId: sandbox.sandboxId,
         generatedFiles,
         deletedFiles,
+        observedModel,
       };
     } catch (error) {
       // Check if this was an abort

--- a/packages/agent-eval/src/lib/agents/cursor.ts
+++ b/packages/agent-eval/src/lib/agents/cursor.ts
@@ -163,17 +163,22 @@ export function createCursorAgent(): Agent {
         // --print: non-interactive mode (required for scripts/headless)
         // --force: auto-approve all tool operations
         // --output-format stream-json: structured JSONL transcript (only works with --print)
+        const cursorArgs = [
+          options.prompt,
+          '--print',
+          '--force',
+        ];
+        if (options.model) {
+          cursorArgs.push('--model', options.model);
+        }
+        cursorArgs.push(
+          '--output-format',
+          'stream-json',
+        );
+
         const cursorResult = await sandbox.runCommand(
           'agent',
-          [
-            options.prompt,
-            '--print',
-            '--force',
-            '--model',
-            options.model,
-            '--output-format',
-            'stream-json',
-          ],
+          cursorArgs,
           {
             env: {
               [CURSOR_DIRECT.apiKeyEnvVar]: options.apiKey,

--- a/packages/agent-eval/src/lib/agents/gemini.ts
+++ b/packages/agent-eval/src/lib/agents/gemini.ts
@@ -163,18 +163,23 @@ export function createGeminiAgent(): Agent {
 
         // Run Gemini CLI with direct API access
         // Using stream-json format for detailed event transcript (similar to Codex's --json)
+        const geminiArgs = [
+          '--prompt',
+          options.prompt,
+        ];
+        if (options.model) {
+          geminiArgs.push('--model', options.model);
+        }
+        geminiArgs.push(
+          '--approval-mode',
+          'yolo',
+          '--output-format',
+          'stream-json',
+        );
+
         const geminiResult = await sandbox.runCommand(
           'gemini',
-          [
-            '--prompt',
-            options.prompt,
-            '--model',
-            options.model,
-            '--approval-mode',
-            'yolo',
-            '--output-format',
-            'stream-json',
-          ],
+          geminiArgs,
           {
             env: {
               [GEMINI_DIRECT.apiKeyEnvVar]: options.apiKey,

--- a/packages/agent-eval/src/lib/agents/opencode.test.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { extractObservedModelFromOpenCodeOutput } from './opencode.js';
+
+describe('OpenCode observed model extraction', () => {
+  it('extracts the primary build model from printed logs', () => {
+    const output = [
+      'INFO service=llm providerID=vercel modelID=anthropic/claude-haiku-4.5 small=true agent=title mode=primary stream',
+      'INFO service=llm providerID=vercel modelID=openai/gpt-5.5 small=false agent=build mode=primary stream',
+    ].join('\n');
+
+    expect(extractObservedModelFromOpenCodeOutput(output)).toBe('vercel/openai/gpt-5.5');
+  });
+});

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -49,6 +49,26 @@ function extractTranscriptFromOutput(output: string): string | undefined {
   return lines.join('\n');
 }
 
+export function extractObservedModelFromOpenCodeOutput(output: string): string | undefined {
+  let observedModel: string | undefined;
+
+  for (const line of output.split('\n')) {
+    if (!line.includes('service=llm') || !line.includes('small=false') || !line.includes('agent=build')) {
+      continue;
+    }
+
+    const providerMatch = line.match(/providerID=([^\s]+)/);
+    const modelMatch = line.match(/modelID=([^\s]+)/);
+    const providerID = providerMatch?.[1];
+    const modelID = modelMatch?.[1];
+    if (providerID && modelID) {
+      observedModel = `${providerID}/${modelID}`;
+    }
+  }
+
+  return observedModel;
+}
+
 /**
  * Additional provider configuration for models not yet available in the
  * default Vercel AI Gateway (e.g., early access / unreleased models).
@@ -232,18 +252,24 @@ export function createOpenCodeAgent(): Agent {
         // Verify no test files in sandbox
         await verifyNoTestFiles(sandbox);
 
-        // Run OpenCode CLI using run mode for non-interactive execution
-        // Use --format json for structured output (transcript)
+        // Run OpenCode CLI using run mode for non-interactive execution.
+        // Use --format json for structured output (transcript). Native-default
+        // runs print logs so we can capture the CLI-selected model.
+        const opencodeArgs = [
+          'run',
+          options.prompt,
+          '--format',
+          'json',
+        ];
+        if (options.model) {
+          opencodeArgs.push('--model', options.model);
+        } else if (options.modelPolicy === 'native-default') {
+          opencodeArgs.push('--print-logs', '--log-level', 'INFO');
+        }
+
         const opencodeResult = await sandbox.runCommand(
           'opencode',
-          [
-            'run',
-            options.prompt,
-            '--model',
-            options.model,
-            '--format',
-            'json',
-          ],
+          opencodeArgs,
           {
             env: {
               [AI_GATEWAY.apiKeyEnvVar]: options.apiKey,
@@ -254,6 +280,7 @@ export function createOpenCodeAgent(): Agent {
 
         agentOutput = opencodeResult.stdout + opencodeResult.stderr;
         transcript = extractTranscriptFromOutput(agentOutput);
+        const observedModel = extractObservedModelFromOpenCodeOutput(agentOutput);
 
         if (opencodeResult.exitCode !== 0) {
           // Extract meaningful error from output (last few lines usually contain the error)
@@ -265,6 +292,7 @@ export function createOpenCodeAgent(): Agent {
             error: errorLines || `OpenCode CLI exited with code ${opencodeResult.exitCode}`,
             duration: Date.now() - startTime,
             sandboxId: sandbox.sandboxId,
+            observedModel,
           };
         }
 
@@ -295,6 +323,7 @@ export function createOpenCodeAgent(): Agent {
           sandboxId: sandbox.sandboxId,
           generatedFiles,
           deletedFiles,
+          observedModel,
         };
       } catch (error) {
         // Check if this was an abort

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -2,7 +2,7 @@
  * Agent interface and common types for all agents.
  */
 
-import type { ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
+import type { ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
 
 /**
  * Common options for all agents.
@@ -10,8 +10,10 @@ import type { ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '.
 export interface AgentRunOptions {
   /** The prompt/task for the agent */
   prompt: string;
-  /** Model to use (agent-specific) */
-  model: ModelTier;
+  /** Model to use (agent-specific). Undefined means do not pass a model override. */
+  model?: ModelTier;
+  /** Model selection policy for this run. */
+  modelPolicy?: ModelPolicy;
   /** Timeout in milliseconds */
   timeout: number;
   /** API key for the agent */
@@ -62,6 +64,8 @@ export interface AgentRunResult {
   generatedFiles?: Record<string, string>;
   /** Files deleted by the agent */
   deletedFiles?: string[];
+  /** Model reported by the underlying agent CLI, when observable */
+  observedModel?: string;
 }
 
 /**

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -43,14 +43,6 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
-  it('accepts native-default model policy', () => {
-    const config = {
-      agent: 'vercel-ai-gateway/claude-code',
-      modelPolicy: 'native-default',
-    };
-    expect(() => validateConfig(config)).not.toThrow();
-  });
-
   it('accepts function evals filter', () => {
     const config = {
       agent: 'claude-code',
@@ -76,26 +68,12 @@ describe('resolveConfig', () => {
     const resolved = resolveConfig(config);
 
     expect(resolved.agent).toBe('claude-code');
-    expect(resolved.model).toBe('opus');
+    expect(resolved.model).toBe('native-default');
     expect(resolved.runs).toBe(CONFIG_DEFAULTS.runs);
     expect(resolved.earlyExit).toBe(CONFIG_DEFAULTS.earlyExit);
     expect(resolved.validation).toBe(CONFIG_DEFAULTS.validation);
     expect(resolved.evals).toBe('*');
-    expect(resolved.modelPolicy).toBe('agent-default');
-  });
-
-  it('preserves native-default policy without resolving an adapter model', () => {
-    const config = { agent: 'vercel-ai-gateway/codex' as const, modelPolicy: 'native-default' as const };
-    const resolved = resolveConfig(config);
-
-    expect(resolved.model).toBe('native-default');
     expect(resolved.modelPolicy).toBe('native-default');
-  });
-
-  it('rejects native-default policy with an explicit model', () => {
-    const config = { agent: 'vercel-ai-gateway/codex' as const, modelPolicy: 'native-default' as const, model: 'openai/gpt-5.2-codex' };
-
-    expect(() => resolveConfig(config)).toThrow('model must be omitted');
   });
 
   it('preserves provided values', () => {
@@ -108,6 +86,7 @@ describe('resolveConfig', () => {
     const resolved = resolveConfig(config);
 
     expect(resolved.model).toBe('haiku');
+    expect(resolved.modelPolicy).toBe('agent-default');
     expect(resolved.runs).toBe(10);
     expect(resolved.earlyExit).toBe(false);
   });

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -43,6 +43,14 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
+  it('accepts native-default model policy', () => {
+    const config = {
+      agent: 'vercel-ai-gateway/claude-code',
+      modelPolicy: 'native-default',
+    };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+
   it('accepts function evals filter', () => {
     const config = {
       agent: 'claude-code',
@@ -73,6 +81,21 @@ describe('resolveConfig', () => {
     expect(resolved.earlyExit).toBe(CONFIG_DEFAULTS.earlyExit);
     expect(resolved.validation).toBe(CONFIG_DEFAULTS.validation);
     expect(resolved.evals).toBe('*');
+    expect(resolved.modelPolicy).toBe('agent-default');
+  });
+
+  it('preserves native-default policy without resolving an adapter model', () => {
+    const config = { agent: 'vercel-ai-gateway/codex' as const, modelPolicy: 'native-default' as const };
+    const resolved = resolveConfig(config);
+
+    expect(resolved.model).toBe('native-default');
+    expect(resolved.modelPolicy).toBe('native-default');
+  });
+
+  it('rejects native-default policy with an explicit model', () => {
+    const config = { agent: 'vercel-ai-gateway/codex' as const, modelPolicy: 'native-default' as const, model: 'openai/gpt-5.2-codex' };
+
+    expect(() => resolveConfig(config)).toThrow('model must be omitted');
   });
 
   it('preserves provided values', () => {

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -9,6 +9,7 @@ import type {
   ResolvedExperimentConfig,
   EvalFilter,
 } from './types.js';
+import { NATIVE_DEFAULT_MODEL } from './types.js';
 import { getAgent } from './agents/index.js';
 
 /**
@@ -16,6 +17,7 @@ import { getAgent } from './agents/index.js';
  */
 export const CONFIG_DEFAULTS = {
   model: 'opus' as const,
+  modelPolicy: 'agent-default' as const,
   evals: '*' as const,
   runs: 1,
   earlyExit: true,
@@ -40,6 +42,7 @@ const experimentConfigSchema = z.object({
     'cursor',
   ]),
   model: z.union([z.string(), z.array(z.string())]).optional(),
+  modelPolicy: z.enum(['agent-default', 'native-default']).optional(),
   evals: z
     .union([z.string(), z.array(z.string()), z.function().args(z.string()).returns(z.boolean())])
     .optional(),
@@ -87,13 +90,21 @@ export function validateConfig(config: unknown): ExperimentConfig {
 export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfig {
   // Validate agent exists
   const agent = getAgent(config.agent);
-  
-  // Get the default model based on the agent type
-  const defaultModel = config.model ?? agent.getDefaultModel();
+  const modelPolicy = config.modelPolicy ?? CONFIG_DEFAULTS.modelPolicy;
+
+  if (modelPolicy === 'native-default' && config.model !== undefined) {
+    throw new Error('model must be omitted when modelPolicy is "native-default"');
+  }
+
+  // Preserve existing behavior unless native-default is explicitly requested.
+  const defaultModel = modelPolicy === 'native-default'
+    ? NATIVE_DEFAULT_MODEL
+    : config.model ?? agent.getDefaultModel();
 
   return {
     agent: config.agent,
     model: defaultModel,
+    modelPolicy,
     evals: config.evals ?? '*',
     runs: config.runs ?? CONFIG_DEFAULTS.runs,
     earlyExit: config.earlyExit ?? CONFIG_DEFAULTS.earlyExit,

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -16,8 +16,6 @@ import { getAgent } from './agents/index.js';
  * Default configuration values.
  */
 export const CONFIG_DEFAULTS = {
-  model: 'opus' as const,
-  modelPolicy: 'agent-default' as const,
   evals: '*' as const,
   runs: 1,
   earlyExit: true,
@@ -42,7 +40,6 @@ const experimentConfigSchema = z.object({
     'cursor',
   ]),
   model: z.union([z.string(), z.array(z.string())]).optional(),
-  modelPolicy: z.enum(['agent-default', 'native-default']).optional(),
   evals: z
     .union([z.string(), z.array(z.string()), z.function().args(z.string()).returns(z.boolean())])
     .optional(),
@@ -89,17 +86,10 @@ export function validateConfig(config: unknown): ExperimentConfig {
  */
 export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfig {
   // Validate agent exists
-  const agent = getAgent(config.agent);
-  const modelPolicy = config.modelPolicy ?? CONFIG_DEFAULTS.modelPolicy;
+  getAgent(config.agent);
 
-  if (modelPolicy === 'native-default' && config.model !== undefined) {
-    throw new Error('model must be omitted when modelPolicy is "native-default"');
-  }
-
-  // Preserve existing behavior unless native-default is explicitly requested.
-  const defaultModel = modelPolicy === 'native-default'
-    ? NATIVE_DEFAULT_MODEL
-    : config.model ?? agent.getDefaultModel();
+  const modelPolicy = config.model === undefined ? 'native-default' : 'agent-default';
+  const defaultModel = config.model ?? NATIVE_DEFAULT_MODEL;
 
   return {
     agent: config.agent,

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -80,6 +80,32 @@ describe('computeFingerprint', () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it('keeps agent-default policy equivalent to existing fingerprints', () => {
+    const evalDir = createEvalDir('eval-policy-default', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, modelPolicy: 'agent-default' });
+
+    expect(fp1).toBe(fp2);
+  });
+
+  it('changes for native-default policy', () => {
+    const evalDir = createEvalDir('eval-policy-native', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, model: 'native-default', modelPolicy: 'native-default' });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
   it('changes when config timeout changes', () => {
     const evalDir = createEvalDir('eval-4', {
       'PROMPT.md': 'Do something',

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -17,6 +17,7 @@ import type { RunnableExperimentConfig } from './types.js';
 interface FingerprintableConfig {
   agent: string;
   model: string;
+  modelPolicy?: string;
   scripts: string[];
   timeout: number;
   earlyExit: boolean;
@@ -73,6 +74,9 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
     earlyExit: config.earlyExit,
     runs: config.runs,
   };
+  if (config.modelPolicy === 'native-default') {
+    configForHash.modelPolicy = config.modelPolicy;
+  }
   hash.update(`config:${JSON.stringify(configForHash)}`);
 
   return hash.digest('hex');

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -195,6 +195,9 @@ describe('results utilities', () => {
       );
       expect(resultJson.status).toBe('passed');
       expect(resultJson.duration).toBe(10);
+      expect(resultJson.modelPolicy).toBeUndefined();
+      expect(resultJson.requestedModel).toBeUndefined();
+      expect(resultJson.observedModel).toBeUndefined();
       // Should have paths to transcript and outputs
       expect(resultJson.transcriptPath).toBe('./transcript.json');
       expect(resultJson.transcriptRawPath).toBe('./transcript-raw.jsonl');
@@ -224,6 +227,45 @@ describe('results utilities', () => {
       expect(parsedTranscript).toHaveProperty('agent');
       expect(parsedTranscript).toHaveProperty('events');
       expect(parsedTranscript).toHaveProperty('summary');
+    });
+
+    it('saves observed model metadata for native-default runs', () => {
+      const config: ResolvedExperimentConfig = {
+        agent: 'vercel-ai-gateway/opencode',
+        model: 'native-default',
+        modelPolicy: 'native-default',
+        evals: ['eval-1'],
+        runs: 1,
+        earlyExit: true,
+        scripts: [],
+        timeout: 300,
+      };
+
+      const evals = [
+        createEvalSummary('eval-1', [
+          { result: { status: 'passed', duration: 10, observedModel: 'vercel/openai/gpt-5.5' } },
+        ]),
+      ];
+
+      const results = createExperimentResults(
+        config,
+        evals,
+        new Date('2024-01-26T12:00:00Z'),
+        new Date('2024-01-26T12:01:00Z')
+      );
+
+      const outputDir = saveResults(results, {
+        resultsDir: TEST_DIR,
+        experimentName: 'native-default-test',
+      });
+
+      const resultJson = JSON.parse(
+        readFileSync(join(outputDir, 'eval-1', 'run-1', 'result.json'), 'utf-8')
+      );
+      expect(resultJson.modelPolicy).toBe('native-default');
+      expect(resultJson.model).toBe('vercel/openai/gpt-5.5');
+      expect(resultJson.requestedModel).toBeUndefined();
+      expect(resultJson.observedModel).toBe('vercel/openai/gpt-5.5');
     });
 
     it('does not collide when script is named "eval"', () => {

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -54,12 +54,17 @@ export function agentResultToEvalRunData(
 		}
 	}
 
+	const result: EvalRunResult = {
+		status: agentResult.success ? 'passed' : 'failed',
+		error: agentResult.error,
+		duration: agentResult.duration / 1000, // Convert to seconds
+	};
+	if (agentResult.observedModel) {
+		result.observedModel = agentResult.observedModel;
+	}
+
 	return {
-		result: {
-			status: agentResult.success ? 'passed' : 'failed',
-			error: agentResult.error,
-			duration: agentResult.duration / 1000, // Convert to seconds
-		},
+		result,
 		transcript: agentResult.transcript,
 		outputContent:
 			Object.keys(outputContent).length > 0 ? outputContent : undefined,
@@ -188,13 +193,21 @@ export function saveResults(
 			mkdirSync(runDir, { recursive: true });
 
 			// Build the result with paths and o11y summary
-			const model = results.config.model;
+			const modelPolicy = results.config.modelPolicy ?? 'agent-default';
+			const requestedModel = modelPolicy === 'native-default' ? undefined : results.config.model;
+			const { observedModel, ...baseResult } = runData.result;
+			const model = modelPolicy === 'native-default' ? (observedModel ?? results.config.model) : results.config.model;
 			const resultWithPaths: EvalRunResult & {
 				o11y?: Transcript['summary'];
 			} = {
-				...runData.result,
+				...baseResult,
 				model,
 			};
+			if (modelPolicy === 'native-default') {
+				resultWithPaths.modelPolicy = modelPolicy;
+				resultWithPaths.requestedModel = requestedModel;
+				resultWithPaths.observedModel = observedModel;
+			}
 
 			// Save transcripts if available
 			if (runData.transcript) {

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -546,6 +546,7 @@ describe('runExperiment', () => {
       expect(mockAgent.run).toHaveBeenCalledWith('/fake/path', {
         prompt: 'Test prompt for agent',
         model: 'opus',
+        modelPolicy: 'agent-default',
         timeout: 600000, // Should be converted to milliseconds
         apiKey: 'my-api-key',
         setup: mockSetup,
@@ -555,6 +556,59 @@ describe('runExperiment', () => {
         sandbox: undefined,
         agentOptions: undefined,
       });
+    });
+
+    it('does not pass a model override for native-default policy', async () => {
+      const mockAgent: Agent = {
+        name: 'mock-agent',
+        displayName: 'Mock Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn().mockResolvedValue({
+          success: true,
+          output: 'Agent output',
+          duration: 1000,
+          observedModel: 'runtime-model',
+          testResult: { success: true, output: 'Test passed' },
+          scriptsResults: {},
+        }),
+      };
+
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+
+      const config: ResolvedExperimentConfig = {
+        agent: 'claude-code',
+        model: 'native-default',
+        modelPolicy: 'native-default',
+        evals: ['test-eval'],
+        runs: 1,
+        earlyExit: false,
+        scripts: [],
+        timeout: 600,
+      };
+
+      const fixtures: EvalFixture[] = [
+        {
+          name: 'test-eval',
+          path: '/fake/path',
+          prompt: 'Test prompt for agent',
+          isModule: true,
+        },
+      ];
+
+      const results = await runExperiment({
+        config,
+        fixtures,
+        apiKey: 'my-api-key',
+        resultsDir: TEST_DIR,
+        experimentName: 'test-experiment',
+      });
+
+      expect(mockAgent.run).toHaveBeenCalledWith('/fake/path', expect.objectContaining({
+        model: undefined,
+        modelPolicy: 'native-default',
+      }));
+      expect(results.evals[0].runs[0].result.observedModel).toBe('runtime-model');
     });
 
     it('passes response-only validation mode to the agent', async () => {

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -179,10 +179,13 @@ export async function runExperiment(
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
+    const modelPolicy = config.modelPolicy ?? 'agent-default';
+    const requestedModel = modelPolicy === 'native-default' ? undefined : config.model;
     const agentResult = await Promise.race([
       agent.run(fixture.path, {
         prompt: config.editPrompt ? config.editPrompt(fixture.prompt) : fixture.prompt,
-        model: config.model,
+        model: requestedModel,
+        modelPolicy,
         timeout: timeoutMs,
         apiKey,
         setup: config.setup,
@@ -397,6 +400,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 	const agentResult = await agent.run(fixture.path, {
 		prompt,
 		model,
+		modelPolicy: 'agent-default',
 		timeout: options.timeout * 1000,
 		apiKey: options.apiKey,
 		setup: options.setup,

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -21,6 +21,16 @@ export type AgentType =
 export type ModelTier = string;
 
 /**
+ * How agent-eval chooses the model for a run.
+ * - agent-default: existing behavior; omitted model resolves to the adapter default.
+ * - native-default: do not pass a model override; let the underlying CLI choose.
+ */
+export type ModelPolicy = 'agent-default' | 'native-default';
+
+/** Stable label used in result paths and fingerprints for native CLI defaults. */
+export const NATIVE_DEFAULT_MODEL = 'native-default' as const;
+
+/**
  * Function type for filtering evals.
  */
 export type EvalFilter = (name: string) => boolean;
@@ -92,6 +102,9 @@ export interface ExperimentConfig {
    * Default is agent-specific: 'opus' for claude-code, 'openai/gpt-5.2-codex' for codex */
   model?: ModelTier | ModelTier[];
 
+  /** Model selection policy. Defaults to existing agent-eval adapter defaults. */
+  modelPolicy?: ModelPolicy;
+
   /** Which evals to run. Can be a string, array, or filter function. @default '*' (all evals) */
   evals?: string | string[] | EvalFilter;
 
@@ -143,6 +156,7 @@ export interface ExperimentConfig {
 export interface ResolvedExperimentConfig {
   agent: AgentType;
   model: ModelTier | ModelTier[];
+  modelPolicy?: ModelPolicy;
   evals: string | string[] | EvalFilter;
   runs: number;
   earlyExit: boolean;
@@ -164,6 +178,7 @@ export interface ResolvedExperimentConfig {
 export interface RunnableExperimentConfig {
   agent: AgentType;
   model: ModelTier;
+  modelPolicy?: ModelPolicy;
   evals: string | string[] | EvalFilter;
   runs: number;
   earlyExit: boolean;
@@ -218,6 +233,12 @@ export interface EvalRunResult {
   duration: number;
   /** Model used for this run */
   model?: string;
+  /** Model selection policy used for this run */
+  modelPolicy?: ModelPolicy;
+  /** Explicit model requested by the caller, if any */
+  requestedModel?: string;
+  /** Model reported by the underlying agent CLI, when observable */
+  observedModel?: string;
   /** Path to parsed transcript file (relative to run directory) */
   transcriptPath?: string;
   /** Path to raw transcript file (relative to run directory) */

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -22,8 +22,8 @@ export type ModelTier = string;
 
 /**
  * How agent-eval chooses the model for a run.
- * - agent-default: existing behavior; omitted model resolves to the adapter default.
- * - native-default: do not pass a model override; let the underlying CLI choose.
+ * - agent-default: an explicit model was provided and is passed to the adapter.
+ * - native-default: no model was provided; let the underlying CLI choose.
  */
 export type ModelPolicy = 'agent-default' | 'native-default';
 
@@ -98,12 +98,8 @@ export interface ExperimentConfig {
   agent: AgentType;
 
   /** Which AI model the agent should use. Can be a single model or array of models to test.
-   * If an array is provided, the experiment will run on each model.
-   * Default is agent-specific: 'opus' for claude-code, 'openai/gpt-5.2-codex' for codex */
+   * If omitted, the underlying agent CLI chooses its native default model. */
   model?: ModelTier | ModelTier[];
-
-  /** Model selection policy. Defaults to existing agent-eval adapter defaults. */
-  modelPolicy?: ModelPolicy;
 
   /** Which evals to run. Can be a string, array, or filter function. @default '*' (all evals) */
   evals?: string | string[] | EvalFilter;


### PR DESCRIPTION
## Summary
- make omitted `model` use the underlying agent CLI native default instead of agent-eval hardcoded adapter defaults
- preserve explicit `model` behavior: configured models are still passed to the agent CLI
- capture observed runtime models for Claude Code, Codex, and OpenCode when available

## Breaking change
- Configs that omit `model` now run with the agent CLI native default model.
- To keep previous behavior, set `model` explicitly in the experiment config.

## Metadata
- Native-default runs use `modelPolicy: "native-default"` in resolved/result metadata.
- Explicit model runs use `modelPolicy: "agent-default"` internally, but existing result JSON stays unchanged for agent-default runs.
- `observedModel` is populated when the agent CLI exposes the runtime model in transcripts/logs.

## Validation
- `npm run build -w packages/agent-eval`
- `npm run lint -w packages/agent-eval`
- `npm run test -w packages/agent-eval`

## Smoke notes
- Ran real `runExperiment` native-default smokes with Vercel Sandbox + fresh OIDC through the branch code path.
- Claude Code: passed, observed `claude-opus-4-8`.
- Codex: passed, observed `gpt-5.5`.
- OpenCode: passed, observed `vercel/google/gemini-3-pro-preview`.
