### PR TITLE
Fix Claude prompt consumed by variadic --allowedTools in webResearch runs

### DIFF
--- a/.changeset/claude-allowed-tools-order.md
+++ b/.changeset/claude-allowed-tools-order.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Fix Claude Code prompt being consumed by `--allowedTools` when `webResearch` is enabled. The flag is variadic and keeps capturing positionals until the next flag, so even the single comma-separated token from 1.1.0 swallowed the trailing prompt ("Input must be provided either through stdin or as a prompt argument when using --print", verified live on claude 2.1.112). `--allowedTools` is now emitted before the always-present `--dangerously-skip-permissions`, which terminates the variadic capture before the prompt. Default-off argument construction is unchanged.

--- a/packages/agent-eval/src/lib/agents/claude-code.test.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.test.ts
@@ -23,11 +23,11 @@ describe('buildClaudeCodeCliArgs', () => {
     const args = buildClaudeCodeCliArgs({ ...baseOptions, model: 'opus', webResearch: true });
     expect(args).toEqual([
       '--print',
+      '--allowedTools',
+      'WebSearch,WebFetch',
       '--model',
       'opus',
       '--dangerously-skip-permissions',
-      '--allowedTools',
-      'WebSearch,WebFetch',
       'where should this run?',
     ]);
   });
@@ -41,6 +41,23 @@ describe('buildClaudeCodeCliArgs', () => {
     expect(allowedToolsIndex).toBeGreaterThan(-1);
     expect(args[allowedToolsIndex + 1]).toBe('WebSearch,WebFetch');
     expect(args[args.length - 1]).toBe(baseOptions.prompt);
+  });
+
+  it('always follows the --allowedTools value with a flag, never the prompt', () => {
+    // The variadic capture only stops at the next flag. Even as a single
+    // comma token, `--allowedTools "WebSearch,WebFetch" <prompt>` consumes
+    // the prompt as another tool name (verified live on claude 2.1.112:
+    // "Input must be provided either through stdin or as a prompt argument").
+    for (const options of [
+      { ...baseOptions, webResearch: true },
+      { ...baseOptions, model: 'opus', webResearch: true },
+      { ...baseOptions, webResearch: true, agentOptions: { effort: 'high' } },
+    ]) {
+      const args = buildClaudeCodeCliArgs(options);
+      const next = args[args.indexOf('--allowedTools') + 2];
+      expect(next, `token after allowedTools value in [${args.join(' ')}]`).toMatch(/^--/);
+      expect(args[args.length - 1]).toBe(baseOptions.prompt);
+    }
   });
 
   it('keeps the prompt as the final argument with effort set', () => {

--- a/packages/agent-eval/src/lib/agents/claude-code.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.ts
@@ -80,13 +80,26 @@ export function extractObservedModelFromClaudeTranscript(transcript: string | un
  * Build the Claude Code CLI argument list.
  *
  * Exported for tests because the argument order is regression-sensitive:
- * `--allowedTools` is variadic, so its tools MUST be passed as a single
- * comma-separated value. Passing them as separate tokens makes the CLI
- * consume the trailing positional prompt as another tool name, which broke
- * every run when #141 used the space-separated form.
+ * `--allowedTools` is variadic — it keeps consuming positional tokens until
+ * the next flag. Two rules follow:
+ *
+ * 1. The tools must be a single comma-separated value (separate tokens broke
+ *    every run in #141).
+ * 2. `--allowedTools` must be followed by another flag, NEVER directly by
+ *    the prompt. The comma token alone is not enough: a live smoke run on
+ *    claude 2.1.112 with `... --allowedTools "WebSearch,WebFetch" <prompt>`
+ *    consumed the prompt as another tool name and failed with "Input must
+ *    be provided either through stdin or as a prompt argument".
+ *
+ * `--allowedTools` is therefore emitted first, and the always-present
+ * `--dangerously-skip-permissions` flag guarantees the variadic capture is
+ * terminated before the trailing positional prompt.
  */
 export function buildClaudeCodeCliArgs(options: AgentRunOptions): string[] {
   const cliArgs = ['--print'];
+  if (options.webResearch) {
+    cliArgs.push('--allowedTools', 'WebSearch,WebFetch');
+  }
   if (options.model) {
     cliArgs.push('--model', options.model);
   }
@@ -94,9 +107,6 @@ export function buildClaudeCodeCliArgs(options: AgentRunOptions): string[] {
   const effort = options.agentOptions?.effort as string | undefined;
   if (effort) {
     cliArgs.push('--effort', effort);
-  }
-  if (options.webResearch) {
-    cliArgs.push('--allowedTools', 'WebSearch,WebFetch');
   }
   cliArgs.push(options.prompt);
   return cliArgs;


### PR DESCRIPTION
## Summary

Fixes a prompt-swallowing bug in the `webResearch` path shipped in 1.1.0 (#150), caught by a live a0-local smoke run.

`--allowedTools` is **variadic**: it keeps capturing positional tokens until the next flag. The single comma-separated token from #150 stops the tools list itself from splitting, but with the prompt placed directly after the value, the CLI still consumed it as another tool name:

```
$ claude --print --dangerously-skip-permissions --allowedTools "WebSearch,WebFetch" "prompt..."
Error: Input must be provided either through stdin or as a prompt argument when using --print
```

Reproduced locally on claude 2.1.112 with exactly the argument order `buildClaudeCodeCliArgs` emitted. The unit tests passed because they asserted that broken order — the same failure mode as #141's tests.

## Fix

Emit `--allowedTools WebSearch,WebFetch` **first**, so the always-present `--dangerously-skip-permissions` flag terminates the variadic capture before the trailing positional prompt:

```
--print --allowedTools WebSearch,WebFetch [--model m] --dangerously-skip-permissions [--effort e] <prompt>
```

Verified live: the reordered invocation accepts the prompt (proceeds to API auth).

## Scope

- Default-off (`webResearch` absent) argument construction is byte-identical — only research runs are affected, and research runs were 100% broken for Claude before this fix.
- New regression test asserts the token after the `--allowedTools` value is always a flag, never the prompt, across model/effort permutations.
- Codex and OpenCode were verified healthy in the same smoke run (completed answers; zero tool calls, which is the expected voluntary-research behavior).

## Smoke evidence (a0-local, run `research_smoke_websearch_test`)

| Agent | Result |
| --- | --- |
| claude-code | `error` in 11.4s — "Input must be provided either through stdin or as a prompt argument when using --print" |
| codex | `completed` (35.1s, parametric answer, no tool calls) |
| opencode | `completed` (38.5s, parametric answer, no tool calls) |

Changeset: patch → 1.1.1.


## Pre-merge verification of this exact branch

#150 also claimed live verification and shipped broken — its spike tested the *mechanism* (comma token) but never the *code's emitted argument order*. To avoid repeating that, this branch was verified by executing the real artifact at every layer:

**1. CLI level** — the exact arg order `buildClaudeCodeCliArgs` emits, run against the real gateway (claude 2.1.112, adapter env):

```
$ claude --print --allowedTools "WebSearch,WebFetch" --dangerously-skip-permissions "Reply with exactly: OK"
OK
```

WebSearch confirmed to actually execute under this order (`"type":"tool_use","name":"WebSearch"` in stream-json output), and the 1.1.0 order re-confirmed broken in the same environment — the delta is provably the flag position.

**2. Full-pipeline level** — this branch was packed (`npm pack`), installed into a0-local, and run through the complete production chain (runner → adapter → Vercel Sandbox → CLI → gateway) with the same 3-agent smoke that caught the bug:

| Agent | 1.1.0 (published) | This branch |
| --- | --- | --- |
| claude-code | `error` 11.4s — prompt swallowed | `completed` 37.0s — real on-topic answer |
| codex | `completed` | `completed` |
| opencode | `completed` | `completed` |

Zero tool calls in the smoke answers is the expected voluntary-research behavior; the tool *permission* path is what this PR fixes, and layer 1 proves the tools fire when invoked.

**Reproducible pre-merge test for reviewers:**

```bash
cd agent-eval/packages/agent-eval && npm run build && npm pack
cd <a0-local> && npm install <path-to-tgz>
npm run dev -- run --prompts prompts/generated/persona-usecase-feature-v5-smoke.json \
  --no-repo --skill baseline --prompt <any-prompt-id> \
  --cohort research-smoke --purpose experiment --no-report --no-skill-report \
  --web-research --id research_smoke_local
git checkout package.json package-lock.json && npm install   # restore
```

Post-release gate: after 1.1.1 publishes, a0-local bumps and re-runs the same smoke against the npm artifact before relying on research runs. Reminder: rotate the repo's npm token secret before releasing — the 1.1.0 release job failed post-publish with E401.
