### PR TITLE
Fix OpenCode observed model extraction for OpenCode >= 1.17.0

### DIFF
--- a/.changeset/opencode-observed-model-export.md
+++ b/.changeset/opencode-observed-model-export.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Fix OpenCode observed model extraction for OpenCode >= 1.17.0. The log-scrape source (`service=llm ... providerID= modelID=` lines) was removed in OpenCode 1.17.0's logging rewrite, which caused native-default runs to report no observed model. The adapter now falls back to `opencode export <sessionID>`, reading `providerID`/`modelID` from the exported assistant message. The legacy log scrape is kept as the first, cheaper source for older CLI versions.

--- a/packages/agent-eval/src/lib/agents/opencode.test.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractObservedModelFromOpenCodeOutput } from './opencode.js';
+import {
+  extractObservedModelFromOpenCodeOutput,
+  extractObservedModelFromSessionExport,
+  extractSessionIdFromTranscript,
+} from './opencode.js';
 
 describe('OpenCode observed model extraction', () => {
   it('extracts the primary build model from printed logs', () => {
@@ -9,5 +13,82 @@ describe('OpenCode observed model extraction', () => {
     ].join('\n');
 
     expect(extractObservedModelFromOpenCodeOutput(output)).toBe('vercel/openai/gpt-5.5');
+  });
+
+  it('returns undefined when no matching log lines exist (OpenCode >= 1.17.0 format)', () => {
+    const output = [
+      'timestamp=2026-06-10T05:40:00.000Z level=INFO run=abc123 message=resolved provider=vercel model=openai/gpt-5.5',
+      '{"type":"text","timestamp":1781000000000,"sessionID":"ses_123","part":{"type":"text","text":"hi"}}',
+    ].join('\n');
+
+    expect(extractObservedModelFromOpenCodeOutput(output)).toBeUndefined();
+  });
+});
+
+describe('OpenCode session id extraction', () => {
+  it('extracts the session id from JSON transcript events', () => {
+    const transcript = [
+      '{"type":"step_start","timestamp":1781000000000,"sessionID":"ses_abc123","part":{"type":"step-start"}}',
+      '{"type":"text","timestamp":1781000001000,"sessionID":"ses_abc123","part":{"type":"text","text":"done"}}',
+    ].join('\n');
+
+    expect(extractSessionIdFromTranscript(transcript)).toBe('ses_abc123');
+  });
+
+  it('skips malformed lines and returns undefined when no session id is present', () => {
+    expect(extractSessionIdFromTranscript('not json\n{"type":"text"}')).toBeUndefined();
+    expect(extractSessionIdFromTranscript(undefined)).toBeUndefined();
+    expect(extractSessionIdFromTranscript('')).toBeUndefined();
+  });
+});
+
+describe('OpenCode session export model extraction', () => {
+  it('extracts providerID/modelID from the first assistant message', () => {
+    const exportOutput = JSON.stringify({
+      info: { id: 'ses_abc123', title: 'Test session' },
+      messages: [
+        { info: { id: 'msg_1', role: 'user' }, parts: [] },
+        {
+          info: {
+            id: 'msg_2',
+            role: 'assistant',
+            providerID: 'vercel',
+            modelID: 'google/gemini-3-pro-preview',
+          },
+          parts: [],
+        },
+      ],
+    });
+
+    expect(extractObservedModelFromSessionExport(exportOutput)).toBe(
+      'vercel/google/gemini-3-pro-preview'
+    );
+  });
+
+  it('tolerates non-JSON prefix lines before the JSON document', () => {
+    const exportOutput = [
+      'Exporting session: ses_abc123',
+      JSON.stringify({
+        messages: [
+          { info: { role: 'assistant', providerID: 'vercel', modelID: 'openai/gpt-5.5' }, parts: [] },
+        ],
+      }),
+    ].join('\n');
+
+    expect(extractObservedModelFromSessionExport(exportOutput)).toBe('vercel/openai/gpt-5.5');
+  });
+
+  it('returns undefined for malformed or incomplete exports', () => {
+    expect(extractObservedModelFromSessionExport('')).toBeUndefined();
+    expect(extractObservedModelFromSessionExport('not json')).toBeUndefined();
+    expect(extractObservedModelFromSessionExport('{"messages":"nope"}')).toBeUndefined();
+    expect(
+      extractObservedModelFromSessionExport(
+        JSON.stringify({ messages: [{ info: { role: 'assistant', providerID: 'vercel' } }] })
+      )
+    ).toBeUndefined();
+    expect(
+      extractObservedModelFromSessionExport(JSON.stringify({ messages: [{ info: { role: 'user' } }] }))
+    ).toBeUndefined();
   });
 });

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -70,6 +70,67 @@ export function extractObservedModelFromOpenCodeOutput(output: string): string |
 }
 
 /**
+ * Extract the session id from the `--format json` event stream.
+ * Every emitted event carries a `sessionID` field.
+ */
+export function extractSessionIdFromTranscript(transcript: string | undefined): string | undefined {
+  if (!transcript) {
+    return undefined;
+  }
+
+  for (const line of transcript.split('\n')) {
+    try {
+      const event = JSON.parse(line) as { sessionID?: unknown };
+      if (typeof event.sessionID === 'string' && event.sessionID) {
+        return event.sessionID;
+      }
+    } catch {
+      // Skip non-JSON lines
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract the observed model from `opencode export <sessionID>` output.
+ * Assistant messages carry `providerID` and `modelID` in their info.
+ */
+export function extractObservedModelFromSessionExport(exportOutput: string): string | undefined {
+  const start = exportOutput.indexOf('{');
+  if (start === -1) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(exportOutput.slice(start));
+  } catch {
+    return undefined;
+  }
+
+  const messages = (parsed as { messages?: unknown }).messages;
+  if (!Array.isArray(messages)) {
+    return undefined;
+  }
+
+  for (const message of messages) {
+    const info = (message as { info?: { role?: unknown; providerID?: unknown; modelID?: unknown } }).info;
+    if (info?.role !== 'assistant') {
+      continue;
+    }
+    if (
+      typeof info.providerID === 'string' && info.providerID &&
+      typeof info.modelID === 'string' && info.modelID
+    ) {
+      return `${info.providerID}/${info.modelID}`;
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Additional provider configuration for models not yet available in the
  * default Vercel AI Gateway (e.g., early access / unreleased models).
  */
@@ -254,7 +315,8 @@ export function createOpenCodeAgent(): Agent {
 
         // Run OpenCode CLI using run mode for non-interactive execution.
         // Use --format json for structured output (transcript). Native-default
-        // runs print logs so we can capture the CLI-selected model.
+        // runs also print logs, which lets older OpenCode versions report the
+        // CLI-selected model without a follow-up export call.
         const opencodeArgs = [
           'run',
           options.prompt,
@@ -280,7 +342,27 @@ export function createOpenCodeAgent(): Agent {
 
         agentOutput = opencodeResult.stdout + opencodeResult.stderr;
         transcript = extractTranscriptFromOutput(agentOutput);
-        const observedModel = extractObservedModelFromOpenCodeOutput(agentOutput);
+
+        // Resolve the model OpenCode actually used. The `--format json` events
+        // never include it, so first try scraping the printed logs (works on
+        // OpenCode <= 1.16.x), then fall back to `opencode export <sessionID>`,
+        // whose assistant messages carry providerID/modelID (OpenCode 1.17.0
+        // changed the log format, which broke the scrape). Observation must
+        // never fail the run.
+        let observedModel = extractObservedModelFromOpenCodeOutput(agentOutput);
+        if (!observedModel) {
+          const sessionId = extractSessionIdFromTranscript(transcript);
+          if (sessionId) {
+            try {
+              const exportResult = await sandbox.runCommand('opencode', ['export', sessionId]);
+              if (exportResult.exitCode === 0) {
+                observedModel = extractObservedModelFromSessionExport(exportResult.stdout);
+              }
+            } catch {
+              // Leave observedModel undefined
+            }
+          }
+        }
 
         if (opencodeResult.exitCode !== 0) {
           // Extract meaningful error from output (last few lines usually contain the error)


### PR DESCRIPTION
## Problem

The `daily_baseline_20260610_053602` snapshot in a0-local published `model: "native-default"` for all 180 OpenCode tasks — the dashboard renders the sentinel literally because no real model was observed.

Root cause: the adapter scrapes OpenCode's printed logs for `service=llm ... small=false agent=build providerID=... modelID=...` lines. OpenCode **1.17.0** (published 2026-06-10 03:10 UTC, ~2.5h before the daily run; the CLI is installed unpinned) rewrote its logging pipeline (`packages/core/src/effect/logger.ts` removed, replaced by a new structured formatter), so those lines no longer exist and `extractObservedModelFromOpenCodeOutput` returns nothing.

## Fix

Model observation now has two sources, tried in order:

1. **Log scrape (unchanged)** — free, still works on OpenCode <= 1.16.x.
2. **`opencode export <sessionID>` fallback** — the session id is taken from the `--format json` event stream (every event carries `sessionID`), and the exported assistant message carries `providerID`/`modelID` as schema fields. This is public CLI surface, stable across the 1.17 logging rewrite, and also works for explicit-model and custom-binary (`binaryUrl`) runs.

Observation never fails the run: export errors are swallowed and `observedModel` stays undefined.

## Testing

- `npm run build` clean
- `npm test`: 200 passed, 14 skipped
- New unit tests cover: legacy log scrape, the 1.17.0 log format returning undefined, session id extraction (incl. malformed lines), export parsing (incl. non-JSON stderr-style prefix, malformed/incomplete exports)