### PR TITLE
[judge] Agentic LLM-judge matcher for EVAL.ts

### DIFF
--- a/.changeset/agentic-judge-matcher.md
+++ b/.changeset/agentic-judge-matcher.md
@@ -1,0 +1,21 @@
+---
+'@vercel/agent-eval': minor
+---
+
+Add an agentic LLM-judge matcher for EVAL.ts. Each judge assertion re-invokes the same agent (and model) that did the codegen, in the same sandbox, to evaluate a criterion — then returns pass/fail. No fresh sandbox, no copied evidence.
+
+```ts
+import { test, expect } from 'vitest';
+import { environment, transcript } from '@vercel/agent-eval/eval';
+
+test('quality', async () => {
+  await expect(environment).toSatisfyCriterion('uses Server Components for the product list');
+  await expect(transcript).toSatisfyCriterion('diagnosed with DevTools, not trial-and-error');
+  await expect(environment).toScoreAtLeast('production-quality error handling', 0.8);
+});
+```
+
+- Two implicit subjects (`environment`, `transcript`) — no paths.
+- You supply only the criterion; the framework owns the prompt + verdict contract.
+- Failures are attributable in the eval output (`[judge:environment] FAIL (score): reason`).
+- The raw transcript is materialized to a sandbox file so the judge reads it by path (never dumped into a prompt). Framework files under `__agent_eval__/` are now gitignored, so they no longer appear in captured generated files.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,47 @@ The `results.o11y` object is a `TranscriptSummary` with these fields:
 
 > **Note**: If the agent's transcript is unavailable (e.g. the agent crashed before producing output), `results.o11y` will be `null`.
 
+### Agentic LLM judge
+
+For open-ended quality checks that exact assertions can't express, EVAL.ts can run an **agentic LLM judge**. Each judge assertion re-invokes the *same agent* that did the codegen, **in the same sandbox**, to evaluate a criterion — then returns pass/fail. No fresh sandbox, no copying evidence around.
+
+```typescript
+import { test, expect } from 'vitest';
+import { environment, transcript } from '@vercel/agent-eval/eval';
+
+// Judge the final state: the agent explores the project (read/grep/run) for evidence.
+test('uses server components', async () => {
+  await expect(environment).toSatisfyCriterion('uses Server Components for the product list');
+});
+
+// Judge the transcript: how the agent worked. It reads the transcript by path, so the
+// full transcript is never stuffed into a prompt.
+test('diagnosed properly', async () => {
+  await expect(transcript).toSatisfyCriterion('diagnosed with DevTools, not trial-and-error edits');
+});
+
+// Numeric: the judge scores 0-1; assert a threshold (still pass/fail overall).
+test('quality bar', async () => {
+  await expect(environment).toScoreAtLeast('production-quality error handling', 0.8);
+});
+```
+
+Two subjects, imported from `@vercel/agent-eval/eval` — no paths, the subject is implicit:
+
+- `environment` — the judge agent explores the final sandbox state (cwd) with its own tools.
+- `transcript` — the judge agent reads the materialized transcript by path.
+
+Two matchers, on either subject:
+
+- `toSatisfyCriterion(criterion)` — passes when the judge decides the criterion is satisfied.
+- `toScoreAtLeast(criterion, threshold)` — passes when the judge's 0–1 score is `>= threshold`.
+
+You supply only the **criterion** string; the framework owns the judge prompt and the verdict contract. On failure the assertion message carries the judge's reasoning, e.g. `[judge:environment] FAIL (score 0.42): product list is a Client Component`, so a failed judge clause is distinguishable from a failed deterministic test or a crash.
+
+The judge uses the same agent and model as the run under test. Because each assertion is a real agent run, it costs time and tokens — keep criteria focused.
+
+> **Note**: requires `validation: 'vitest'` (the default). The framework gives the eval process the run's credentials automatically so the judge can call the agent CLI in-sandbox.
+
 ## Configuration Reference
 
 ### Experiment config

--- a/packages/agent-eval/scripts/copy-runners.mjs
+++ b/packages/agent-eval/scripts/copy-runners.mjs
@@ -1,10 +1,11 @@
 /**
- * Build step: copy each agent's in-sandbox runner (`src/lib/agents/<agent>/run.mjs`)
- * into the compiled output (`dist/lib/agents/<agent>/run.mjs`).
+ * Build step: copy the in-sandbox `.mjs` artifacts into the compiled output:
+ *   - each agent's runner   `src/lib/agents/<agent>/run.mjs` → `dist/lib/agents/<agent>/run.mjs`
+ *   - the eval helper       `src/lib/agents/eval-helper.mjs` → `dist/lib/agents/eval-helper.mjs`
  *
- * `tsc` only emits .ts → .js; the `.mjs` runners are plain JS artifacts that ship
- * as-is and get read at runtime via `new URL('./run.mjs', import.meta.url)` next to
- * the compiled definition. So they must sit beside the compiled agent.js in dist.
+ * `tsc` only emits .ts → .js; these `.mjs` files are plain JS artifacts that ship
+ * as-is and get read at runtime via `new URL(..., import.meta.url)` next to the
+ * compiled code. So they must sit beside the compiled output in dist.
  */
 
 import { readdirSync, existsSync, mkdirSync, copyFileSync } from 'node:fs';
@@ -24,4 +25,9 @@ for (const entry of readdirSync(SRC, { withFileTypes: true })) {
   copied++;
 }
 
-console.log(`copy-runners: copied ${copied} run.mjs file(s) into ${OUT}`);
+// The in-sandbox eval helper (shipped by the orchestrator before validation).
+mkdirSync(OUT, { recursive: true });
+copyFileSync(join(SRC, 'eval-helper.mjs'), join(OUT, 'eval-helper.mjs'));
+copied++;
+
+console.log(`copy-runners: copied ${copied} .mjs file(s) into ${OUT}`);

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -307,6 +307,87 @@ test('greet exists', () => {
     }, 600000); // 10 minute timeout
   });
 
+  describe.skipIf(!hasAiGatewayCredentials)('Agentic judge matcher (EVAL.ts)', () => {
+    // Real end-to-end: a fixture whose EVAL.ts uses the in-sandbox agentic judge
+    // matcher. Each assertion re-invokes the SAME agent (claude) IN the codegen
+    // sandbox to judge the final state / transcript. No mocks.
+    function writeJudgeFixture(name: string, evalBody: string): void {
+      const dir = join(TEST_DIR, name);
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(
+        join(dir, 'PROMPT.md'),
+        'Create src/greeting.ts that exports a function greet() returning the string "Hello!".'
+      );
+      writeFileSync(join(dir, 'EVAL.ts'), evalBody);
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify({ name, type: 'module', devDependencies: { vitest: '^2.1.0' } })
+      );
+      writeFileSync(join(dir, 'src/index.ts'), '');
+    }
+
+    it('PASSES when the judge confirms the code and the transcript', async () => {
+      writeJudgeFixture(
+        'judge-pass',
+        `
+import { test, expect } from 'vitest';
+import { environment, transcript } from '@vercel/agent-eval/eval';
+
+test('environment judge (true)', async () => {
+  await expect(environment).toSatisfyCriterion(
+    'exports a greet() function that returns a non-empty greeting string'
+  );
+});
+test('transcript judge (true)', async () => {
+  await expect(transcript).toSatisfyCriterion(
+    'the agent created or edited at least one TypeScript file'
+  );
+});
+`
+      );
+      const fixture = loadFixture(TEST_DIR, 'judge-pass');
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/claude-code',
+        model: 'sonnet',
+        timeout: 900,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: [],
+      });
+      if (result.result.status === 'failed') {
+        console.error('judge-pass eval output:\n', result.outputContent?.eval);
+      }
+      expect(result.result.status).toBe('passed');
+    }, 900000);
+
+    it('FAILS (attributably) when the judge rejects a false criterion', async () => {
+      writeJudgeFixture(
+        'judge-fail',
+        `
+import { test, expect } from 'vitest';
+import { environment } from '@vercel/agent-eval/eval';
+
+test('environment judge (false)', async () => {
+  await expect(environment).toSatisfyCriterion(
+    'the project uses a PostgreSQL database via the Prisma ORM'
+  );
+});
+`
+      );
+      const fixture = loadFixture(TEST_DIR, 'judge-fail');
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/claude-code',
+        model: 'sonnet',
+        timeout: 900,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: [],
+      });
+      // The judge must REJECT the false criterion → eval fails, and the failure is
+      // attributable to the judge clause in the captured vitest output.
+      expect(result.result.status).toBe('failed');
+      expect(result.outputContent?.eval ?? '').toContain('[judge:environment] FAIL');
+    }, 900000);
+  });
+
   describe.skipIf(!hasAnthropicCredentials)('Claude Code (Direct API) sandbox execution', () => {
     it('can run a simple eval with Claude Code using direct Anthropic API', async () => {
       // Create a simple test fixture

--- a/packages/agent-eval/src/lib/agents/eval-helper.mjs
+++ b/packages/agent-eval/src/lib/agents/eval-helper.mjs
@@ -1,0 +1,222 @@
+/**
+ * In-sandbox eval helper — the EVAL.ts agentic-judge surface.
+ *
+ * Shipped INTO the sandbox by the orchestrator (like run.mjs) and aliased to
+ * `@vercel/agent-eval/eval` + registered as a vitest setup file by the generated
+ * vitest config. That lets EVAL.ts do:
+ *
+ *   import { environment, transcript } from '@vercel/agent-eval/eval';
+ *
+ *   test('quality', async () => {
+ *     await expect(environment).toSatisfyCriterion('uses Server Components for the list');
+ *     await expect(transcript).toSatisfyCriterion('diagnosed with DevTools, not guesswork');
+ *     await expect(environment).toScoreAtLeast('code quality', 0.8);
+ *   });
+ *
+ * It is AGENTIC and reuses the SAME harness: each assertion re-invokes the codegen
+ * agent's runner (`__agent_eval__/run.mjs`, already shipped) IN this sandbox. The
+ * judge explores the final state (cwd) or reads the materialized transcript file —
+ * no fresh sandbox, no copying evidence around, no new harness.
+ *
+ * Zero-dependency apart from `vitest` (already present in the fixture). Runs only
+ * in-sandbox. The path constants below mirror shared.ts (the orchestrator writes
+ * these files before validation).
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { expect } from 'vitest';
+
+// Canonical sandbox paths (kept in sync with shared.ts).
+const RUNNER_PATH = '__agent_eval__/run.mjs';
+const JUDGE_CONFIG_PATH = '__agent_eval__/judge-config.json';
+const TRANSCRIPT_FILE = '__agent_eval__/transcript.txt';
+const JUDGE_IO_DIR = '__agent_eval__/judge';
+
+/**
+ * The two things you can judge — import sentinels, NOT paths. The matcher routes
+ * on which one you pass; the path/cwd resolution is an internal detail.
+ */
+export const environment = { __judgeSubject: 'environment' };
+export const transcript = { __judgeSubject: 'transcript' };
+
+/** Path to the materialized transcript. Rarely needed — prefer the `transcript` subject. */
+export function transcriptPath() {
+  return TRANSCRIPT_FILE;
+}
+
+/**
+ * Build the judge prompt for a subject + criterion. Framework-owned: you supply
+ * only the criterion; the scaffolding (skeptical stance, how to gather evidence,
+ * and the verdict output contract) is fixed so the verdict parses reliably.
+ */
+export function buildJudgePrompt(subject, criterion, verdictPath, opts = {}) {
+  const lines = [];
+  lines.push(
+    "You are a strict, skeptical judge evaluating an AI coding agent's work. " +
+      'Decide the criterion ONLY on clear evidence; when in doubt, FAIL it.'
+  );
+  lines.push('');
+  if (subject === 'transcript') {
+    lines.push(
+      `Read the agent's transcript at ${TRANSCRIPT_FILE} (open it with your tools) to ` +
+        'see how the agent worked. Cite what the transcript actually shows; do not assume.'
+    );
+  } else {
+    lines.push(
+      'Inspect the project in the current directory — read files, grep, run commands as ' +
+        'needed — to gather concrete evidence.'
+    );
+  }
+  lines.push('');
+  lines.push(`Criterion: ${criterion}`);
+  lines.push('');
+  if (opts.numeric) {
+    lines.push(
+      'Also give a score from 0 to 1 (1 = fully satisfies the criterion). Set pass=true ' +
+        'iff the criterion is satisfied.'
+    );
+  }
+  lines.push(`When done, write your verdict to ${verdictPath} as JSON of exactly this shape:`);
+  lines.push(
+    '{"pass": true|false,' +
+      (opts.numeric ? ' "score": <0-1>,' : '') +
+      ' "reason": "<1-2 sentences citing concrete evidence>"}'
+  );
+  lines.push('Then print that same JSON as your final message.');
+  return lines.join('\n');
+}
+
+/**
+ * Parse a verdict from the verdict file or the agent's final output. Tolerant of
+ * surrounding prose / ```json fences. Returns null when nothing parseable is found.
+ */
+export function parseJudgeVerdict(raw) {
+  if (!raw) return null;
+  const match = raw.match(/\{[\s\S]*"pass"[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    const obj = JSON.parse(match[0]);
+    return {
+      pass: !!obj.pass,
+      score: typeof obj.score === 'number' ? obj.score : undefined,
+      reason: typeof obj.reason === 'string' ? obj.reason : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/* ───────────────────────────── judge invocation ───────────────────────────── */
+
+let counter = 0;
+function nextId() {
+  counter += 1;
+  return `${process.pid}-${counter}`;
+}
+
+function readJudgeConfig() {
+  try {
+    return JSON.parse(readFileSync(JUDGE_CONFIG_PATH, 'utf8'));
+  } catch {
+    // No config (e.g. run outside the orchestrator) → let the agent CLI default.
+    return { model: null, extra: null };
+  }
+}
+
+/**
+ * Run one agentic judgment IN this sandbox by re-invoking the codegen agent's
+ * runner. Blocking (spawnSync) — the test has nothing else to do while the judge
+ * works, and the sandbox-level timeout bounds it. Returns {pass, score?, reason}.
+ */
+function runJudge(subject, criterion, opts = {}) {
+  const id = nextId();
+  mkdirSync(JUDGE_IO_DIR, { recursive: true });
+  const verdictPath = `${JUDGE_IO_DIR}/${id}-verdict.json`;
+  const resultPath = `${JUDGE_IO_DIR}/${id}-result.json`;
+  const cfg = readJudgeConfig();
+
+  // Same AgentRunInput contract run.mjs already understands. Reuse the codegen
+  // model + host-computed extra (e.g. codex's resolved model/effort) so the judge
+  // is the SAME agent. No secrets here — the key rides in process.env (inherited).
+  const input = {
+    prompt: buildJudgePrompt(subject, criterion, verdictPath, opts),
+    model: cfg.model ?? undefined,
+    cwd: process.cwd(),
+    resultPath,
+    extra: cfg.extra ?? undefined,
+  };
+
+  const res = spawnSync('node', [RUNNER_PATH, JSON.stringify(input)], {
+    cwd: process.cwd(),
+    env: process.env,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+  // Prefer the verdict file the judge agent wrote; then the runner result's output
+  // (the agent's final message); then raw stdout.
+  let verdict = existsSync(verdictPath) ? parseJudgeVerdict(readFileSync(verdictPath, 'utf8')) : null;
+  if (!verdict && existsSync(resultPath)) {
+    try {
+      const rr = JSON.parse(readFileSync(resultPath, 'utf8'));
+      verdict = parseJudgeVerdict(rr.output);
+      if (!verdict && !rr.ok) {
+        return { pass: false, reason: `judge agent failed: ${rr.error || 'unknown error'}` };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  if (!verdict) verdict = parseJudgeVerdict(res.stdout || '');
+  if (!verdict) {
+    const tail = (res.stdout || res.stderr || '').slice(-300);
+    return { pass: false, reason: `could not parse a judge verdict (node exit ${res.status}). Tail: ${tail}` };
+  }
+  return verdict;
+}
+
+function subjectOf(received) {
+  return received && typeof received === 'object' ? received.__judgeSubject : undefined;
+}
+
+// Sync matchers: spawnSync blocks, so these work whether or not you `await` them.
+expect.extend({
+  toSatisfyCriterion(received, criterion) {
+    const subject = subjectOf(received);
+    if (!subject) {
+      return {
+        pass: false,
+        message: () =>
+          'toSatisfyCriterion expects `environment` or `transcript` from @vercel/agent-eval/eval',
+      };
+    }
+    const v = runJudge(subject, criterion);
+    return {
+      pass: v.pass,
+      message: () =>
+        `[judge:${subject}] ${v.pass ? 'PASS' : 'FAIL'}` +
+        (typeof v.score === 'number' ? ` (score ${v.score})` : '') +
+        ` — ${criterion}\n  reason: ${v.reason}`,
+    };
+  },
+
+  toScoreAtLeast(received, criterion, threshold) {
+    const subject = subjectOf(received);
+    if (!subject) {
+      return {
+        pass: false,
+        message: () =>
+          'toScoreAtLeast expects `environment` or `transcript` from @vercel/agent-eval/eval',
+      };
+    }
+    const v = runJudge(subject, criterion, { numeric: true });
+    const score = typeof v.score === 'number' ? v.score : v.pass ? 1 : 0;
+    const pass = score >= threshold;
+    return {
+      pass,
+      message: () =>
+        `[judge:${subject}] score ${score} ${pass ? '>=' : '<'} ${threshold} — ${criterion}\n  reason: ${v.reason}`,
+    };
+  },
+});

--- a/packages/agent-eval/src/lib/agents/eval-helper.test.ts
+++ b/packages/agent-eval/src/lib/agents/eval-helper.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+// Importing the helper registers the judge matchers on `expect` as a side effect
+// (harmless here); we only exercise the pure exports.
+import {
+  buildJudgePrompt,
+  parseJudgeVerdict,
+  transcriptPath,
+  environment,
+  transcript,
+} from './eval-helper.mjs';
+
+describe('buildJudgePrompt', () => {
+  it('environment variant: explores cwd, embeds criterion + verdict path + contract', () => {
+    const p = buildJudgePrompt('environment', 'uses Server Components', '__agent_eval__/judge/1-verdict.json');
+    expect(p).toContain('Inspect the project in the current directory');
+    expect(p).not.toContain('__agent_eval__/transcript.txt');
+    expect(p).toContain('Criterion: uses Server Components');
+    expect(p).toContain('__agent_eval__/judge/1-verdict.json');
+    expect(p).toContain('"pass": true|false');
+    expect(p).not.toContain('"score"'); // non-numeric by default
+  });
+
+  it('transcript variant: points at the materialized transcript, not cwd exploration', () => {
+    const p = buildJudgePrompt('transcript', 'used DevTools', '__agent_eval__/judge/2-verdict.json');
+    expect(p).toContain('__agent_eval__/transcript.txt');
+    expect(p).not.toContain('Inspect the project in the current directory');
+    expect(p).toContain('Criterion: used DevTools');
+  });
+
+  it('numeric mode asks for a score and includes it in the contract', () => {
+    const p = buildJudgePrompt('environment', 'code quality', 'v.json', { numeric: true });
+    expect(p).toContain('score from 0 to 1');
+    expect(p).toContain('"score": <0-1>');
+  });
+});
+
+describe('parseJudgeVerdict', () => {
+  it('parses a clean verdict object', () => {
+    expect(parseJudgeVerdict('{"pass":true,"reason":"ok"}')).toEqual({
+      pass: true,
+      score: undefined,
+      reason: 'ok',
+    });
+  });
+
+  it('tolerates prose and ```json fences around the object', () => {
+    const raw = 'Here:\n```json\n{"pass":false,"reason":"nope"}\n```\ndone';
+    expect(parseJudgeVerdict(raw)).toEqual({ pass: false, score: undefined, reason: 'nope' });
+  });
+
+  it('keeps a numeric score', () => {
+    expect(parseJudgeVerdict('{"pass":true,"score":0.7,"reason":"good"}')).toEqual({
+      pass: true,
+      score: 0.7,
+      reason: 'good',
+    });
+  });
+
+  it('coerces a truthy non-boolean pass and a missing reason', () => {
+    const v = parseJudgeVerdict('{"pass":"yes"}');
+    expect(v?.pass).toBe(true);
+    expect(v?.reason).toBe('');
+  });
+
+  it('returns null when nothing parseable is present', () => {
+    expect(parseJudgeVerdict('no json here')).toBeNull();
+    expect(parseJudgeVerdict(undefined)).toBeNull();
+    expect(parseJudgeVerdict('{ broken "pass": true ')).toBeNull();
+  });
+});
+
+describe('subjects', () => {
+  it('environment and transcript are distinct judge sentinels', () => {
+    expect(environment).toEqual({ __judgeSubject: 'environment' });
+    expect(transcript).toEqual({ __judgeSubject: 'transcript' });
+  });
+
+  it('transcriptPath() returns the canonical materialized path', () => {
+    expect(transcriptPath()).toBe('__agent_eval__/transcript.txt');
+  });
+});

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -14,6 +14,7 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import type { AgentRunOptions, AgentRunResult } from '../types.js';
 import {
@@ -31,6 +32,9 @@ import {
   initGitAndCommit,
   injectTranscriptContext,
   prepareNeutralWorkspace,
+  EVAL_HELPER_PATH,
+  JUDGE_TRANSCRIPT_FILE,
+  JUDGE_CONFIG_PATH,
 } from '../shared.js';
 import type { AgentDefinition, AgentRunInput, RunnerResult } from './contract.js';
 
@@ -43,6 +47,14 @@ type CommandResult = { stdout: string; stderr: string; exitCode: number };
 /** Well-known paths inside the sandbox for the runner + its result file. */
 const RUNNER_PATH = '__agent_eval__/run.mjs';
 const RESULT_PATH = '__agent_eval__/agent-result.json';
+
+/**
+ * Host-disk path to the in-sandbox eval helper, resolved next to the compiled
+ * output (dist/lib/agents/eval-helper.mjs) and in src during dev. Shipped into the
+ * sandbox at {@link EVAL_HELPER_PATH} before validation so EVAL.ts judge matchers
+ * can re-invoke the agent in this sandbox.
+ */
+const EVAL_HELPER_DISK_PATH = fileURLToPath(new URL('../eval-helper.mjs', import.meta.url));
 
 /**
  * Run all install steps for an agent, reproducing the old per-step error wording.
@@ -261,12 +273,31 @@ export async function runWithDefinition(
     }
 
     // 10. VALIDATION (unchanged shared helpers; parseTranscript runs host-side here).
+    // The auth env is reused for the eval process so EVAL.ts judge matchers can
+    // re-invoke the agent in-sandbox (the vitest process inherits it to children).
+    const validationEnv = { ...def.authEnv(options), ...neutralWorkspace.env };
     if (options.validation !== 'none') {
       await sandbox.uploadFiles(testFiles);
       await createVitestConfig(sandbox);
       await injectTranscriptContext(sandbox, transcript, def.o11yAgentName, options.model);
+      // Judge runtime: ship the eval helper, materialize the raw transcript as a
+      // file the judge agent can read by path, and record the judge config (same
+      // agent/model + host-computed extra the codegen run used).
+      await sandbox.writeFiles({
+        [EVAL_HELPER_PATH]: readFileSync(EVAL_HELPER_DISK_PATH, 'utf8'),
+        [JUDGE_TRANSCRIPT_FILE]: transcript ?? '',
+        [JUDGE_CONFIG_PATH]: JSON.stringify({
+          model: options.model ?? null,
+          extra: def.runnerExtra?.(options) ?? null,
+        }),
+      });
     }
-    const validationResults = await runValidation(sandbox, options.scripts ?? [], options.validation);
+    const validationResults = await runValidation(
+      sandbox,
+      options.scripts ?? [],
+      options.validation,
+      validationEnv
+    );
 
     // 11. Capture generated/deleted files (git diff).
     const { generatedFiles, deletedFiles } = await captureGeneratedFiles(sandbox);

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -21,6 +21,19 @@ export const TRANSCRIPT_CONTEXT_DIR = '__agent_eval__';
 /** Path to the results file inside the sandbox. */
 export const TRANSCRIPT_CONTEXT_PATH = `${TRANSCRIPT_CONTEXT_DIR}/results.json`;
 
+// ── Agentic-judge runtime, shipped into the sandbox before validation ──────────
+// These paths are mirrored as literals in eval-helper.mjs (a zero-dep file that
+// cannot import this module). Keep the two in sync.
+
+/** The in-sandbox eval helper, aliased to `@vercel/agent-eval/eval` for EVAL.ts. */
+export const EVAL_HELPER_PATH = `${TRANSCRIPT_CONTEXT_DIR}/eval-helper.mjs`;
+
+/** Raw transcript materialized as a file so the judge agent can read it by path. */
+export const JUDGE_TRANSCRIPT_FILE = `${TRANSCRIPT_CONTEXT_DIR}/transcript.txt`;
+
+/** Judge config (`{ model, extra }`) — the same agent/model the codegen used. */
+export const JUDGE_CONFIG_PATH = `${TRANSCRIPT_CONTEXT_DIR}/judge-config.json`;
+
 /**
  * Combined validation results.
  */
@@ -71,7 +84,11 @@ async function detectEvalFile(sandbox: AnySandbox): Promise<string> {
 export async function runValidation(
   sandbox: AnySandbox,
   scripts: string[],
-  validation: ValidationMode = 'vitest'
+  validation: ValidationMode = 'vitest',
+  // Auth/neutral env for the eval process. EVAL.ts judge matchers re-invoke the
+  // agent CLI in-sandbox, which needs the same credentials the codegen run used —
+  // so the vitest process must carry them (it inherits them to its child spawns).
+  env?: Record<string, string>
 ): Promise<ValidationResults> {
   const results: ValidationResults = {
     allPassed: true,
@@ -83,7 +100,7 @@ export async function runValidation(
     const evalFile = await detectEvalFile(sandbox);
 
     // Always run vitest for the eval file (explicitly specify the file)
-    const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile]);
+    const testResult = await sandbox.runCommand('npx', ['vitest', 'run', evalFile], env ? { env } : undefined);
     results.test = {
       success: testResult.exitCode === 0,
       output: testResult.stdout + testResult.stderr,
@@ -141,7 +158,9 @@ export async function prepareNeutralWorkspace(sandbox: AnySandbox): Promise<Neut
 
 export async function initGitAndCommit(sandbox: AnySandbox): Promise<void> {
   await sandbox.writeFiles({
-    ".gitignore": "node_modules/\n",
+    // `__agent_eval__/` holds framework scaffolding only (the runner, transcript,
+    // judge I/O) — never agent output — so keep it out of the captured git diff.
+    ".gitignore": "node_modules/\n__agent_eval__/\n",
   });
 
   // init a git repo and set user and name since those are needed. Commit everything to have a clean diff with HEAD to capture
@@ -201,6 +220,11 @@ export async function createVitestConfig(sandbox: AnySandbox): Promise<void> {
   // Detect which eval file exists
   const evalFile = await detectEvalFile(sandbox);
 
+  // Absolute path to the shipped eval helper. It is BOTH the source of the
+  // `environment`/`transcript` exports (aliased to `@vercel/agent-eval/eval`) and
+  // the setup file that registers the judge matchers via expect.extend.
+  const helperPath = `${sandbox.getWorkingDirectory()}/${EVAL_HELPER_PATH}`;
+
   await sandbox.writeFiles({
     'vitest.config.ts': `
 import { defineConfig } from 'vitest/config';
@@ -208,6 +232,14 @@ export default defineConfig({
   test: {
     include: ['${evalFile}'],
     globals: false,
+    // Agentic judge matchers spawn a full agent run in-sandbox; give them room.
+    // The sandbox-level timeout is the real bound.
+    testTimeout: 900000,
+    hookTimeout: 900000,
+    setupFiles: ['${helperPath}'],
+  },
+  resolve: {
+    alias: { '@vercel/agent-eval/eval': '${helperPath}' },
   },
 });
 `,


### PR DESCRIPTION
EVAL.ts can now run an agentic LLM judge inline. `await expect(environment).toSatisfyCriterion('uses Server Components')` and `expect(transcript).toSatisfyCriterion(...)` re-invoke the *same* agent and sandbox that did the codegen — the matcher spawns the already-shipped `__agent_eval__/run.mjs` with a judge prompt, so there is no second sandbox and no copied evidence. `environment` judges the final state (the agent explores cwd with its own tools); `transcript` judges how it worked (read by path, never dumped into a prompt). `toScoreAtLeast(criterion, threshold)` is the numeric variant. You supply only the criterion — the framework owns the prompt and the verdict contract — and a failed judge surfaces `[judge:environment] FAIL (score): reason`, so it's distinguishable from a deterministic-test failure or a crash.

To support this the orchestrator ships the helper (aliased to `@vercel/agent-eval/eval` plus a vitest setup file), materializes the raw transcript to a file, records the codegen model, and passes the run's auth env to validation so the judge CLI can authenticate; `__agent_eval__/` is now gitignored so framework I/O stays out of captured generated files. Verified with unit tests and a real e2e on a Vercel sandbox with Claude over the AI gateway: the judge confirms true criteria (eval passes) and rejects a false one (eval fails, attributably).

Stacked on #160.
