### PR TITLE
[agent-eval] judge: codebase() — explore the workspace instead of pre-collected evidence

### DIFF
--- a/.changeset/judge-codebase-explore.md
+++ b/.changeset/judge-codebase-explore.md
@@ -1,0 +1,12 @@
+---
+'@vercel/agent-eval': minor
+---
+
+Add `codebase()` evidence for LLM-judge assertions — the judge explores the workspace itself instead of grading pre-collected evidence:
+
+```ts
+import { codebase } from './__agent_eval__/judge.mjs';
+await expect(codebase()).toSatisfyCriterion('greet() is exported and returns a non-empty string');
+```
+
+It reuses an agent CLI already installed in the sandbox (native exploration), and falls back to a built-in, path-sandboxed tool-loop (`read_file`/`grep`/`list_dir`) — force the loop with `AGENT_EVAL_JUDGE_EXPLORER=fetch`. The generated vitest config now uses a higher `testTimeout` so judge assertions (which call a model, and may run a multi-turn explorer) aren't killed by the 5s default.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ Evidence helpers (import from `./__agent_eval__/judge.mjs`):
 | `transcript()` | The agent's full run — assistant text, thinking, tool calls + results |
 | `diff()` | The agent's code changes (`git diff` against the pre-run state) |
 | `files(...paths)` | The contents of specific files |
+| `codebase()` | Nothing up front — the judge **explores** the workspace itself (reads files, greps, runs the code) |
+
+For judgments that need to roam the project ("is this implemented correctly/idiomatically?"), pass `codebase()` instead of pre-collected evidence:
+
+```ts
+import { codebase } from './__agent_eval__/judge.mjs';
+await expect(codebase()).toSatisfyCriterion('greet() is exported and returns a non-empty string');
+```
+
+`codebase()` reuses an agent CLI already installed in the sandbox (it explores natively), and falls back to a built-in tool-loop (`read_file`/`grep`/`list_dir`, path-sandboxed to the project) when no CLI is present. Force the loop with `AGENT_EVAL_JUDGE_EXPLORER=fetch`. It's heavier than the single-shot helpers (multiple model calls / a sub-agent run), so reach for it only when fixed evidence won't do.
 
 The judge runs **inside the sandbox** (in your eval's vitest worker) and calls the AI Gateway — it's zero-dependency, so nothing is added to your fixture. It needs a gateway credential in the environment (`AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`); the harness forwards it automatically. The judge model is **independent of the model under test** (so multi-model sweeps stay consistent and nothing self-scores) — it defaults to a strong model and is overridable with `AGENT_EVAL_JUDGE_MODEL`. See [Environment Variables](#environment-variables).
 

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -1408,7 +1408,7 @@ describe.skipIf(!process.env.INTEGRATION_TEST || !hasAiGatewayCredentials)('LLM 
       join(fixtureDir, 'EVAL.ts'),
       `
 import { test, expect } from 'vitest';
-import { transcript, diff } from './__agent_eval__/judge.mjs';
+import { transcript, diff, codebase } from './__agent_eval__/judge.mjs';
 
 test('implemented the greeting (judged on the diff)', async () => {
   await expect(diff()).toSatisfyCriterion(
@@ -1419,6 +1419,12 @@ test('implemented the greeting (judged on the diff)', async () => {
 test('did real work (judged on the transcript)', async () => {
   await expect(transcript()).toSatisfyCriterion(
     'The assistant created or edited a file to implement the requested task'
+  );
+});
+
+test('implementation is correct (judged by exploring the codebase)', async () => {
+  await expect(codebase()).toSatisfyCriterion(
+    'The project exports a greet() function that returns a non-empty greeting string'
   );
 });
 `
@@ -1443,10 +1449,9 @@ test('did real work (judged on the transcript)', async () => {
       scripts: [],
     });
 
-    if (result.result.status === 'failed') {
-      console.error('judge e2e failed:', result.result.error);
-      console.error('eval output:', result.outputContent?.eval);
-    }
+    // Surface the in-sandbox vitest output (incl. which judge explorer ran).
+    console.error('eval output:\n' + (result.outputContent?.eval ?? ''));
+    if (result.result.status === 'failed') console.error('judge e2e failed:', result.result.error);
     expect(result.result.status).toBe('passed');
   }, 240000);
 });

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -223,6 +223,9 @@ export default defineConfig({
   test: {
     include: ['${evalFile}'],
     globals: false,
+    // LLM-judge assertions call a model (and codebase() may run a multi-turn
+    // explorer or agent CLI), so the 5s default is far too low.
+    testTimeout: 120000,
   },
 });
 `,

--- a/packages/agent-eval/src/lib/judge-runtime.mjs
+++ b/packages/agent-eval/src/lib/judge-runtime.mjs
@@ -17,8 +17,9 @@
  *   AGENT_EVAL_DIR                          — context dir (default: __agent_eval__)
  */
 import { expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { execSync, execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
 
 const DIR = process.env.AGENT_EVAL_DIR || '__agent_eval__';
 const BASE = process.env.AGENT_EVAL_JUDGE_BASE_URL || 'https://ai-gateway.vercel.sh/v1';
@@ -103,42 +104,21 @@ export async function judge(evidence, criterion, opts) {
     throw new Error('agent-eval judge: no judge model set (AGENT_EVAL_JUDGE_MODEL)');
   }
 
-  const res = await fetch(BASE + '/chat/completions', {
-    method: 'POST',
-    headers: { authorization: 'Bearer ' + KEY, 'content-type': 'application/json' },
-    body: JSON.stringify({
-      // No response_format: the gateway rejects OpenAI's json_object mode for
-      // several routes (e.g. Anthropic). We instruct JSON in the prompt and parse
-      // tolerantly (parseVerdict handles prose / ```json fences).
-      model: model,
-      temperature: 0,
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are a strict grader for an AI coding-agent eval. Decide whether the EVIDENCE ' +
-            'satisfies the CRITERION. Reply ONLY with JSON of the form ' +
-            '{"pass": boolean, "reason": string}. Pass only if the criterion is clearly met.',
-        },
-        { role: 'user', content: 'CRITERION:\n' + criterion + '\n\nEVIDENCE:\n' + String(evidence) },
-      ],
-    }),
+  const data = await chatCompletion({
+    model: model,
+    temperature: 0,
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are a strict grader for an AI coding-agent eval. Decide whether the EVIDENCE ' +
+          'satisfies the CRITERION. Reply ONLY with JSON of the form ' +
+          '{"pass": boolean, "reason": string}. Pass only if the criterion is clearly met.',
+      },
+      { role: 'user', content: 'CRITERION:\n' + criterion + '\n\nEVIDENCE:\n' + String(evidence) },
+    ],
   });
-
-  if (!res.ok) {
-    let body = '';
-    try {
-      body = await res.text();
-    } catch {
-      /* ignore */
-    }
-    throw new Error('agent-eval judge: gateway error ' + res.status + ' ' + body);
-  }
-
-  const data = await res.json();
-  const content =
-    (data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) ||
-    '';
+  const content = msgContent(data);
   let verdict;
   try {
     verdict = parseVerdict(content);
@@ -148,9 +128,275 @@ export async function judge(evidence, criterion, opts) {
   return { pass: !!verdict.pass, reason: String(verdict.reason == null ? '' : verdict.reason) };
 }
 
+/* ───────────────────────────── gateway plumbing ───────────────────────────── */
+
+// No response_format: the gateway rejects OpenAI's json_object mode for several
+// routes (e.g. Anthropic). We instruct JSON in the prompt and parse tolerantly.
+async function chatCompletion(body) {
+  if (!KEY) {
+    throw new Error(
+      'agent-eval judge: AI_GATEWAY_API_KEY (or VERCEL_OIDC_TOKEN) is not set in the eval environment'
+    );
+  }
+  const res = await fetch(BASE + '/chat/completions', {
+    method: 'POST',
+    headers: { authorization: 'Bearer ' + KEY, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let text = '';
+    try {
+      text = await res.text();
+    } catch {
+      /* ignore */
+    }
+    throw new Error('agent-eval judge: gateway error ' + res.status + ' ' + text);
+  }
+  return res.json();
+}
+
+function msgContent(data) {
+  return (
+    (data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content) || ''
+  );
+}
+
+/* ─────────────────────────── codebase exploration ─────────────────────────── */
+
+/**
+ * Sentinel evidence: `expect(codebase()).toSatisfyCriterion(...)` makes the judge
+ * EXPLORE the workspace (read files, grep, run the code) rather than grade a fixed
+ * string. `root` defaults to the eval's working directory inside the sandbox.
+ */
+export function codebase(root) {
+  return { __agentEvalKind: 'codebase', root: root || process.cwd() };
+}
+
+const JUDGE_SYSTEM =
+  'You are a strict grader for an AI coding-agent eval. Investigate the project, then decide ' +
+  'whether it clearly meets the CRITERION. Be skeptical; pass only if it is clearly met.';
+
+// Prefer reusing an agent CLI already installed in the sandbox (it explores
+// natively); fall back to a fetch tool-loop. Set AGENT_EVAL_JUDGE_EXPLORER=fetch
+// to force the loop.
+function findCli() {
+  if ((process.env.AGENT_EVAL_JUDGE_EXPLORER || '').toLowerCase() === 'fetch') return null;
+  for (const bin of ['claude']) {
+    try {
+      execFileSync('command', ['-v', bin], { stdio: 'ignore', shell: true });
+      return bin;
+    } catch {
+      /* not installed */
+    }
+  }
+  return null;
+}
+
+function exploreViaCli(bin, root, criterion, opts) {
+  const model = opts.model || MODEL;
+  const prompt =
+    JUDGE_SYSTEM +
+    '\n\nCRITERION:\n' +
+    criterion +
+    '\n\nInspect this project (read files, run commands as needed), then respond with ONLY ' +
+    'a JSON object: {"pass": boolean, "reason": string}.';
+  // The CLI talks to the same gateway, anthropic-style base (no /v1), bearer = KEY.
+  const env = Object.assign({}, process.env, {
+    ANTHROPIC_BASE_URL: BASE.replace(/\/v1\/?$/, ''),
+    ANTHROPIC_AUTH_TOKEN: KEY,
+    ANTHROPIC_API_KEY: '',
+  });
+  const args = ['-p', prompt, '--output-format', 'json', '--dangerously-skip-permissions'];
+  if (model) args.push('--model', model);
+  const out = execFileSync(bin, args, { cwd: root, encoding: 'utf8', env: env, maxBuffer: 32 * 1024 * 1024 });
+  // claude -p --output-format json => { result: "<final text>" }
+  let text = out;
+  try {
+    text = JSON.parse(out).result || out;
+  } catch {
+    /* not JSON-wrapped; use raw output */
+  }
+  return parseVerdict(text);
+}
+
+function safePath(root, rel) {
+  const abs = resolve(root, rel || '.');
+  return abs === root || abs.startsWith(root + '/') ? abs : null;
+}
+
+function toolDef(name, description, props, required) {
+  const properties = {};
+  for (const k of Object.keys(props)) properties[k] = { type: props[k] };
+  return {
+    type: 'function',
+    function: { name: name, description: description, parameters: { type: 'object', properties, required } },
+  };
+}
+
+const EXPLORER_TOOLS = [
+  toolDef('list_dir', 'List entries at a path relative to the project root.', { path: 'string' }, []),
+  toolDef(
+    'read_file',
+    'Read a file relative to the project root (optional line offset/limit).',
+    { path: 'string', offset: 'number', limit: 'number' },
+    ['path']
+  ),
+  toolDef(
+    'grep',
+    'Regex search across files under a dir relative to the project root.',
+    { pattern: 'string', path: 'string' },
+    ['pattern']
+  ),
+  toolDef(
+    'submit_verdict',
+    'Submit your final judgment once you have enough evidence.',
+    { pass: 'boolean', reason: 'string' },
+    ['pass', 'reason']
+  ),
+];
+
+function runTool(root, name, args) {
+  const target = safePath(root, args.path);
+  if (name === 'list_dir') {
+    if (!target) return { error: 'path outside project root' };
+    try {
+      return {
+        entries: readdirSync(target).map((e) => ({ name: e, dir: statSync(resolve(target, e)).isDirectory() })),
+      };
+    } catch {
+      return { error: 'cannot list ' + args.path };
+    }
+  }
+  if (name === 'read_file') {
+    if (!target) return { error: 'path outside project root' };
+    try {
+      const lines = readFileSync(target, 'utf8').split('\n');
+      const offset = args.offset || 0;
+      const limit = args.limit || 400;
+      return { content: lines.slice(offset, offset + limit).join('\n'), totalLines: lines.length };
+    } catch {
+      return { error: 'cannot read ' + args.path };
+    }
+  }
+  if (name === 'grep') {
+    const base = safePath(root, args.path || '.');
+    if (!base) return { error: 'path outside project root' };
+    let re;
+    try {
+      re = new RegExp(args.pattern, 'i');
+    } catch {
+      return { error: 'bad regex' };
+    }
+    const matches = [];
+    const walk = (dir) => {
+      let entries = [];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        if (matches.length >= 50) return;
+        if (e === 'node_modules' || e === '.git') continue;
+        const p = resolve(dir, e);
+        let st;
+        try {
+          st = statSync(p);
+        } catch {
+          continue;
+        }
+        if (st.isDirectory()) {
+          walk(p);
+        } else {
+          try {
+            readFileSync(p, 'utf8')
+              .split('\n')
+              .forEach((ln, i) => {
+                if (matches.length < 50 && re.test(ln)) {
+                  matches.push(p.slice(root.length + 1) + ':' + (i + 1) + ': ' + ln.slice(0, 200));
+                }
+              });
+          } catch {
+            /* skip binary/unreadable */
+          }
+        }
+      }
+    };
+    walk(base);
+    return { matches };
+  }
+  return { error: 'unknown tool ' + name };
+}
+
+async function exploreViaFetch(root, criterion, opts) {
+  const model = opts.model || MODEL;
+  if (!model) throw new Error('agent-eval judge: no judge model set (AGENT_EVAL_JUDGE_MODEL)');
+  const messages = [
+    { role: 'system', content: JUDGE_SYSTEM },
+    {
+      role: 'user',
+      content: 'CRITERION:\n' + criterion + '\n\nInspect the project from its root, then call submit_verdict.',
+    },
+  ];
+  for (let turn = 0; turn < 12; turn++) {
+    const data = await chatCompletion({
+      model: model,
+      temperature: 0,
+      tools: EXPLORER_TOOLS,
+      tool_choice: 'auto',
+      messages: messages,
+    });
+    const msg = data.choices[0].message;
+    messages.push(msg);
+    const calls = msg.tool_calls || [];
+    if (!calls.length) return parseVerdict(msg.content || ''); // model answered in prose
+    for (const c of calls) {
+      let args = {};
+      try {
+        args = JSON.parse(c.function.arguments || '{}');
+      } catch {
+        /* ignore malformed args */
+      }
+      if (c.function.name === 'submit_verdict') {
+        return { pass: !!args.pass, reason: String(args.reason == null ? '' : args.reason) };
+      }
+      const result = runTool(root, c.function.name, args);
+      messages.push({ role: 'tool', tool_call_id: c.id, content: JSON.stringify(result).slice(0, 8000) });
+    }
+  }
+  throw new Error('agent-eval judge: explorer exceeded its turn budget without a verdict');
+}
+
+async function explore(root, criterion, opts) {
+  const bin = findCli();
+  if (bin) {
+    try {
+      const verdict = exploreViaCli(bin, root, criterion, opts);
+      console.error('[agent-eval judge] explored via ' + bin + ' CLI');
+      return verdict;
+    } catch (e) {
+      console.error(
+        '[agent-eval judge] ' + bin + ' CLI explorer failed, falling back to fetch loop: ' +
+          (e && e.message ? e.message : e)
+      );
+    }
+  }
+  console.error('[agent-eval judge] explored via fetch tool-loop');
+  return exploreViaFetch(root, criterion, opts);
+}
+
+// Exposed for unit tests only (not part of the public surface).
+export const __test = { runTool, safePath };
+
+/* ───────────────────────────────── matcher ────────────────────────────────── */
+
 expect.extend({
   async toSatisfyCriterion(received, criterion, opts) {
-    const v = await judge(received, criterion, opts);
+    opts = opts || {};
+    const v =
+      received && received.__agentEvalKind === 'codebase'
+        ? await explore(received.root, criterion, opts)
+        : await judge(String(received), criterion, opts);
     return {
       pass: v.pass,
       message: function () {

--- a/packages/agent-eval/src/lib/judge.test.ts
+++ b/packages/agent-eval/src/lib/judge.test.ts
@@ -239,3 +239,73 @@ describe('toSatisfyCriterion (e2e, real vitest subprocess)', () => {
     expect(output).toContain('NO_DEVTOOLS_MARKER');
   }, 60000);
 });
+
+// --- codebase() agentic explorer: fetch tool-loop path, stubbed gateway, real fs ---
+describe('codebase() exploration (fetch tool-loop, stubbed gateway)', () => {
+  const ws = mkdtempSync(join(tmpdir(), 'agent-eval-ws-'));
+  const realFetch = globalThis.fetch;
+  let rt: typeof import('./judge-runtime.mjs');
+
+  // Queue gateway responses; the loop drives them turn by turn.
+  let responses: unknown[];
+  let seen: { tools?: { function: { name: string } }[]; messages: unknown[] }[];
+  const stub = () => {
+    let i = 0;
+    globalThis.fetch = (async (_url: string | URL, init: { body: string }) => {
+      seen.push(JSON.parse(init.body));
+      const r = responses[Math.min(i++, responses.length - 1)];
+      return { ok: true, status: 200, json: async () => r, text: async () => '' };
+    }) as unknown as typeof fetch;
+  };
+
+  beforeAll(async () => {
+    writeFileSync(join(ws, 'greeting.ts'), 'export function greet() {\n  return "Hello!";\n}\n');
+    process.env.AGENT_EVAL_JUDGE_EXPLORER = 'fetch'; // skip CLI detection → use the loop
+    process.env.AI_GATEWAY_API_KEY = 'stub-key';
+    process.env.AGENT_EVAL_JUDGE_MODEL = 'stub/model';
+    rt = await import('./judge-runtime.mjs');
+  });
+
+  beforeEach(() => {
+    seen = [];
+    stub();
+  });
+
+  afterAll(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.AGENT_EVAL_JUDGE_EXPLORER;
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const toolCall = (name: string, args: unknown) => ({
+    choices: [
+      { message: { role: 'assistant', content: null, tool_calls: [{ id: name, type: 'function', function: { name, arguments: JSON.stringify(args) } }] } },
+    ],
+  });
+
+  it('reads a file via a tool call, feeds it back, then passes on submit_verdict', async () => {
+    responses = [
+      toolCall('read_file', { path: 'greeting.ts' }),
+      toolCall('submit_verdict', { pass: true, reason: 'greet returns a greeting' }),
+    ];
+    await (expect(rt.codebase(ws)) as { toSatisfyCriterion(c: string): Promise<void> }).toSatisfyCriterion(
+      'greet() returns a non-empty greeting'
+    );
+    // turn 1 sent the tool definitions...
+    expect(seen[0].tools?.some((t) => t.function.name === 'read_file')).toBe(true);
+    // ...and turn 2 carried the real file contents back as a tool result.
+    expect(JSON.stringify(seen[1].messages)).toContain('Hello!');
+  });
+
+  it('rejects (with the reason) when submit_verdict is pass:false', async () => {
+    responses = [toolCall('submit_verdict', { pass: false, reason: 'NO_GREET_FOUND' })];
+    await expect(
+      (expect(rt.codebase(ws)) as { toSatisfyCriterion(c: string): Promise<void> }).toSatisfyCriterion('x')
+    ).rejects.toThrow(/NO_GREET_FOUND/);
+  });
+
+  it('guards against path traversal in tools', () => {
+    const r = rt.__test.runTool(ws, 'read_file', { path: '../../etc/passwd' });
+    expect(r.error).toMatch(/outside/);
+  });
+});

--- a/packages/agent-eval/src/lib/judge.ts
+++ b/packages/agent-eval/src/lib/judge.ts
@@ -63,5 +63,10 @@ export function resolveJudgeEnv(model?: string): Record<string, string> | undefi
   const base = process.env.AGENT_EVAL_JUDGE_BASE_URL;
   if (base) env.AGENT_EVAL_JUDGE_BASE_URL = base;
 
+  // codebase() explorer strategy: 'fetch' forces the tool-loop; otherwise an
+  // in-sandbox agent CLI is used when present.
+  const explorer = process.env.AGENT_EVAL_JUDGE_EXPLORER;
+  if (explorer) env.AGENT_EVAL_JUDGE_EXPLORER = explorer;
+
   return env;
 }


### PR DESCRIPTION
Stacked on #157. Adds `codebase()` evidence for LLM-judge assertions: instead of grading pre-collected text, the judge **explores the workspace itself**.

```ts
import { codebase } from './__agent_eval__/judge.mjs';
await expect(codebase()).toSatisfyCriterion('greet() is exported and returns a non-empty string');
```

`codebase()` is a sentinel; when the matcher sees it, it explores rather than single-shots. It **reuses an agent CLI already installed in the sandbox** (it reads/greps/runs natively) and falls back to a built-in tool-loop (`read_file`/`grep`/`list_dir` over OpenAI tool-calling, path-sandboxed to the project) when no CLI is present — `AGENT_EVAL_JUDGE_EXPLORER=fetch` forces the loop. This sidesteps `diff()`'s footguns (it reads the live tree, untracked files included) and can run the code, not just read it. It's heavier (a sub-agent run / multiple model calls), so it's opt-in per assertion. The generated vitest config bumps `testTimeout` to 120s since a judge call / explorer would blow the 5s default.

Verified against the real gateway both ways via the gated full-stack e2e (real sandbox + claude-code agent): default mode logged `explored via claude CLI`, and `AGENT_EVAL_JUDGE_EXPLORER=fetch` exercised real multi-turn tool-calling — both pass. Hermetic coverage drives the tool-loop against a stub gateway (a real `read_file` tool call feeding real file contents back, then `submit_verdict`) plus a path-traversal guard. Full suite 231 passed, lint/build green.
