### PR TITLE
[agent-eval] LLM-as-judge assertions for EVAL.ts

### DIFF
--- a/.changeset/llm-judge-assertions.md
+++ b/.changeset/llm-judge-assertions.md
@@ -1,0 +1,14 @@
+---
+'@vercel/agent-eval': minor
+---
+
+Add LLM-as-judge assertions for `EVAL.ts`. You can now grade qualitative criteria that deterministic checks can't express:
+
+```ts
+import { transcript, diff } from './__agent_eval__/judge.mjs';
+
+await expect(transcript()).toSatisfyCriterion('Used React DevTools to diagnose, not guesswork');
+await expect(diff()).toSatisfyCriterion('Added Suspense boundaries; did not use force-dynamic');
+```
+
+`toSatisfyCriterion` is a normal async vitest matcher, so a failed verdict is just a failed test — it rides the existing pass-rate, result reuse, and dashboard. The judge runs inside the sandbox (zero added fixture deps), calls the AI Gateway with the credential the harness already forwards, and uses a judge model independent of the model under test (override via `AGENT_EVAL_JUDGE_MODEL`). The full normalized transcript is now also exposed to `EVAL.ts` for evidence.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,37 @@ The `results.o11y` object is a `TranscriptSummary` with these fields:
 
 > **Note**: If the agent's transcript is unavailable (e.g. the agent crashed before producing output), `results.o11y` will be `null`.
 
+### LLM-as-judge assertions
+
+Some things can't be checked with `expect(...).toBe(...)` — "did the agent debug with React DevTools instead of guessing?", "is this the idiomatic fix?". For those, `EVAL.ts` can assert with an LLM judge:
+
+```ts
+import { test, expect } from 'vitest';
+import { transcript, diff, files } from './__agent_eval__/judge.mjs';
+
+test('diagnosed with devtools, not guesswork', async () => {
+  await expect(transcript()).toSatisfyCriterion(
+    'Used React DevTools or the performance tracks to locate the slow component — not trial-and-error edits'
+  );
+});
+
+test('fixed it the right way', async () => {
+  await expect(diff()).toSatisfyCriterion('Added Suspense boundaries; did NOT reach for force-dynamic');
+});
+```
+
+`toSatisfyCriterion(criterion)` sends the evidence + criterion to a judge model and passes only if the model says the criterion is clearly met; on failure the test fails with the judge's reason. It's a normal async matcher, so it rides the existing pass-rate, result reuse, and dashboard with no extra wiring.
+
+Evidence helpers (import from `./__agent_eval__/judge.mjs`):
+
+| Helper | Evidence |
+| ------ | -------- |
+| `transcript()` | The agent's full run — assistant text, thinking, tool calls + results |
+| `diff()` | The agent's code changes (`git diff` against the pre-run state) |
+| `files(...paths)` | The contents of specific files |
+
+The judge runs **inside the sandbox** (in your eval's vitest worker) and calls the AI Gateway — it's zero-dependency, so nothing is added to your fixture. It needs a gateway credential in the environment (`AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`); the harness forwards it automatically. The judge model is **independent of the model under test** (so multi-model sweeps stay consistent and nothing self-scores) — it defaults to a strong model and is overridable with `AGENT_EVAL_JUDGE_MODEL`. See [Environment Variables](#environment-variables).
+
 ## Configuration Reference
 
 ### Experiment config
@@ -516,6 +547,8 @@ Every run requires an API key for the agent and a token for the sandbox. Classif
 | `CURSOR_API_KEY`     | `agent: 'cursor'`                      | Direct Cursor API key                                                                        |
 | `VERCEL_TOKEN`       | Always (pick one)                      | Vercel personal access token -- for local dev                                                |
 | `VERCEL_OIDC_TOKEN`  | Always (pick one) OR for classifier    | Vercel OIDC token -- for CI/CD pipelines, or enables classifier without `AI_GATEWAY_API_KEY` |
+| `AGENT_EVAL_JUDGE_MODEL` | Optional                           | Model id for [LLM-as-judge assertions](#llm-as-judge-assertions). Defaults to a strong model; independent of the model under test |
+| `AGENT_EVAL_JUDGE_BASE_URL` | Optional                        | Override the judge's gateway base URL (defaults to the AI Gateway). Mainly for testing |
 
 The **classifier is optional**: if neither `AI_GATEWAY_API_KEY` nor `VERCEL_OIDC_TOKEN` is set, failure classification is skipped and all results are preserved as-is. Set either key to enable the classifier, which automatically identifies and removes non-model failures (infrastructure errors, rate limits, timeouts).
 

--- a/packages/agent-eval/eslint.config.js
+++ b/packages/agent-eval/eslint.config.js
@@ -11,6 +11,13 @@ export default tseslint.config(
     },
   },
   {
+    // Injected sandbox runtime: plain JS that runs on Node (fetch + process globals).
+    files: ['src/**/*.mjs'],
+    languageOptions: {
+      globals: { process: 'readonly', fetch: 'readonly', console: 'readonly' },
+    },
+  },
+  {
     ignores: ['dist/**', 'node_modules/**'],
   },
 );

--- a/packages/agent-eval/package.json
+++ b/packages/agent-eval/package.json
@@ -16,7 +16,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node -e \"require('fs').copyFileSync('src/lib/judge-runtime.mjs','dist/lib/judge-runtime.mjs')\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:docker": "SANDBOX_BACKEND=docker vitest run src/lib/docker-sandbox.test.ts",

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -1392,3 +1392,61 @@ test('greet exists', () => {
     });
   });
 });
+
+// Full-stack e2e for the LLM judge: a real agent run whose EVAL.ts grades itself
+// with `toSatisfyCriterion`. Requires INTEGRATION_TEST + AI Gateway creds + sandbox.
+describe.skipIf(!process.env.INTEGRATION_TEST || !hasAiGatewayCredentials)('LLM judge (e2e)', () => {
+  it('grades an agent run via toSatisfyCriterion', async () => {
+    const fixtureDir = join(TEST_DIR, 'judge-eval-claude');
+    mkdirSync(join(fixtureDir, 'src'), { recursive: true });
+
+    writeFileSync(
+      join(fixtureDir, 'PROMPT.md'),
+      'Create src/greeting.ts that exports a function `greet()` returning the string "Hello!".'
+    );
+    writeFileSync(
+      join(fixtureDir, 'EVAL.ts'),
+      `
+import { test, expect } from 'vitest';
+import { transcript, diff } from './__agent_eval__/judge.mjs';
+
+test('implemented the greeting (judged on the diff)', async () => {
+  await expect(diff()).toSatisfyCriterion(
+    'A greet function that returns a greeting string was added'
+  );
+});
+
+test('did real work (judged on the transcript)', async () => {
+  await expect(transcript()).toSatisfyCriterion(
+    'The assistant created or edited a file to implement the requested task'
+  );
+});
+`
+    );
+    writeFileSync(
+      join(fixtureDir, 'package.json'),
+      JSON.stringify({
+        name: 'judge-eval-claude',
+        type: 'module',
+        devDependencies: { vitest: '^2.1.0' },
+      })
+    );
+    writeFileSync(join(fixtureDir, 'src/index.ts'), '// TODO: implement');
+
+    const fixture = loadFixture(TEST_DIR, 'judge-eval-claude');
+
+    const result = await runSingleEval(fixture, {
+      agent: 'vercel-ai-gateway/claude-code',
+      model: 'sonnet',
+      timeout: 180,
+      apiKey: process.env.AI_GATEWAY_API_KEY!,
+      scripts: [],
+    });
+
+    if (result.result.status === 'failed') {
+      console.error('judge e2e failed:', result.result.error);
+      console.error('eval output:', result.outputContent?.eval);
+    }
+    expect(result.result.status).toBe('passed');
+  }, 240000);
+});

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -7,6 +7,12 @@ import type { SandboxManager } from '../sandbox.js';
 import type { DockerSandboxManager } from '../docker-sandbox.js';
 import { parseTranscript } from '../o11y/index.js';
 import type { ValidationMode } from '../types.js';
+import {
+  getJudgeRuntimeSource,
+  resolveJudgeEnv,
+  TRANSCRIPT_EVENTS_PATH,
+  JUDGE_RUNTIME_PATH,
+} from '../judge.js';
 
 /** Union type for sandbox implementations */
 type AnySandbox = SandboxManager | DockerSandboxManager;
@@ -82,8 +88,17 @@ export async function runValidation(
     // Detect which eval file exists (EVAL.ts or EVAL.tsx)
     const evalFile = await detectEvalFile(sandbox);
 
-    // Always run vitest for the eval file (explicitly specify the file)
-    const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile]);
+    // Always run vitest for the eval file (explicitly specify the file).
+    // Forward gateway creds + judge model so in-eval `toSatisfyCriterion` LLM
+    // assertions can reach the model. Env is merged by the sandbox, not replaced,
+    // so PATH/etc. are preserved; when no gateway credential is present we pass no
+    // env and judge-based assertions are simply unavailable.
+    const judgeEnv = resolveJudgeEnv();
+    const testResult = await sandbox.runCommand(
+      'npx',
+      ['vitest', 'run', evalFile],
+      judgeEnv ? { env: judgeEnv } : {}
+    );
     results.test = {
       success: testResult.exitCode === 0,
       output: testResult.stdout + testResult.stderr,
@@ -237,6 +252,10 @@ export async function injectTranscriptContext(
 
     await sandbox.writeFiles({
       [TRANSCRIPT_CONTEXT_PATH]: JSON.stringify(context, null, 2),
+      // Full normalized transcript for LLM-judge assertions (toSatisfyCriterion).
+      [TRANSCRIPT_EVENTS_PATH]: JSON.stringify({ events: transcript?.events ?? [] }),
+      // Zero-dep judge runtime EVAL.ts can import (registers the matcher + helpers).
+      [JUDGE_RUNTIME_PATH]: getJudgeRuntimeSource(),
     });
   } catch {
     // Best-effort: don't fail the eval if context injection fails

--- a/packages/agent-eval/src/lib/judge-runtime.mjs
+++ b/packages/agent-eval/src/lib/judge-runtime.mjs
@@ -57,7 +57,14 @@ export function transcript() {
 /** The agent's code changes, as a unified diff against the pre-run commit. */
 export function diff() {
   try {
-    const out = execSync('git diff HEAD', { encoding: 'utf8' });
+    // Stage first so newly-created (untracked) files show up — `git diff HEAD`
+    // alone omits them, which is most of what an agent produces.
+    try {
+      execSync('git add -A', { stdio: 'ignore' });
+    } catch {
+      /* not a git repo */
+    }
+    const out = execSync('git diff --cached HEAD', { encoding: 'utf8' });
     return out ? out.slice(0, 100000) : '(no changes)';
   } catch {
     return '(diff unavailable)';
@@ -100,9 +107,11 @@ export async function judge(evidence, criterion, opts) {
     method: 'POST',
     headers: { authorization: 'Bearer ' + KEY, 'content-type': 'application/json' },
     body: JSON.stringify({
+      // No response_format: the gateway rejects OpenAI's json_object mode for
+      // several routes (e.g. Anthropic). We instruct JSON in the prompt and parse
+      // tolerantly (parseVerdict handles prose / ```json fences).
       model: model,
       temperature: 0,
-      response_format: { type: 'json_object' },
       messages: [
         {
           role: 'system',

--- a/packages/agent-eval/src/lib/judge-runtime.mjs
+++ b/packages/agent-eval/src/lib/judge-runtime.mjs
@@ -1,0 +1,154 @@
+/**
+ * agent-eval LLM-judge runtime — injected into the sandbox as `__agent_eval__/judge.mjs`.
+ *
+ * Zero-dependency on purpose: it runs inside the eval fixture's own vitest worker,
+ * so it relies only on the fixture's `vitest` (always present) and Node globals
+ * (`fetch`, `node:fs`, `node:child_process`). It must NOT import anything that the
+ * fixture wouldn't already have installed.
+ *
+ * Importing this module:
+ *   1. exposes evidence helpers — `transcript()`, `diff()`, `files()`
+ *   2. registers the async `expect(...).toSatisfyCriterion(criterion)` matcher
+ *
+ * Configuration comes from env (forwarded onto the `npx vitest` exec by the harness):
+ *   AI_GATEWAY_API_KEY / VERCEL_OIDC_TOKEN  — gateway auth (required)
+ *   AGENT_EVAL_JUDGE_MODEL                  — judge model id (required)
+ *   AGENT_EVAL_JUDGE_BASE_URL               — gateway base (default: AI Gateway)
+ *   AGENT_EVAL_DIR                          — context dir (default: __agent_eval__)
+ */
+import { expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const DIR = process.env.AGENT_EVAL_DIR || '__agent_eval__';
+const BASE = process.env.AGENT_EVAL_JUDGE_BASE_URL || 'https://ai-gateway.vercel.sh/v1';
+const MODEL = process.env.AGENT_EVAL_JUDGE_MODEL;
+const KEY = process.env.AI_GATEWAY_API_KEY || process.env.VERCEL_OIDC_TOKEN;
+
+function readJSON(path, fallback) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+/** Normalized agent transcript (assistant text, thinking, tool calls + results). */
+export function transcript() {
+  const data = readJSON(DIR + '/transcript.json', { events: [] });
+  const events = data.events || [];
+  if (!events.length) return '(transcript unavailable)';
+  return events
+    .map(function (e) {
+      if (e.type === 'tool_call' && e.tool) {
+        return '[tool:' + e.tool.name + '] ' + JSON.stringify(e.tool.args || {});
+      }
+      if (e.type === 'tool_result' && e.tool) {
+        const r =
+          typeof e.tool.result === 'string' ? e.tool.result : JSON.stringify(e.tool.result || '');
+        return '[result:' + e.tool.name + '] ' + String(r).slice(0, 2000);
+      }
+      const tag = e.type === 'thinking' ? 'thinking' : e.role || e.type;
+      return '[' + tag + '] ' + (e.content || '');
+    })
+    .join('\n');
+}
+
+/** The agent's code changes, as a unified diff against the pre-run commit. */
+export function diff() {
+  try {
+    const out = execSync('git diff HEAD', { encoding: 'utf8' });
+    return out ? out.slice(0, 100000) : '(no changes)';
+  } catch {
+    return '(diff unavailable)';
+  }
+}
+
+/** Contents of one or more files in the workspace, concatenated. */
+export function files(...paths) {
+  return paths
+    .map(function (p) {
+      try {
+        return '--- ' + p + ' ---\n' + readFileSync(p, 'utf8');
+      } catch {
+        return '--- ' + p + ' ---\n(missing)';
+      }
+    })
+    .join('\n\n');
+}
+
+function parseVerdict(content) {
+  // Tolerate prose / ```json fences around the JSON object.
+  const match = content.match(/\{[\s\S]*\}/);
+  return JSON.parse(match ? match[0] : content);
+}
+
+/** Ask the judge model whether `evidence` satisfies `criterion`. */
+export async function judge(evidence, criterion, opts) {
+  opts = opts || {};
+  if (!KEY) {
+    throw new Error(
+      'agent-eval judge: AI_GATEWAY_API_KEY (or VERCEL_OIDC_TOKEN) is not set in the eval environment'
+    );
+  }
+  const model = opts.model || MODEL;
+  if (!model) {
+    throw new Error('agent-eval judge: no judge model set (AGENT_EVAL_JUDGE_MODEL)');
+  }
+
+  const res = await fetch(BASE + '/chat/completions', {
+    method: 'POST',
+    headers: { authorization: 'Bearer ' + KEY, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: model,
+      temperature: 0,
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a strict grader for an AI coding-agent eval. Decide whether the EVIDENCE ' +
+            'satisfies the CRITERION. Reply ONLY with JSON of the form ' +
+            '{"pass": boolean, "reason": string}. Pass only if the criterion is clearly met.',
+        },
+        { role: 'user', content: 'CRITERION:\n' + criterion + '\n\nEVIDENCE:\n' + String(evidence) },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    let body = '';
+    try {
+      body = await res.text();
+    } catch {
+      /* ignore */
+    }
+    throw new Error('agent-eval judge: gateway error ' + res.status + ' ' + body);
+  }
+
+  const data = await res.json();
+  const content =
+    (data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) ||
+    '';
+  let verdict;
+  try {
+    verdict = parseVerdict(content);
+  } catch {
+    throw new Error('agent-eval judge: could not parse verdict JSON from model output: ' + content);
+  }
+  return { pass: !!verdict.pass, reason: String(verdict.reason == null ? '' : verdict.reason) };
+}
+
+expect.extend({
+  async toSatisfyCriterion(received, criterion, opts) {
+    const v = await judge(received, criterion, opts);
+    return {
+      pass: v.pass,
+      message: function () {
+        return v.pass
+          ? 'expected criterion NOT to be satisfied, but the judge passed it: ' + v.reason
+          : 'criterion not satisfied — judge: ' + v.reason;
+      },
+    };
+  },
+});

--- a/packages/agent-eval/src/lib/judge.test.ts
+++ b/packages/agent-eval/src/lib/judge.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_JUDGE_MODEL, getJudgeRuntimeSource, resolveJudgeEnv } from './judge.js';
+
+// --- unit: host-side env resolution (what we forward into the sandbox vitest) ---
+describe('resolveJudgeEnv', () => {
+  beforeEach(() => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    delete process.env.VERCEL_OIDC_TOKEN;
+    delete process.env.AGENT_EVAL_JUDGE_MODEL;
+    delete process.env.AGENT_EVAL_JUDGE_BASE_URL;
+  });
+
+  it('returns undefined without a gateway credential', () => {
+    expect(resolveJudgeEnv()).toBeUndefined();
+  });
+
+  it('uses the default judge model when none is configured', () => {
+    process.env.AI_GATEWAY_API_KEY = 'k';
+    expect(resolveJudgeEnv()).toEqual({
+      AI_GATEWAY_API_KEY: 'k',
+      AGENT_EVAL_JUDGE_MODEL: DEFAULT_JUDGE_MODEL,
+    });
+  });
+
+  it('respects AGENT_EVAL_JUDGE_MODEL and an explicit override', () => {
+    process.env.AI_GATEWAY_API_KEY = 'k';
+    process.env.AGENT_EVAL_JUDGE_MODEL = 'anthropic/from-env';
+    expect(resolveJudgeEnv()?.AGENT_EVAL_JUDGE_MODEL).toBe('anthropic/from-env');
+    expect(resolveJudgeEnv('explicit/model')?.AGENT_EVAL_JUDGE_MODEL).toBe('explicit/model');
+  });
+
+  it('falls back to VERCEL_OIDC_TOKEN', () => {
+    process.env.VERCEL_OIDC_TOKEN = 'oidc';
+    expect(resolveJudgeEnv()?.AI_GATEWAY_API_KEY).toBe('oidc');
+  });
+
+  it('forwards a custom base url when set', () => {
+    process.env.AI_GATEWAY_API_KEY = 'k';
+    process.env.AGENT_EVAL_JUDGE_BASE_URL = 'http://example/v1';
+    expect(resolveJudgeEnv()?.AGENT_EVAL_JUDGE_BASE_URL).toBe('http://example/v1');
+  });
+});
+
+// --- the runtime artifact that ships in the package + gets injected ---
+describe('judge runtime artifact', () => {
+  it('exposes helpers + the matcher and stays sandbox-portable', () => {
+    const src = getJudgeRuntimeSource();
+    expect(src).toContain('export function transcript');
+    expect(src).toContain('export function diff');
+    expect(src).toContain('toSatisfyCriterion');
+    expect(src).toContain("import { expect } from 'vitest'");
+    // Must not import anything beyond vitest + node builtins — it runs inside the
+    // eval fixture's sandbox, which only has the fixture's own deps.
+    expect(src).not.toMatch(/from ['"](?!vitest|node:)/);
+  });
+});
+
+// --- e2e: the injected runtime, driven through a real vitest matcher, gateway stubbed ---
+describe('toSatisfyCriterion (e2e, stubbed gateway)', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'agent-eval-judge-'));
+  const realFetch = globalThis.fetch;
+  let lastBody: { model: string; messages: unknown[] };
+  let nextVerdict: { pass: boolean; reason: string };
+  let rt: typeof import('./judge-runtime.mjs');
+
+  const stubFetch = (respond: () => unknown) => {
+    globalThis.fetch = (async (_url: string | URL, init: { body: string }) => {
+      lastBody = JSON.parse(init.body);
+      return { ok: true, status: 200, json: async () => respond(), text: async () => '' };
+    }) as unknown as typeof fetch;
+  };
+
+  beforeAll(async () => {
+    writeFileSync(
+      join(tmp, 'transcript.json'),
+      JSON.stringify({
+        events: [
+          { type: 'message', role: 'assistant', content: 'Opening React DevTools to inspect.' },
+          { type: 'tool_call', tool: { name: 'shell', args: { command: 'agent-browser react devtools' } } },
+        ],
+      })
+    );
+
+    process.env.AGENT_EVAL_DIR = tmp;
+    process.env.AGENT_EVAL_JUDGE_BASE_URL = 'http://stub.local/v1';
+    process.env.AGENT_EVAL_JUDGE_MODEL = 'stub/model';
+    process.env.AI_GATEWAY_API_KEY = 'stub-key';
+
+    stubFetch(() => ({ choices: [{ message: { content: JSON.stringify(nextVerdict) } }] }));
+
+    // Import the EXACT artifact that gets injected into the sandbox. Importing it
+    // registers `toSatisfyCriterion` on this file's vitest `expect`.
+    rt = await import('./judge-runtime.mjs');
+  });
+
+  afterAll(() => {
+    globalThis.fetch = realFetch;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reads the normalized transcript as evidence', () => {
+    const t = rt.transcript();
+    expect(t).toContain('Opening React DevTools');
+    expect(t).toContain('[tool:shell]');
+  });
+
+  it('passes when the judge returns pass, sending criterion + evidence to the gateway', async () => {
+    nextVerdict = { pass: true, reason: 'used devtools' };
+    await (expect(rt.transcript()) as { toSatisfyCriterion(c: string): Promise<void> }).toSatisfyCriterion(
+      'used React DevTools to diagnose'
+    );
+    expect(lastBody.model).toBe('stub/model');
+    expect(JSON.stringify(lastBody.messages)).toContain('used React DevTools to diagnose');
+    expect(JSON.stringify(lastBody.messages)).toContain('Opening React DevTools');
+  });
+
+  it('fails (rejects) when the judge returns fail, surfacing the reason', async () => {
+    nextVerdict = { pass: false, reason: 'no devtools used' };
+    await expect(
+      (expect(rt.transcript()) as { toSatisfyCriterion(c: string): Promise<void> }).toSatisfyCriterion(
+        'used React DevTools to diagnose'
+      )
+    ).rejects.toThrow(/no devtools used/);
+  });
+
+  it('tolerates prose / fenced JSON in the model output', async () => {
+    stubFetch(() => ({
+      choices: [{ message: { content: '```json\n{"pass": true, "reason": "ok"}\n```' } }],
+    }));
+    await expect(rt.judge('evidence', 'criterion')).resolves.toEqual({ pass: true, reason: 'ok' });
+  });
+});

--- a/packages/agent-eval/src/lib/judge.test.ts
+++ b/packages/agent-eval/src/lib/judge.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
 import { DEFAULT_JUDGE_MODEL, getJudgeRuntimeSource, resolveJudgeEnv } from './judge.js';
 
 // --- unit: host-side env resolution (what we forward into the sandbox vitest) ---
@@ -115,6 +117,9 @@ describe('toSatisfyCriterion (e2e, stubbed gateway)', () => {
     expect(lastBody.model).toBe('stub/model');
     expect(JSON.stringify(lastBody.messages)).toContain('used React DevTools to diagnose');
     expect(JSON.stringify(lastBody.messages)).toContain('Opening React DevTools');
+    // The gateway rejects OpenAI's json_object response_format on some routes
+    // (e.g. Anthropic) — we must not send it. Verified against the real gateway.
+    expect(Object.keys(lastBody)).not.toContain('response_format');
   });
 
   it('fails (rejects) when the judge returns fail, surfacing the reason', async () => {
@@ -132,4 +137,105 @@ describe('toSatisfyCriterion (e2e, stubbed gateway)', () => {
     }));
     await expect(rt.judge('evidence', 'criterion')).resolves.toEqual({ pass: true, reason: 'ok' });
   });
+});
+
+// --- e2e: the REAL in-sandbox path — a separate `vitest run EVAL.ts` process that
+// imports the injected runtime and judges against a local stub gateway. This mirrors
+// exactly what runValidation does in the sandbox (no agent / real gateway needed). ---
+describe('toSatisfyCriterion (e2e, real vitest subprocess)', () => {
+  async function runEval(opts: { verdict: { pass: boolean; reason: string }; criterion: string }) {
+    const dir = mkdtempSync(join(process.cwd(), '.judge-e2e-'));
+    let received: { model: string; messages: unknown[] } | undefined;
+
+    // Stub gateway. Must serve while the child runs, so the parent uses async spawn
+    // (a sync spawn would block this event loop and deadlock the request).
+    const server = createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        try {
+          received = JSON.parse(body);
+        } catch {
+          /* ignore */
+        }
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(opts.verdict) } }] }));
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    try {
+      // Reproduce what the harness injects into the sandbox.
+      mkdirSync(join(dir, '__agent_eval__'), { recursive: true });
+      writeFileSync(
+        join(dir, '__agent_eval__', 'transcript.json'),
+        JSON.stringify({
+          events: [{ type: 'message', role: 'assistant', content: 'opened react devtools' }],
+        })
+      );
+      writeFileSync(join(dir, '__agent_eval__', 'judge.mjs'), getJudgeRuntimeSource());
+      writeFileSync(
+        join(dir, 'vitest.config.ts'),
+        "import { defineConfig } from 'vitest/config';\n" +
+          "export default defineConfig({ test: { include: ['EVAL.ts'], globals: false } });\n"
+      );
+      writeFileSync(
+        join(dir, 'EVAL.ts'),
+        "import { test, expect } from 'vitest';\n" +
+          "import { transcript } from './__agent_eval__/judge.mjs';\n" +
+          'test(\'judged\', async () => {\n' +
+          `  await expect(transcript()).toSatisfyCriterion(${JSON.stringify(opts.criterion)});\n` +
+          '});\n'
+      );
+
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      for (const k of Object.keys(env)) if (k.startsWith('VITEST')) delete env[k];
+      env.AI_GATEWAY_API_KEY = 'stub';
+      env.AGENT_EVAL_JUDGE_MODEL = 'stub/model';
+      env.AGENT_EVAL_JUDGE_BASE_URL = `http://127.0.0.1:${port}/v1`;
+      // Absolute so the child's transcript read is independent of the worker cwd.
+      env.AGENT_EVAL_DIR = join(dir, '__agent_eval__');
+
+      const result = await new Promise<{ code: number | null; output: string }>((resolve) => {
+        // --root/--config pin the fixture's own config; otherwise the test's parent
+        // package vitest config is discovered up-tree. In the real sandbox the fixture
+        // is the only project, so the harness needs no such flags.
+        const child = spawn(
+          'npx',
+          ['vitest', 'run', '--root', dir, '--config', join(dir, 'vitest.config.ts'), 'EVAL.ts'],
+          { cwd: dir, env }
+        );
+        let out = '';
+        child.stdout.on('data', (d) => (out += d));
+        child.stderr.on('data', (d) => (out += d));
+        child.on('close', (code) => resolve({ code, output: out }));
+      });
+      return { ...result, received };
+    } finally {
+      server.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('passes the real vitest run when the judge passes, with criterion + evidence sent', async () => {
+    const { code, received } = await runEval({
+      verdict: { pass: true, reason: 'ok' },
+      criterion: 'the agent used React DevTools',
+    });
+    expect(code).toBe(0);
+    expect(received?.model).toBe('stub/model');
+    expect(JSON.stringify(received?.messages)).toContain('the agent used React DevTools');
+    expect(JSON.stringify(received?.messages)).toContain('opened react devtools');
+  }, 60000);
+
+  it('fails the real vitest run (surfacing the reason) when the judge fails', async () => {
+    const { code, output } = await runEval({
+      verdict: { pass: false, reason: 'NO_DEVTOOLS_MARKER' },
+      criterion: 'the agent used React DevTools',
+    });
+    expect(code).not.toBe(0);
+    expect(output).toContain('NO_DEVTOOLS_MARKER');
+  }, 60000);
 });

--- a/packages/agent-eval/src/lib/judge.ts
+++ b/packages/agent-eval/src/lib/judge.ts
@@ -1,0 +1,67 @@
+/**
+ * LLM-judge support (host side).
+ *
+ * The judge itself runs *inside* the sandbox, in the eval fixture's vitest worker
+ * (see `judge-runtime.mjs`). This module supplies the pieces the harness needs to
+ * wire that up:
+ *   - the runtime source to inject (`getJudgeRuntimeSource`)
+ *   - the sandbox paths it reads (`TRANSCRIPT_EVENTS_PATH`, `JUDGE_RUNTIME_PATH`)
+ *   - the env to forward onto the `npx vitest` exec (`resolveJudgeEnv`)
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Well-known context directory inside the sandbox (matches TRANSCRIPT_CONTEXT_DIR). */
+export const AGENT_EVAL_DIR = '__agent_eval__';
+
+/** Full normalized transcript (events), written for the judge to read. */
+export const TRANSCRIPT_EVENTS_PATH = `${AGENT_EVAL_DIR}/transcript.json`;
+
+/** Injected zero-dep judge runtime that EVAL.ts imports. */
+export const JUDGE_RUNTIME_PATH = `${AGENT_EVAL_DIR}/judge.mjs`;
+
+/**
+ * Default judge model. Independent of the model under test — judging should use a
+ * strong, fixed model so multi-model sweeps stay consistent and nothing self-scores.
+ * Override per-experiment via the `AGENT_EVAL_JUDGE_MODEL` env var.
+ */
+export const DEFAULT_JUDGE_MODEL = 'anthropic/claude-opus-4-8';
+
+let cachedSource: string | undefined;
+
+/**
+ * Read the judge runtime source (the `.mjs` shipped alongside this module).
+ * Works in dev (src) and in the published package (dist) because the build copies
+ * `judge-runtime.mjs` next to the compiled output.
+ */
+export function getJudgeRuntimeSource(): string {
+  if (cachedSource === undefined) {
+    const runtimeUrl = new URL('./judge-runtime.mjs', import.meta.url);
+    cachedSource = readFileSync(fileURLToPath(runtimeUrl), 'utf8');
+  }
+  return cachedSource;
+}
+
+/**
+ * Build the env to forward onto the in-sandbox `npx vitest` exec so the judge can
+ * reach the gateway. Returns `undefined` when no gateway credential is available
+ * (then judge-based assertions are simply not wired — vitest runs as before).
+ *
+ * @param model Optional explicit judge model (e.g. from experiment config). Falls
+ *   back to `AGENT_EVAL_JUDGE_MODEL`, then `DEFAULT_JUDGE_MODEL`.
+ */
+export function resolveJudgeEnv(model?: string): Record<string, string> | undefined {
+  const key = process.env.AI_GATEWAY_API_KEY ?? process.env.VERCEL_OIDC_TOKEN;
+  if (!key) return undefined;
+
+  const env: Record<string, string> = {
+    AI_GATEWAY_API_KEY: key,
+    AGENT_EVAL_JUDGE_MODEL: model ?? process.env.AGENT_EVAL_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL,
+  };
+
+  const base = process.env.AGENT_EVAL_JUDGE_BASE_URL;
+  if (base) env.AGENT_EVAL_JUDGE_BASE_URL = base;
+
+  return env;
+}


### PR DESCRIPTION
EVAL.ts can now grade qualitative criteria that deterministic assertions can't express — "debugged with React DevTools instead of guessing", "fixed it the idiomatic way" — via an async vitest matcher: `await expect(transcript()).toSatisfyCriterion('...')`. Evidence helpers `transcript()`, `diff()`, and `files()` are imported from an injected `__agent_eval__/judge.mjs`. A failed verdict is just a failed test, so it rides the existing pass-rate, result reuse, and dashboard with no new aggregation.

The judge runs inside the sandbox in the fixture's own vitest worker — zero-dependency (global `fetch` + the fixture's `vitest` only), so nothing is added to fixtures. It calls the AI Gateway with the credential the harness already forwards onto the `npx vitest` exec (`AI_GATEWAY_API_KEY` / `VERCEL_OIDC_TOKEN`), and the judge model is independent of the model under test so multi-model sweeps stay consistent and nothing self-scores — override with `AGENT_EVAL_JUDGE_MODEL`. The `__agent_eval__` context channel now also carries the full normalized transcript for evidence.

Two layers of e2e: a real-subprocess test that spawns an actual `vitest run EVAL.ts` importing the injected runtime and judging against a local stub gateway (runs in CI, no creds), and the full-stack `LLM judge (e2e)` — gated on `INTEGRATION_TEST` + gateway creds — which was run against a real Vercel sandbox + claude-code agent + AI Gateway judge (`anthropic/claude-opus-4-8`) and passes. That real run caught two bugs now fixed: the gateway 400s on OpenAI's `response_format: json_object` for Anthropic routes (dropped; the prompt instructs JSON and parsing is tolerant), and `diff()` must stage (`git add -A` + `git diff --cached HEAD`) so the agent's new untracked files show up.
