### PR TITLE
Add opt-in webResearch option for agent web tools

### DIFF
--- a/.changeset/brave-webs-search.md
+++ b/.changeset/brave-webs-search.md
@@ -1,0 +1,11 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add an opt-in `webResearch` option to `AgentRunOptions` that enables each agent's web research tools so recommendation evals can produce citation/source data. Default is off: command construction is byte-identical to previous releases for existing consumers.
+
+When enabled:
+
+- Claude Code: allows `WebSearch` and `WebFetch` via a single comma-separated `--allowedTools` value (the flag is variadic — the space-separated form in #141 consumed the trailing positional prompt as a tool name, which is what broke all CLI evals and forced the #144 revert).
+- Codex: sets `tools.web_search = true` in the generated profile config.
+- OpenCode: sets `OPENCODE_ENABLE_EXA=1` and allows the `websearch`/`webfetch` tools.

--- a/.changeset/brave-webs-search.md
+++ b/.changeset/brave-webs-search.md
@@ -2,7 +2,9 @@
 "@vercel/agent-eval": minor
 ---
 
-Add an opt-in `webResearch` option to `AgentRunOptions` that enables each agent's web research tools so recommendation evals can produce citation/source data. Default is off: command construction is byte-identical to previous releases for existing consumers.
+Add an opt-in `webResearch` option that enables each agent's web research tools so recommendation evals can produce citation/source data. Default is off: command construction is byte-identical to previous releases for existing consumers.
+
+The option is available on `AgentRunOptions` and on `ExperimentConfig`, and is forwarded by `runExperiment`/`runSingleEval`, so both direct `executeAgent` callers and experiment-config consumers can use it.
 
 When enabled:
 

--- a/packages/agent-eval/src/lib/agents/claude-code.test.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.test.ts
@@ -1,5 +1,58 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createClaudeCodeAgent, extractObservedModelFromClaudeTranscript } from './claude-code.js';
+import { buildClaudeCodeCliArgs, createClaudeCodeAgent, extractObservedModelFromClaudeTranscript } from './claude-code.js';
+
+describe('buildClaudeCodeCliArgs', () => {
+  const baseOptions = {
+    prompt: 'where should this run?',
+    timeout: 60_000,
+    apiKey: 'test-key',
+  };
+
+  it('builds unchanged arguments when webResearch is off', () => {
+    const args = buildClaudeCodeCliArgs({ ...baseOptions, model: 'opus' });
+    expect(args).toEqual([
+      '--print',
+      '--model',
+      'opus',
+      '--dangerously-skip-permissions',
+      'where should this run?',
+    ]);
+  });
+
+  it('allows web tools as a single comma-separated --allowedTools value', () => {
+    const args = buildClaudeCodeCliArgs({ ...baseOptions, model: 'opus', webResearch: true });
+    expect(args).toEqual([
+      '--print',
+      '--model',
+      'opus',
+      '--dangerously-skip-permissions',
+      '--allowedTools',
+      'WebSearch,WebFetch',
+      'where should this run?',
+    ]);
+  });
+
+  it('never passes tools as separate variadic tokens (the #141 regression)', () => {
+    // --allowedTools is variadic: separate tokens make the CLI consume the
+    // trailing positional prompt as another tool name, so runs execute with
+    // no prompt at all.
+    const args = buildClaudeCodeCliArgs({ ...baseOptions, webResearch: true });
+    const allowedToolsIndex = args.indexOf('--allowedTools');
+    expect(allowedToolsIndex).toBeGreaterThan(-1);
+    expect(args[allowedToolsIndex + 1]).toBe('WebSearch,WebFetch');
+    expect(args[args.length - 1]).toBe(baseOptions.prompt);
+  });
+
+  it('keeps the prompt as the final argument with effort set', () => {
+    const args = buildClaudeCodeCliArgs({
+      ...baseOptions,
+      webResearch: true,
+      agentOptions: { effort: 'high' },
+    });
+    expect(args[args.length - 1]).toBe(baseOptions.prompt);
+    expect(args).toContain('--effort');
+  });
+});
 
 describe('createClaudeCodeAgent', () => {
   const originalEnv = process.env;

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -77,6 +77,32 @@ export function extractObservedModelFromClaudeTranscript(transcript: string | un
 }
 
 /**
+ * Build the Claude Code CLI argument list.
+ *
+ * Exported for tests because the argument order is regression-sensitive:
+ * `--allowedTools` is variadic, so its tools MUST be passed as a single
+ * comma-separated value. Passing them as separate tokens makes the CLI
+ * consume the trailing positional prompt as another tool name, which broke
+ * every run when #141 used the space-separated form.
+ */
+export function buildClaudeCodeCliArgs(options: AgentRunOptions): string[] {
+  const cliArgs = ['--print'];
+  if (options.model) {
+    cliArgs.push('--model', options.model);
+  }
+  cliArgs.push('--dangerously-skip-permissions');
+  const effort = options.agentOptions?.effort as string | undefined;
+  if (effort) {
+    cliArgs.push('--effort', effort);
+  }
+  if (options.webResearch) {
+    cliArgs.push('--allowedTools', 'WebSearch,WebFetch');
+  }
+  cliArgs.push(options.prompt);
+  return cliArgs;
+}
+
+/**
  * Create Claude Code agent with specified authentication method.
  */
 export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGateway: boolean }): Agent {
@@ -221,16 +247,7 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
       }
 
       // Build CLI arguments
-      const cliArgs = ['--print'];
-      if (options.model) {
-        cliArgs.push('--model', options.model);
-      }
-      cliArgs.push('--dangerously-skip-permissions');
-      const effort = options.agentOptions?.effort as string | undefined;
-      if (effort) {
-        cliArgs.push('--effort', effort);
-      }
-      cliArgs.push(options.prompt);
+      const cliArgs = buildClaudeCodeCliArgs(options);
 
       // Run Claude Code with appropriate authentication
       const claudeResult = await sandbox.runCommand(

--- a/packages/agent-eval/src/lib/agents/codex.test.ts
+++ b/packages/agent-eval/src/lib/agents/codex.test.ts
@@ -74,6 +74,24 @@ describe('generateCodexConfig', () => {
     expect(config).not.toContain('model_reasoning_effort');
     expect(config).not.toContain('model_verbosity');
   });
+
+  it('omits the tools section by default', () => {
+    expect(generateCodexConfig(undefined, true)).not.toContain('[tools]');
+    expect(generateCodexConfig(undefined, false)).not.toContain('[tools]');
+  });
+
+  it('enables web_search when webResearch is set', () => {
+    const gatewayConfig = generateCodexConfig(undefined, true, undefined, true);
+    expect(gatewayConfig).toContain('[tools]');
+    expect(gatewayConfig).toContain('web_search = true');
+    // The tools table must come after the provider table's keys so the
+    // provider settings are not absorbed into [tools].
+    expect(gatewayConfig.indexOf('[tools]')).toBeGreaterThan(gatewayConfig.indexOf('wire_api'));
+
+    const directConfig = generateCodexConfig(undefined, false, undefined, true);
+    expect(directConfig).toContain('[tools]');
+    expect(directConfig).toContain('web_search = true');
+  });
 });
 
 describe('Codex observed model extraction', () => {

--- a/packages/agent-eval/src/lib/agents/codex.ts
+++ b/packages/agent-eval/src/lib/agents/codex.ts
@@ -163,7 +163,14 @@ export function generateCodexConfig(
   model: string | undefined,
   useVercelAiGateway: boolean,
   reasoningEffort?: string,
+  webResearch?: boolean,
 ): string {
+  // Opt-in web research. Note: through the AI Gateway (`wire_api =
+  // "responses"`), no `web_search` items have been observed — Codex instead
+  // researches via shell commands when it decides to. The setting is still
+  // written so direct-OpenAI runs and future gateway support pick it up; it
+  // is harmless when the server-side tool is unavailable.
+  const toolsSection = webResearch ? `\n[tools]\nweb_search = true\n` : '';
   if (useVercelAiGateway) {
     // AI Gateway uses prefixed model names like "openai/gpt-5.2-codex".
     // Native-default runs intentionally omit model and reasoning overrides.
@@ -176,14 +183,14 @@ name = "Vercel AI Gateway"
 base_url = "${AI_GATEWAY.openAiBaseUrl}"
 env_key = "${AI_GATEWAY.apiKeyEnvVar}"
 wire_api = "responses"
-`;
+${toolsSection}`;
   } else {
     // Direct OpenAI API — use the built-in "openai" provider (no custom provider needed).
     // Native-default runs intentionally omit model and reasoning overrides.
     const directModel = model ? (model.includes('/') ? model.split('/').pop()! : model) : undefined;
     return `# Direct OpenAI API configuration
 model_provider = "openai"
-${directModel ? `model = "${directModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}`;
+${directModel ? `model = "${directModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}${toolsSection}`;
   }
 }
 
@@ -309,7 +316,7 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
       // and so the CLI's own default of "low" can't sneak through. For
       // native-default runs we omit these settings to match the CLI's behavior.
       await sandbox.runShell('mkdir -p ~/.codex');
-      const configContent = generateCodexConfig(baseModel, useVercelAiGateway, reasoningEffort);
+      const configContent = generateCodexConfig(baseModel, useVercelAiGateway, reasoningEffort, options.webResearch);
       await sandbox.runShell(`cat > ~/.codex/default.config.toml << 'EOF'
 ${configContent}
 EOF`);

--- a/packages/agent-eval/src/lib/agents/opencode.test.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.test.ts
@@ -3,7 +3,32 @@ import {
   extractObservedModelFromOpenCodeOutput,
   extractObservedModelFromSessionExport,
   extractSessionIdFromTranscript,
+  generateOpenCodeConfig,
 } from './opencode.js';
+
+describe('generateOpenCodeConfig', () => {
+  it('grants only the default tool permissions when webResearch is off', () => {
+    const config = JSON.parse(generateOpenCodeConfig(undefined, 'test-key'));
+    expect(config.permission).toEqual({ write: 'allow', edit: 'allow', bash: 'allow' });
+  });
+
+  it('allows websearch and webfetch when webResearch is set', () => {
+    const config = JSON.parse(generateOpenCodeConfig(undefined, 'test-key', undefined, true));
+    expect(config.permission).toEqual({
+      write: 'allow',
+      edit: 'allow',
+      bash: 'allow',
+      webfetch: 'allow',
+      websearch: 'allow',
+    });
+  });
+
+  it('keeps provider configuration unchanged when webResearch is set', () => {
+    const withResearch = JSON.parse(generateOpenCodeConfig(undefined, 'test-key', undefined, true));
+    const without = JSON.parse(generateOpenCodeConfig(undefined, 'test-key'));
+    expect(withResearch.provider).toEqual(without.provider);
+  });
+});
 
 describe('OpenCode observed model extraction', () => {
   it('extracts the primary build model from printed logs', () => {

--- a/packages/agent-eval/src/lib/agents/opencode.ts
+++ b/packages/agent-eval/src/lib/agents/opencode.ts
@@ -151,7 +151,7 @@ export interface OpenCodeProviderConfig {
  * Generate OpenCode config file content.
  * Configures the Vercel AI Gateway provider, plus any additional providers.
  */
-function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>, apiKey?: string, timeoutMs?: number): string {
+export function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProviderConfig>, apiKey?: string, timeoutMs?: number, webResearch?: boolean): string {
   const vercelBase: Record<string, unknown> = {
     options: {
       apiKey: apiKey || '{env:AI_GATEWAY_API_KEY}',
@@ -176,6 +176,9 @@ function generateOpenCodeConfig(extraProviders?: Record<string, OpenCodeProvider
       write: 'allow',
       edit: 'allow',
       bash: 'allow',
+      // OpenCode has no native web search; Exa-backed search is enabled via
+      // OPENCODE_ENABLE_EXA=1 alongside these tool permissions.
+      ...(webResearch ? { webfetch: 'allow', websearch: 'allow' } : {}),
     },
   }, null, 2);
 }
@@ -305,7 +308,7 @@ export function createOpenCodeAgent(): Agent {
         }
 
         // Create OpenCode config file in the project directory
-        const configContent = generateOpenCodeConfig(extraProviders, options.apiKey, options.timeout);
+        const configContent = generateOpenCodeConfig(extraProviders, options.apiKey, options.timeout, options.webResearch);
         await sandbox.writeFiles({
           'opencode.json': configContent,
         });
@@ -335,6 +338,10 @@ export function createOpenCodeAgent(): Agent {
           {
             env: {
               [AI_GATEWAY.apiKeyEnvVar]: options.apiKey,
+              // Exa-backed websearch is gated behind this env var in the
+              // OpenCode CLI; the matching tool permissions are written into
+              // opencode.json by generateOpenCodeConfig.
+              ...(options.webResearch ? { OPENCODE_ENABLE_EXA: '1' } : {}),
               ...neutralWorkspace.env,
             },
           }

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -28,6 +28,22 @@ export interface AgentRunOptions {
   signal?: AbortSignal;
   /** Sandbox backend to use */
   sandbox?: SandboxBackend | 'auto';
+  /**
+   * Enable each agent's web research tools so answers can produce
+   * citation/source data. Default false: command construction is unchanged
+   * for existing consumers (coding evals do not want web tools silently
+   * enabled).
+   *
+   * When true:
+   * - Claude Code: allows `WebSearch` and `WebFetch` via a single
+   *   comma-separated `--allowedTools` value. The flag is variadic, so the
+   *   tools MUST be one comma-separated token — separate tokens swallow the
+   *   trailing positional prompt (the #141 regression).
+   * - Codex: sets `tools.web_search = true` in the generated profile config.
+   * - OpenCode: sets `OPENCODE_ENABLE_EXA=1` and allows the
+   *   `websearch`/`webfetch` tools.
+   */
+  webResearch?: boolean;
   /** Agent-specific options (e.g., binaryUrl, extraProviders for opencode) */
   agentOptions?: Record<string, unknown>;
 }

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -60,6 +60,16 @@ describe('validateConfig', () => {
     const config = { agent: 'claude-code', runs: 0 };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
+
+  it('keeps webResearch through validation (zod strips unknown keys)', () => {
+    const config = { agent: 'claude-code', webResearch: true };
+    expect(validateConfig(config).webResearch).toBe(true);
+  });
+
+  it('rejects non-boolean webResearch', () => {
+    const config = { agent: 'claude-code', webResearch: 'yes' };
+    expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
+  });
 });
 
 describe('resolveConfig', () => {
@@ -89,6 +99,11 @@ describe('resolveConfig', () => {
     expect(resolved.modelPolicy).toBe('agent-default');
     expect(resolved.runs).toBe(10);
     expect(resolved.earlyExit).toBe(false);
+  });
+
+  it('passes webResearch through and leaves it undefined by default', () => {
+    expect(resolveConfig({ agent: 'claude-code' as const }).webResearch).toBeUndefined();
+    expect(resolveConfig({ agent: 'claude-code' as const, webResearch: true }).webResearch).toBe(true);
   });
 
 });

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -53,6 +53,9 @@ const experimentConfigSchema = z.object({
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
   copyFiles: z.enum(['none', 'changed', 'all']).optional(),
   agentOptions: z.record(z.unknown()).optional(),
+  // Must be in the schema: z.object strips unknown keys, so omitting it here
+  // would make validateConfig silently drop the option.
+  webResearch: z.boolean().optional(),
   brands: z.array(z.object({
     id: z.string().optional(),
     name: z.string().min(1),
@@ -106,6 +109,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     editPrompt: config.editPrompt,
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
     agentOptions: config.agentOptions,
+    webResearch: config.webResearch,
     brands: config.brands,
     onRunComplete: config.onRunComplete,
   };

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -106,6 +106,34 @@ describe('computeFingerprint', () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it('keeps webResearch-off equivalent to existing fingerprints', () => {
+    const evalDir = createEvalDir('eval-research-default', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, webResearch: false });
+    const fp3 = computeFingerprint(evalDir, { ...baseConfig, webResearch: undefined });
+
+    expect(fp1).toBe(fp2);
+    expect(fp1).toBe(fp3);
+  });
+
+  it('changes when webResearch is enabled (research results must not be reused for parametric runs)', () => {
+    const evalDir = createEvalDir('eval-research-on', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, webResearch: true });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
   it('changes when config timeout changes', () => {
     const evalDir = createEvalDir('eval-4', {
       'PROMPT.md': 'Do something',

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -22,6 +22,7 @@ interface FingerprintableConfig {
   timeout: number;
   earlyExit: boolean;
   runs: number;
+  webResearch?: boolean;
 }
 
 /**
@@ -76,6 +77,13 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   };
   if (config.modelPolicy === 'native-default') {
     configForHash.modelPolicy = config.modelPolicy;
+  }
+  // Included only when enabled so existing (default-off) fingerprints are
+  // unchanged, while research and non-research configs never share a
+  // fingerprint — result reuse must not serve a cached parametric-only
+  // result for a research run, or vice versa.
+  if (config.webResearch) {
+    configForHash.webResearch = true;
   }
   hash.update(`config:${JSON.stringify(configForHash)}`);
 

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -555,7 +555,59 @@ describe('runExperiment', () => {
         signal: expect.any(AbortSignal), // Signal always passed for timeout cleanup
         sandbox: undefined,
         agentOptions: undefined,
+        webResearch: undefined,
       });
+    });
+
+    it('forwards webResearch to agent.run when set', async () => {
+      const mockAgent: Agent = {
+        name: 'mock-agent',
+        displayName: 'Mock Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn().mockResolvedValue({
+          success: true,
+          output: 'Agent output',
+          duration: 1000,
+          testResult: { success: true, output: 'Test passed' },
+          scriptsResults: {},
+        }),
+      };
+
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+
+      const config: ResolvedExperimentConfig = {
+        agent: 'claude-code',
+        model: 'opus',
+        evals: ['test-eval'],
+        runs: 1,
+        earlyExit: false,
+        scripts: [],
+        timeout: 600,
+        webResearch: true,
+      };
+
+      const fixtures: EvalFixture[] = [
+        {
+          name: 'test-eval',
+          path: '/fake/path',
+          prompt: 'Test prompt for agent',
+          isModule: true,
+        },
+      ];
+
+      await runExperiment({
+        config,
+        fixtures,
+        apiKey: 'my-api-key',
+        resultsDir: TEST_DIR,
+        experimentName: 'test-experiment',
+      });
+
+      expect(mockAgent.run).toHaveBeenCalledWith(
+        '/fake/path',
+        expect.objectContaining({ webResearch: true })
+      );
     });
 
     it('does not pass a model override for native-default policy', async () => {

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -194,6 +194,7 @@ export async function runExperiment(
         signal: attemptController.signal,
         sandbox: config.sandbox,
         agentOptions: config.agentOptions,
+        webResearch: config.webResearch,
       }),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
@@ -386,6 +387,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     editPrompt?: (prompt: string) => string;
     verbose?: boolean;
     agentOptions?: ResolvedExperimentConfig['agentOptions'];
+    webResearch?: ResolvedExperimentConfig['webResearch'];
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
@@ -408,6 +410,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		validation: options.validation,
 		sandbox: options.sandbox,
 		agentOptions: options.agentOptions,
+		webResearch: options.webResearch,
 	});
 
     results.push(agentResultToEvalRunData(agentResult));

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -139,6 +139,11 @@ export interface ExperimentConfig {
    * These are forwarded to the agent's run() method. @default undefined */
   agentOptions?: Record<string, unknown>;
 
+  /** Enable each agent's web research tools (see `AgentRunOptions.webResearch`
+   * for the per-agent mechanics). Forwarded to the agent's run() method.
+   * @default false — command construction is unchanged when omitted. */
+  webResearch?: boolean;
+
   /** Brands to track or compare in downstream analysis. @default undefined */
   brands?: BrandConfig[];
 
@@ -164,6 +169,7 @@ export interface ResolvedExperimentConfig {
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
+  webResearch?: boolean;
   brands?: BrandConfig[];
   onRunComplete?: RunCompleteHook;
 }
@@ -186,6 +192,7 @@ export interface RunnableExperimentConfig {
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
+  webResearch?: boolean;
   brands?: BrandConfig[];
   onRunComplete?: RunCompleteHook;
 }


### PR DESCRIPTION
## Summary

Safe redo of #141 (reverted in #144). Adds `webResearch?: boolean` to `AgentRunOptions` **and** `ExperimentConfig`, **default false** — command construction is byte-identical to current releases for every existing consumer. Coding evals are unaffected unless they explicitly opt in.

When enabled:

| Agent | Change |
| --- | --- |
| Claude Code | `--allowedTools "WebSearch,WebFetch"` as a **single comma-separated value** |
| Codex | `tools.web_search = true` in the generated profile config |
| OpenCode | `OPENCODE_ENABLE_EXA=1` env + `websearch`/`webfetch` permissions in opencode.json |

The option is reachable from both entry points:

- **`executeAgent` / direct agent callers** — `AgentRunOptions.webResearch`
- **`runExperiment` / `runSingleEval` consumers** — `ExperimentConfig.webResearch`, forwarded by the runner to `agent.run()`. Without this plumbing the adapter changes were dead code for experiment-config consumers (a0-local calls `runExperiment`, never `executeAgent`): the runner builds `AgentRunOptions` from an explicit field list, and `validateConfig`'s `z.object` schema strips unknown keys, so the flag is also a schema member — omitting it there would have silently dropped it.

## Why #141 broke, and why this won't

#141 passed the Claude Code tools as separate tokens: `--allowedTools WebSearch WebFetch <prompt>`. The flag is **variadic**, so the trailing positional prompt was consumed as a third tool name — every run executed with no prompt, which is why all CLI evals broke at once. #141's unit tests passed because they asserted the buggy form.

This PR:
- uses the single-token comma-separated form, verified working end-to-end (below)
- adds a regression test that explicitly asserts the prompt remains the final argument and the tools are one token
- is **opt-in**, so even a latent bug in the research path cannot affect existing consumers' default behavior

## Live verification (through AI Gateway)

Spiked each agent manually with these exact mechanisms against `ai-gateway.vercel.sh`:

- **Claude Code** (2.1.112): `WebSearch` executed (`tool_use`/`tool_result` events), answer cited fresh June-2026 URLs. Prompt not swallowed.
- **OpenCode** (1.17.0): Exa `websearch` tool executed with `OPENCODE_ENABLE_EXA=1`, accurate cited answer.
- **Codex** (0.139.0): no `web_search` items observed through the responses wire — Codex instead researched via shell (`curl`/`npm view`) and produced a correct cited answer. The config setting is kept: it is harmless when the server-side tool is unavailable, and applies to direct-OpenAI runs and future gateway support.

Also verified: with tools enabled but a prompt that doesn't call for research, Claude Code makes zero tool calls — enabling `webResearch` does not force research, it permits it.

## Tests

- `buildClaudeCodeCliArgs` extracted (again, correctly this time) with 4 tests including the explicit #141 regression case
- `generateCodexConfig`: default-off + enabled cases, including `[tools]` table placement after the provider table
- `generateOpenCodeConfig` exported with 3 tests (default permissions unchanged, research permissions added, provider config untouched)
- Runner: `webResearch: true` in `ExperimentConfig` reaches `agent.run()`; the exact-options assertion pins `webResearch: undefined` when absent
- Fingerprints: `webResearch` is included in result-reuse fingerprints **only when enabled** (same conditional pattern as native-default `modelPolicy`) — default-off fingerprints are unchanged, and research/non-research configs never share a fingerprint, so result reuse cannot serve a cached parametric-only result for a research run
- Config: `validateConfig` keeps `webResearch` (the zod strip case), rejects non-boolean values; `resolveConfig` passes it through and leaves it `undefined` by default
- Full suite: 215 passed

## Consumer plan

`a0-local` will adopt this behind a dedicated research cohort (not the daily baseline), recorded in run metadata for comparability. Recommend a manual pre-release smoke of one real sandbox run per agent with the flag on and off before publishing — the class of bug that sank #141 is invisible to unit tests.

