### PR TITLE
[judge] Agentic LLM judge: judge codebases and transcripts

### DIFF
--- a/.changeset/agentic-judge.md
+++ b/.changeset/agentic-judge.md
@@ -1,0 +1,19 @@
+---
+'@vercel/agent-eval': minor
+---
+
+Add `judge()` — an agentic LLM judge built on the plugin model. It runs a real agent as the judge: the agent explores a codebase with its own tools and/or reads a transcript, then returns a structured verdict.
+
+```ts
+import { judge } from '@vercel/agent-eval';
+
+const v = await judge({
+  criteria: ['greet() is exported and returns a non-empty string', 'imports next/link'],
+  codebase: '/path/to/project',   // the judge agent explores it (agentic)
+  transcript,                      // and/or judge how the agent worked
+});
+v.pass;       // true iff every criterion passed
+v.results;    // [{ criterion, pass, reason }, ...]
+```
+
+A judge is just an agent run, so it reuses the whole plugin orchestrator (sandbox, CLI, agentic tool use) and writes its verdict to a file captured back to the host — working across every supported agent. The judge model is independent of the model under test.

--- a/README.md
+++ b/README.md
@@ -496,6 +496,48 @@ Classification uses Claude Sonnet 4.5 via the Vercel AI Gateway with sandboxed r
 - **Enabled** (with `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`): Classifications are cached in `classification.json`. Non-model failures are removed by default so they can be re-run; pass `--ack-failures` to keep them as final results.
 - **Disabled** (without keys): The classifier is skipped. All results are preserved as-is. Housekeeping will not remove non-model failures (only incomplete and duplicate results). Add `AI_GATEWAY_API_KEY` to `.env` to enable the classifier.
 
+## LLM Judge
+
+For qualitative checks that deterministic `EVAL.ts` tests can't express — "is the code idiomatic?", "did the agent debug with DevTools instead of guessing?" — use the agentic `judge()`. It runs a real agent as the judge: it **explores** a codebase with its own tools and/or reads a transcript, then returns a structured verdict. (A judge is just an agent run, so it reuses the same sandbox + plugin machinery as evals.)
+
+```typescript
+import { judge } from '@vercel/agent-eval';
+
+// Judge a codebase — the judge agent explores it:
+const v = await judge({
+  criteria: 'The project exports a greet() function that returns a non-empty string',
+  codebase: '/path/to/project',
+});
+v.pass; // boolean
+
+// Judge a transcript — how the agent worked:
+await judge({
+  criteria: 'Used React DevTools to diagnose, not trial-and-error edits',
+  transcript,
+});
+
+// Both, with several criteria (each judged independently):
+const r = await judge({
+  criteria: ['greet() is exported', 'imports next/link', 'no force-dynamic'],
+  codebase: '/path/to/project',
+  transcript,
+});
+r.pass;                      // true iff every criterion passed
+r.results;                   // [{ criterion, pass, reason }, ...]
+```
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `criteria` | — | One criterion or an array; each is judged independently with its own pass/reason |
+| `codebase` | — | A directory the judge agent explores (`node_modules`/`.git` excluded) |
+| `transcript` | — | A transcript string the judge reads (at least one of `codebase`/`transcript` is required) |
+| `agent` | `vercel-ai-gateway/claude-code` | Which agent acts as the judge |
+| `model` | the judge agent's default | Judge model (independent of the model under test) |
+| `apiKey` | `process.env[agent.getApiKeyEnvVar()]` | Judge agent credential |
+| `timeout` | `600` | Sandbox timeout (seconds) |
+
+The judge runs in a sandbox and needs the judge agent's credential (e.g. `AI_GATEWAY_API_KEY`). It writes its verdict to a file that's captured back to the host, so it works across every supported agent.
+
 ## Housekeeping
 
 After each experiment completes, the framework automatically:

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -145,3 +145,7 @@ export {
   parseCodexTranscript,
   parseOpenCodeTranscript,
 } from './lib/o11y/index.js';
+
+// Re-export the agentic LLM judge
+export type { JudgeOptions, JudgeVerdict, CriterionVerdict } from './lib/judge.js';
+export { judge, buildJudgePrompt, parseJudgeVerdict } from './lib/judge.js';

--- a/packages/agent-eval/src/lib/judge.test.ts
+++ b/packages/agent-eval/src/lib/judge.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { buildJudgePrompt, parseJudgeVerdict, judge, isFixtureExcluded } from './judge.js';
+
+describe('buildJudgePrompt', () => {
+  it('includes codebase + transcript instructions and lists criteria', () => {
+    const p = buildJudgePrompt(['greet() is exported', 'uses next/link'], {
+      hasCodebase: true,
+      hasTranscript: true,
+    });
+    expect(p).toContain('Inspect the project in the current directory');
+    expect(p).toContain('__judge__/transcript.md');
+    expect(p).toContain('1. greet() is exported');
+    expect(p).toContain('2. uses next/link');
+    expect(p).toContain('__judge__/verdict.json');
+    expect(p).toContain('"results"');
+  });
+
+  it('omits the codebase instruction when there is no codebase', () => {
+    const p = buildJudgePrompt(['x'], { hasCodebase: false, hasTranscript: true });
+    expect(p).not.toContain('Inspect the project in the current directory');
+    expect(p).toContain("transcript");
+  });
+
+  it('omits the transcript instruction when there is no transcript', () => {
+    const p = buildJudgePrompt(['x'], { hasCodebase: true, hasTranscript: false });
+    expect(p).not.toContain('__judge__/transcript.md');
+  });
+});
+
+describe('parseJudgeVerdict', () => {
+  const criteria = ['c1', 'c2'];
+
+  it('parses a clean results object', () => {
+    const raw = JSON.stringify({
+      results: [
+        { criterion: 'c1', pass: true, reason: 'ok' },
+        { criterion: 'c2', pass: false, reason: 'nope' },
+      ],
+    });
+    expect(parseJudgeVerdict(raw, criteria)).toEqual([
+      { criterion: 'c1', pass: true, reason: 'ok' },
+      { criterion: 'c2', pass: false, reason: 'nope' },
+    ]);
+  });
+
+  it('tolerates prose and ```json fences around the object', () => {
+    const raw = 'Here is my verdict:\n```json\n{"results":[{"criterion":"c1","pass":true,"reason":"good"}]}\n```\nDone.';
+    expect(parseJudgeVerdict(raw, ['c1'])).toEqual([{ criterion: 'c1', pass: true, reason: 'good' }]);
+  });
+
+  it('backfills the criterion text from the input when the model omits it', () => {
+    const raw = '{"results":[{"pass":true,"reason":"r1"},{"pass":false,"reason":"r2"}]}';
+    const out = parseJudgeVerdict(raw, criteria);
+    expect(out[0].criterion).toBe('c1');
+    expect(out[1].criterion).toBe('c2');
+  });
+
+  it('coerces pass to a boolean', () => {
+    const raw = '{"results":[{"criterion":"c1","pass":"yes","reason":"r"}]}';
+    expect(parseJudgeVerdict(raw, ['c1'])[0].pass).toBe(true);
+  });
+
+  it('throws when there is no parseable verdict', () => {
+    expect(() => parseJudgeVerdict('no json here', criteria)).toThrow(/could not parse/);
+    expect(() => parseJudgeVerdict(undefined, criteria)).toThrow(/could not parse/);
+  });
+});
+
+describe('isFixtureExcluded', () => {
+  it('excludes node_modules and .git trees (whole-segment match)', () => {
+    expect(isFixtureExcluded(join('node_modules', 'react', 'index.js'))).toBe(true);
+    expect(isFixtureExcluded(join('.git', 'HEAD'))).toBe(true);
+    expect(isFixtureExcluded('node_modules')).toBe(true);
+    expect(isFixtureExcluded('.git')).toBe(true);
+  });
+
+  it('KEEPS .github / .gitignore / sources (no loose substring match)', () => {
+    expect(isFixtureExcluded(join('.github', 'workflows', 'ci.yml'))).toBe(false);
+    expect(isFixtureExcluded('.gitignore')).toBe(false);
+    expect(isFixtureExcluded('.gitattributes')).toBe(false);
+    expect(isFixtureExcluded(join('src', 'index.ts'))).toBe(false);
+    expect(isFixtureExcluded('')).toBe(false); // the codebase root itself
+  });
+});
+
+describe('judge (input validation, no sandbox)', () => {
+  const saved = { ...process.env };
+  beforeEach(() => {
+    process.env = { ...saved };
+  });
+  afterEach(() => {
+    process.env = saved;
+  });
+
+  it('requires at least one criterion', async () => {
+    await expect(judge({ criteria: [], transcript: 't' })).rejects.toThrow(/at least one criterion/);
+  });
+
+  it('requires a codebase or a transcript', async () => {
+    await expect(judge({ criteria: 'c' })).rejects.toThrow(/codebase.*or.*transcript|provide a/);
+  });
+
+  it('requires an API key (no sandbox is created before this check)', async () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    await expect(judge({ criteria: 'c', transcript: 't' })).rejects.toThrow(/no API key.*AI_GATEWAY_API_KEY/);
+  });
+});

--- a/packages/agent-eval/src/lib/judge.ts
+++ b/packages/agent-eval/src/lib/judge.ts
@@ -1,0 +1,252 @@
+/**
+ * Agentic LLM judge.
+ *
+ * `judge()` runs a real agent — the same plugin agents the framework already
+ * orchestrates — as a JUDGE. It explores a codebase and/or reads a transcript,
+ * evaluates your criteria, and returns a structured verdict.
+ *
+ * Because a judge is just an agent run, it reuses the entire plugin orchestrator
+ * (sandbox lifecycle, CLI install, agentic tool use) via `runWithDefinition`. The
+ * judge agent inspects the project with its OWN tools (read/grep/run) rather than
+ * grading a fixed evidence blob — i.e. it is genuinely agentic. The verdict is
+ * returned the same way an eval's generated files are: the judge writes a small
+ * JSON file and the orchestrator's git-diff capture brings it back to the host.
+ *
+ * Super-easy usage:
+ *
+ *   import { judge } from '@vercel/agent-eval';
+ *
+ *   // Judge a codebase (the judge agent explores it):
+ *   const v = await judge({
+ *     criteria: 'greet() is exported and returns a non-empty string',
+ *     codebase: '/path/to/project',
+ *   });
+ *   v.pass; // boolean
+ *
+ *   // Judge a transcript (how the agent worked):
+ *   await judge({
+ *     criteria: 'Used React DevTools to diagnose, not trial-and-error',
+ *     transcript,
+ *   });
+ *
+ *   // Judge both, with several criteria:
+ *   await judge({ criteria: ['…', '…'], codebase: '/p', transcript });
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, sep, relative } from 'node:path';
+
+// Import from the registry's index (NOT registry.js) so the built-in agents are
+// registered as a side effect before getAgent() is called.
+import { getAgent } from './agents/index.js';
+import type { AgentType, ModelTier, SandboxBackend } from './types.js';
+
+/** Sandbox-relative directory for judge I/O (transcript in, verdict out). */
+const JUDGE_DIR = '__judge__';
+const TRANSCRIPT_FILE = `${JUDGE_DIR}/transcript.md`;
+const VERDICT_FILE = `${JUDGE_DIR}/verdict.json`;
+
+/**
+ * Whether a codebase-relative path lives inside a tree we never copy into the judge
+ * fixture: `node_modules` (heavyweight) or `.git` (recreated in-sandbox). Matched by
+ * whole path SEGMENT, so siblings like `.github` / `.gitignore` are KEPT (a plain
+ * `includes('/.git')` would wrongly drop them). Exported for unit testing.
+ */
+export function isFixtureExcluded(relativePath: string): boolean {
+  return relativePath.split(sep).some((seg) => seg === 'node_modules' || seg === '.git');
+}
+
+/** The default judge agent — a strong, gateway-routed coding agent. */
+const DEFAULT_JUDGE_AGENT: AgentType = 'vercel-ai-gateway/claude-code';
+
+export interface JudgeOptions {
+  /** What to evaluate. A single criterion or several (each judged independently). */
+  criteria: string | string[];
+  /**
+   * A codebase to judge: a directory path. The judge agent explores it with its
+   * own tools (agentic). `node_modules` and `.git` are not copied.
+   */
+  codebase?: string;
+  /** A transcript to judge (e.g. an agent run's transcript), made available to the judge. */
+  transcript?: string;
+  /** Which agent acts as the judge. Default: `vercel-ai-gateway/claude-code`. */
+  agent?: AgentType;
+  /** Judge model. Default: the judge agent's own default model (claude → opus). */
+  model?: ModelTier;
+  /** API key for the judge agent. Default: `process.env[agent.getApiKeyEnvVar()]`. */
+  apiKey?: string;
+  /** Sandbox timeout in seconds. Default: 600. */
+  timeout?: number;
+  /** Sandbox backend. Default: 'auto'. */
+  sandbox?: SandboxBackend | 'auto';
+}
+
+/** One criterion's verdict. */
+export interface CriterionVerdict {
+  criterion: string;
+  pass: boolean;
+  reason: string;
+}
+
+/** The judge's overall verdict. */
+export interface JudgeVerdict {
+  /** True iff every criterion passed. */
+  pass: boolean;
+  /** Per-criterion verdicts, in the order the criteria were given. */
+  results: CriterionVerdict[];
+  /** The judge agent's own transcript (for debugging the judgment). */
+  judgeTranscript?: string;
+  /** The raw verdict text the judge produced (for debugging). */
+  raw?: string;
+}
+
+/**
+ * Build the judge prompt. Exported for tests.
+ *
+ * Instructs the judge to (optionally) inspect the codebase and/or the transcript,
+ * evaluate each criterion skeptically, and emit a verdict BOTH as a file (the
+ * reliable channel, captured via git-diff) and as its final message (a fallback).
+ */
+export function buildJudgePrompt(
+  criteria: string[],
+  opts: { hasCodebase: boolean; hasTranscript: boolean }
+): string {
+  const lines: string[] = [];
+  lines.push(
+    "You are a strict, skeptical judge evaluating an AI coding agent's work. " +
+      'Decide each criterion ONLY on clear evidence; when in doubt, FAIL it.'
+  );
+  lines.push('');
+  if (opts.hasCodebase) {
+    lines.push(
+      'Inspect the project in the current directory — read files, grep, run commands as ' +
+        'needed — to gather evidence.'
+    );
+  }
+  if (opts.hasTranscript) {
+    lines.push(`Read the agent's transcript at ${TRANSCRIPT_FILE} to see how it worked.`);
+  }
+  lines.push('');
+  lines.push('Evaluate these criteria:');
+  criteria.forEach((c, i) => lines.push(`${i + 1}. ${c}`));
+  lines.push('');
+  lines.push(
+    `When done, write your verdict to ${VERDICT_FILE} as JSON of exactly this shape:`
+  );
+  lines.push('{"results":[{"criterion":"<criterion text>","pass":true|false,"reason":"<1-2 sentences citing evidence>"}]}');
+  lines.push('Include one entry per criterion, in the same order. Then print the same JSON as your final message.');
+  return lines.join('\n');
+}
+
+/**
+ * Parse a judge verdict from raw text. Tolerant of prose / ```json fences around
+ * the object. Exported for tests. Throws if no usable verdict is found.
+ */
+export function parseJudgeVerdict(raw: string | undefined, criteria: string[]): CriterionVerdict[] {
+  if (raw) {
+    // Grab the JSON object that contains "results" (handles fences / surrounding prose).
+    const match = raw.match(/\{[\s\S]*"results"[\s\S]*\}/);
+    if (match) {
+      try {
+        const obj = JSON.parse(match[0]);
+        if (Array.isArray(obj.results) && obj.results.length > 0) {
+          return obj.results.map((r: { criterion?: unknown; pass?: unknown; reason?: unknown }, i: number) => ({
+            criterion: String(r.criterion ?? criteria[i] ?? `criterion ${i + 1}`),
+            pass: !!r.pass,
+            reason: String(r.reason ?? ''),
+          }));
+        }
+      } catch {
+        // fall through to the throw
+      }
+    }
+  }
+  throw new Error('judge: could not parse a verdict from the judge output');
+}
+
+/**
+ * Judge a codebase and/or a transcript against one or more criteria, using an
+ * agent as an agentic judge. Returns a structured pass/fail verdict.
+ */
+export async function judge(options: JudgeOptions): Promise<JudgeVerdict> {
+  const criteria = Array.isArray(options.criteria) ? options.criteria : [options.criteria];
+  if (criteria.length === 0) {
+    throw new Error('judge: at least one criterion is required');
+  }
+  if (!options.codebase && !options.transcript) {
+    throw new Error('judge: provide a `codebase` and/or a `transcript` to judge');
+  }
+
+  const agent = getAgent(options.agent ?? DEFAULT_JUDGE_AGENT);
+  const apiKey = options.apiKey ?? process.env[agent.getApiKeyEnvVar()];
+  if (!apiKey) {
+    throw new Error(`judge: no API key — set ${agent.getApiKeyEnvVar()} or pass options.apiKey`);
+  }
+  const model = options.model ?? agent.getDefaultModel();
+
+  // Build a temp judge "fixture": the codebase (if any) + the transcript file + a
+  // fallback package.json so the orchestrator's `npm install` step has something to
+  // run. NOTE: if the copied codebase brings its OWN package.json, install runs its
+  // full dependency tree in-sandbox (slow, and a broken install fails the judge).
+  // No EVAL.ts → validation is skipped; the judge prompt drives the run and the
+  // verdict comes back as a captured generated file.
+  const dir = mkdtempSync(join(tmpdir(), 'agent-eval-judge-'));
+  try {
+    if (options.codebase) {
+      const root = options.codebase;
+      cpSync(root, dir, {
+        recursive: true,
+        // cpSync passes absolute source paths; compare segments RELATIVE to the
+        // codebase root so an ancestor dir named node_modules/.git can't match.
+        filter: (src) => !isFixtureExcluded(relative(root, src)),
+      });
+    }
+    if (!existsSync(join(dir, 'package.json'))) {
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify({ name: 'judge-target', private: true, type: 'module' }, null, 2)
+      );
+    }
+    if (options.transcript) {
+      mkdirSync(join(dir, JUDGE_DIR), { recursive: true });
+      writeFileSync(join(dir, TRANSCRIPT_FILE), options.transcript);
+    }
+
+    const prompt = buildJudgePrompt(criteria, {
+      hasCodebase: !!options.codebase,
+      hasTranscript: !!options.transcript,
+    });
+
+    // A judge is just an agent run: validation 'none' (no EVAL.ts), the judge prompt
+    // drives an agentic exploration, and the verdict file is captured like any other
+    // generated file (git diff). Reuses the whole plugin orchestrator.
+    const result = await agent.run(dir, {
+      prompt,
+      model,
+      apiKey,
+      validation: 'none',
+      scripts: [],
+      timeout: (options.timeout ?? 600) * 1000,
+      sandbox: options.sandbox,
+    });
+
+    // The judge agent CLI itself failed (and didn't leave a verdict) → surface it.
+    if (!result.success && !result.generatedFiles?.[VERDICT_FILE]) {
+      throw new Error(`judge: the judge agent failed: ${result.error ?? 'unknown error'}`);
+    }
+
+    // Prefer the verdict file; fall back to the judge's final message.
+    const verdictRaw = result.generatedFiles?.[VERDICT_FILE] ?? result.output;
+    const results = parseJudgeVerdict(verdictRaw, criteria);
+
+    return {
+      pass: results.every((r) => r.pass),
+      results,
+      judgeTranscript: result.transcript,
+      raw: verdictRaw,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
Stacked on #160 (the plugin model). Adds `judge()` — an agentic LLM judge — as a small API on top of it.

A judge is just an agent run, so `judge()` reuses the whole plugin orchestrator: it spins up the same sandbox, installs the judge agent's CLI, and runs it agentically. The judge **explores a codebase with its own tools** and/or reads a **transcript**, evaluates one or more criteria (each independently), and returns `{ pass, results: [{ criterion, pass, reason }] }`. The verdict comes back via the same generated-file (git-diff) capture evals use, so it works across every supported agent, and the judge model is independent of the model under test.

```ts
import { judge } from '@vercel/agent-eval';

const v = await judge({
  criteria: ['greet() is exported and returns a non-empty string', 'imports next/link'],
  codebase: '/path/to/project',   // judge agent explores it
  transcript,                      // and/or judge how the agent worked
});
v.pass;     // true iff every criterion passed
v.results;  // [{ criterion, pass, reason }, ...]
```

Pure pieces (`buildJudgePrompt`, `parseJudgeVerdict`) and input validation are unit-tested (11 tests). Validated live against a real Vercel sandbox + AI Gateway: a codebase judge correctly PASSed "exports greet()" and FAILed "imports a database client" with evidence-cited reasons, and a transcript judge correctly PASSed "used React DevTools to diagnose". 227 unit tests, lint, and build are green.
