### PR TITLE
[agent-eval] Pin the agentic judge to a fixed agent and model

### DIFF
--- a/.changeset/pinnable-judge.md
+++ b/.changeset/pinnable-judge.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Pin the agentic LLM judge to a fixed agent + model via `ExperimentConfig.judge`. By default the `expect(environment|transcript)` matchers still self-grade with the codegen agent+model; setting `judge: { agent?, model }` grades every run with one fixed judge — the apples-to-apples choice for cross-model comparisons (judge quality no longer varies with the model under test, and a model never grades itself). When `judge.agent` names a different agent, its CLI is installed in the sandbox and its key is resolved from its own env var (falling back to `VERCEL_OIDC_TOKEN`). Pinning is reflected in the eval fingerprint, so pinned runs don't reuse self-graded cached results.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,22 @@ Two matchers, on either subject:
 
 You supply only the **criterion** string; the framework owns the judge prompt and the verdict contract. On failure the assertion message carries the judge's reasoning, e.g. `[judge:environment] FAIL (score 0.42): product list is a Client Component`, so a failed judge clause is distinguishable from a failed deterministic test or a crash.
 
-The judge uses the same agent and model as the run under test. Because each assertion is a real agent run, it costs time and tokens — keep criteria focused.
+By default the judge uses the **same agent and model** as the run under test (self-grading). Because each assertion is a real agent run, it costs time and tokens — keep criteria focused.
+
+**Pin the judge** to grade every run with one fixed agent + model — the apples-to-apples choice when comparing models, since the judge quality no longer varies with the model under test (and a model never grades itself):
+
+```typescript
+const config: ExperimentConfig = {
+  agent: 'codex',
+  model: 'gpt-5.4',
+  // Grade with a fixed Claude judge regardless of the model under test.
+  judge: { agent: 'vercel-ai-gateway/claude-code', model: 'claude-opus-4-8' },
+};
+```
+
+- `judge.model` is required (pinning the model is the point).
+- `judge.agent` is optional and defaults to the codegen agent — omit it to keep the same harness and only pin the model. When it names a different agent, that agent's CLI is installed in the sandbox automatically and its key is resolved from its own env var (falling back to `VERCEL_OIDC_TOKEN`).
+- Pinning changes the eval fingerprint, so a pinned run won't reuse self-graded cached results.
 
 > **Note**: requires `validation: 'vitest'` (the default). The framework gives the eval process the run's credentials automatically so the judge can call the agent CLI in-sandbox.
 
@@ -279,6 +294,10 @@ const config: ExperimentConfig = {
   // 'changed' - copy only files modified by the agent
   // 'all' - copy the entire project including original fixture files
   copyFiles: 'changed',
+
+  // Pin the agentic LLM judge (see "Agentic LLM judge" above). Omit to self-grade
+  // with the codegen agent+model. `model` required; `agent` defaults to codegen.
+  judge: { agent: 'vercel-ai-gateway/claude-code', model: 'claude-opus-4-8' },
 };
 
 export default config;

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -17,6 +17,7 @@ import { Dashboard, createConsoleProgressHandler } from './lib/dashboard.js';
 import type { ProgressEvent, Classification } from './lib/types.js';
 import { initProject, getPostInitInstructions } from './lib/init.js';
 import { getAgent } from './lib/agents/index.js';
+import { resolveAgentApiKey } from './lib/agents/shared.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
 import { computeFingerprint } from './lib/fingerprint.js';
 import { scanReusableResults } from './lib/results.js';
@@ -147,7 +148,7 @@ async function runExperimentCommand(configInput: string, options: { dry?: boolea
     // Get the agent to check for required API key
     const agent = getAgent(config.agent);
     const apiKeyEnvVar = agent.getApiKeyEnvVar();
-    const apiKey = process.env[apiKeyEnvVar] ?? process.env.VERCEL_OIDC_TOKEN;
+    const apiKey = resolveAgentApiKey(agent.getApiKeyEnvVar);
     if (!apiKey) {
       console.error(chalk.red(`${apiKeyEnvVar} (or VERCEL_OIDC_TOKEN) environment variable is required`));
       console.error(chalk.gray(`Get your API key at: https://vercel.com/dashboard -> AI Gateway`));
@@ -474,7 +475,7 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
 
         const agent = getAgent(config.agent);
         const apiKeyEnvVar = agent.getApiKeyEnvVar();
-        const apiKey = process.env[apiKeyEnvVar] ?? process.env.VERCEL_OIDC_TOKEN;
+        const apiKey = resolveAgentApiKey(agent.getApiKeyEnvVar);
         if (!apiKey) {
           console.error(chalk.red(`${apiKeyEnvVar} (or VERCEL_OIDC_TOKEN) not set, skipping ${baseExperimentName}`));
           return;

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -386,6 +386,38 @@ test('environment judge (false)', async () => {
       expect(result.result.status).toBe('failed');
       expect(result.outputContent?.eval ?? '').toContain('[judge:environment] FAIL');
     }, 900000);
+
+    it('PASSES with a judge pinned to a different model than codegen', async () => {
+      // Codegen runs sonnet; the judge is pinned to a fixed model (opus). This is the
+      // cross-model dashboard config — grade every model with one fixed judge. Proves
+      // the pinned model flows: judge-config.model = the pinned model, not codegen's.
+      writeJudgeFixture(
+        'judge-pinned',
+        `
+import { test, expect } from 'vitest';
+import { environment } from '@vercel/agent-eval/eval';
+
+test('environment judge (pinned, true)', async () => {
+  await expect(environment).toSatisfyCriterion(
+    'exports a greet() function that returns a non-empty greeting string'
+  );
+});
+`
+      );
+      const fixture = loadFixture(TEST_DIR, 'judge-pinned');
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/claude-code',
+        model: 'sonnet',
+        timeout: 900,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: [],
+        judge: { model: 'claude-opus-4-8' },
+      });
+      if (result.result.status === 'failed') {
+        console.error('judge-pinned eval output:\n', result.outputContent?.eval);
+      }
+      expect(result.result.status).toBe('passed');
+    }, 900000);
   });
 
   describe.skipIf(!hasAnthropicCredentials)('Claude Code (Direct API) sandbox execution', () => {

--- a/packages/agent-eval/src/lib/agents/claude-code/agent.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code/agent.ts
@@ -84,5 +84,6 @@ export function createClaudeCodeAgent({ useVercelAiGateway }: { useVercelAiGatew
       return definition.defaultModel;
     },
     run: (fixturePath, options) => runWithDefinition(definition, fixturePath, options),
+    definition,
   };
 }

--- a/packages/agent-eval/src/lib/agents/codex/agent.ts
+++ b/packages/agent-eval/src/lib/agents/codex/agent.ts
@@ -237,5 +237,6 @@ export function createCodexAgent({ useVercelAiGateway }: { useVercelAiGateway: b
       return definition.defaultModel;
     },
     run: (fixturePath, options) => runWithDefinition(definition, fixturePath, options),
+    definition,
   };
 }

--- a/packages/agent-eval/src/lib/agents/cursor/agent.ts
+++ b/packages/agent-eval/src/lib/agents/cursor/agent.ts
@@ -92,5 +92,6 @@ export function createCursorAgent(): Agent {
       return definition.defaultModel;
     },
     run: (fixturePath, options) => runWithDefinition(definition, fixturePath, options),
+    definition,
   };
 }

--- a/packages/agent-eval/src/lib/agents/eval-helper.mjs
+++ b/packages/agent-eval/src/lib/agents/eval-helper.mjs
@@ -119,8 +119,9 @@ function readJudgeConfig() {
   try {
     return JSON.parse(readFileSync(JUDGE_CONFIG_PATH, 'utf8'));
   } catch {
-    // No config (e.g. run outside the orchestrator) → let the agent CLI default.
-    return { model: null, extra: null };
+    // No config (e.g. run outside the orchestrator) → reuse the codegen runner and
+    // let the agent CLI pick its default model.
+    return { runnerPath: RUNNER_PATH, model: null, extra: null };
   }
 }
 
@@ -136,9 +137,12 @@ function runJudge(subject, criterion, opts = {}) {
   const resultPath = `${JUDGE_IO_DIR}/${id}-result.json`;
   const cfg = readJudgeConfig();
 
-  // Same AgentRunInput contract run.mjs already understands. Reuse the codegen
-  // model + host-computed extra (e.g. codex's resolved model/effort) so the judge
-  // is the SAME agent. No secrets here — the key rides in process.env (inherited).
+  // Same AgentRunInput contract the runner already understands. The judge model +
+  // host-computed extra come from judge-config.json: by default they match the
+  // codegen run (self-grade); when the experiment pins a judge, runnerPath points at
+  // the pinned agent's judge-run.mjs and model is the pinned model. No secrets here —
+  // the key rides in process.env (inherited from the orchestrator's validation env).
+  const runnerPath = cfg.runnerPath ?? RUNNER_PATH;
   const input = {
     prompt: buildJudgePrompt(subject, criterion, verdictPath, opts),
     model: cfg.model ?? undefined,
@@ -147,7 +151,7 @@ function runJudge(subject, criterion, opts = {}) {
     extra: cfg.extra ?? undefined,
   };
 
-  const res = spawnSync('node', [RUNNER_PATH, JSON.stringify(input)], {
+  const res = spawnSync('node', [runnerPath, JSON.stringify(input)], {
     cwd: process.cwd(),
     env: process.env,
     encoding: 'utf8',

--- a/packages/agent-eval/src/lib/agents/gemini/agent.ts
+++ b/packages/agent-eval/src/lib/agents/gemini/agent.ts
@@ -75,5 +75,6 @@ export function createGeminiAgent(): Agent {
       return definition.defaultModel;
     },
     run: (fixturePath, options) => runWithDefinition(definition, fixturePath, options),
+    definition,
   };
 }

--- a/packages/agent-eval/src/lib/agents/opencode/agent.ts
+++ b/packages/agent-eval/src/lib/agents/opencode/agent.ts
@@ -207,5 +207,6 @@ export function createOpenCodeAgent(): Agent {
       return definition.defaultModel;
     },
     run: (fixturePath, options) => runWithDefinition(definition, fixturePath, options),
+    definition,
   };
 }

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.test.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveJudgeRuntime } from './orchestrator.js';
+import { JUDGE_RUNNER_PATH } from '../shared.js';
+import { getAgent } from '../index.js';
+import type { AgentRunOptions } from '../types.js';
+
+const RUNNER_PATH = '__agent_eval__/run.mjs';
+
+const baseOptions: AgentRunOptions = {
+  prompt: 'do it',
+  model: 'claude-sonnet-4-5',
+  timeout: 600_000,
+  apiKey: 'codegen-key',
+};
+
+describe('resolveJudgeRuntime', () => {
+  const savedGatewayKey = process.env.AI_GATEWAY_API_KEY;
+  afterEach(() => {
+    if (savedGatewayKey === undefined) delete process.env.AI_GATEWAY_API_KEY;
+    else process.env.AI_GATEWAY_API_KEY = savedGatewayKey;
+  });
+
+  it('self-grades with the codegen agent+model when judge is unset', () => {
+    const def = getAgent('vercel-ai-gateway/claude-code').definition;
+    const rt = resolveJudgeRuntime(def, baseOptions);
+
+    expect(rt.isSelf).toBe(true);
+    expect(rt.runnerSource).toBeNull();
+    expect(rt.config.runnerPath).toBe(RUNNER_PATH);
+    expect(rt.config.model).toBe('claude-sonnet-4-5'); // codegen model
+    expect(rt.authEnv.ANTHROPIC_AUTH_TOKEN).toBe('codegen-key'); // codegen auth
+  });
+
+  it('pins the judge model but reuses the codegen runner when the agent matches', () => {
+    const def = getAgent('vercel-ai-gateway/claude-code').definition;
+    const rt = resolveJudgeRuntime(def, {
+      ...baseOptions,
+      judge: { model: 'claude-opus-4-8' }, // agent omitted → same as codegen
+    });
+
+    expect(rt.isSelf).toBe(true);
+    expect(rt.runnerSource).toBeNull(); // no second runner shipped
+    expect(rt.config.runnerPath).toBe(RUNNER_PATH);
+    expect(rt.config.model).toBe('claude-opus-4-8'); // PINNED, not codegen's sonnet
+    expect(rt.authEnv.ANTHROPIC_AUTH_TOKEN).toBe('codegen-key'); // same-agent auth reused
+  });
+
+  it('resolves a different judge agent with its own runner, model, and auth', () => {
+    process.env.AI_GATEWAY_API_KEY = 'judge-gateway-key';
+    const codegen = getAgent('codex').definition; // codegen is codex...
+    const rt = resolveJudgeRuntime(codegen, {
+      ...baseOptions,
+      judge: { agent: 'vercel-ai-gateway/claude-code', model: 'claude-opus-4-8' }, // ...judge is Claude
+    });
+
+    expect(rt.isSelf).toBe(false);
+    expect(rt.config.runnerPath).toBe(JUDGE_RUNNER_PATH); // ships a separate judge-run.mjs
+    expect(typeof rt.runnerSource).toBe('string');
+    expect((rt.runnerSource ?? '').length).toBeGreaterThan(0); // the Claude runner source
+    expect(rt.config.model).toBe('claude-opus-4-8'); // judge model
+    // Judge uses ITS OWN gateway auth (resolved from AI_GATEWAY_API_KEY), not codex's.
+    expect(rt.authEnv.ANTHROPIC_BASE_URL).toBeTruthy();
+    expect(rt.authEnv.ANTHROPIC_AUTH_TOKEN).toBe('judge-gateway-key');
+  });
+});

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -32,10 +32,13 @@ import {
   initGitAndCommit,
   injectTranscriptContext,
   prepareNeutralWorkspace,
+  resolveAgentApiKey,
   EVAL_HELPER_PATH,
   JUDGE_TRANSCRIPT_FILE,
   JUDGE_CONFIG_PATH,
+  JUDGE_RUNNER_PATH,
 } from '../shared.js';
+import { getAgent } from '../registry.js';
 import type { AgentDefinition, AgentRunInput, RunnerResult } from './contract.js';
 
 /** Union of the two sandbox backends (same alias the old adapters used). */
@@ -55,6 +58,82 @@ const RESULT_PATH = '__agent_eval__/agent-result.json';
  * can re-invoke the agent in this sandbox.
  */
 const EVAL_HELPER_DISK_PATH = fileURLToPath(new URL('../eval-helper.mjs', import.meta.url));
+
+/** The judge-config.json payload eval-helper.mjs reads to invoke the judge. */
+interface JudgeRuntimeConfig {
+  /** Sandbox-relative runner the judge spawns (codegen run.mjs, or judge-run.mjs). */
+  runnerPath: string;
+  /** Model the judge grades with (null → let the agent CLI default). */
+  model: string | null;
+  /** Host-computed runner extra (e.g. codex's resolved model/effort). */
+  extra: Record<string, unknown> | null;
+}
+
+interface JudgeRuntime {
+  /** The judge agent's definition (the codegen `def` itself when self-grading). */
+  judgeDef: AgentDefinition;
+  /** Options the judge runs under (model pinned; apiKey re-resolved if cross-agent). */
+  judgeOptions: AgentRunOptions;
+  /** True when the judge reuses the codegen agent (no extra install/runner needed). */
+  isSelf: boolean;
+  /** Auth env set on the vitest process so the in-sandbox judge inherits credentials. */
+  authEnv: Record<string, string>;
+  /** Judge runner source to ship at JUDGE_RUNNER_PATH; null when self-grading. */
+  runnerSource: string | null;
+  /** The judge-config.json payload eval-helper.mjs reads. */
+  config: JudgeRuntimeConfig;
+}
+
+/**
+ * Resolve the agentic-judge runtime for this run.
+ *
+ * Default (no `options.judge`): the judge IS the codegen agent+model — self-grading,
+ * the historical behavior. No second runner or install is needed; it reuses run.mjs.
+ *
+ * Pinned (`options.judge` set): the judge grades with a fixed agent+model regardless
+ * of the model under test — the apples-to-apples choice for cross-model dashboards.
+ * When the pinned agent differs from the codegen agent we resolve ITS definition,
+ * key (own env var → VERCEL_OIDC_TOKEN), auth env, and runner from the registry; the
+ * caller also installs that agent's CLI (it isn't installed by the codegen setup).
+ */
+export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptions): JudgeRuntime {
+  const spec = options.judge;
+
+  // Same harness as codegen (default, or judge.agent omitted/equal): reuse run.mjs,
+  // just pin the model when asked. Identical to pre-feature behavior when unset.
+  if (!spec || (spec.agent ?? def.name) === def.name) {
+    const judgeOptions = spec ? { ...options, model: spec.model } : options;
+    return {
+      judgeDef: def,
+      judgeOptions,
+      isSelf: true,
+      authEnv: def.authEnv(judgeOptions),
+      runnerSource: null,
+      config: {
+        runnerPath: RUNNER_PATH,
+        model: spec?.model ?? options.model ?? null,
+        extra: def.runnerExtra?.(judgeOptions) ?? null,
+      },
+    };
+  }
+
+  // Pinned to a DIFFERENT agent — resolve its definition + key + runner.
+  const judgeDef = getAgent(spec.agent!).definition;
+  const judgeApiKey = resolveAgentApiKey(judgeDef.getApiKeyEnvVar) ?? '';
+  const judgeOptions: AgentRunOptions = { ...options, model: spec.model, apiKey: judgeApiKey };
+  return {
+    judgeDef,
+    judgeOptions,
+    isSelf: false,
+    authEnv: judgeDef.authEnv(judgeOptions),
+    runnerSource: readFileSync(judgeDef.runnerPath, 'utf8'),
+    config: {
+      runnerPath: JUDGE_RUNNER_PATH,
+      model: spec.model,
+      extra: judgeDef.runnerExtra?.(judgeOptions) ?? null,
+    },
+  };
+}
 
 /**
  * Run all install steps for an agent, reproducing the old per-step error wording.
@@ -215,6 +294,15 @@ export async function runWithDefinition(
     await runInstallSteps(sandbox, def, options);
     await writeConfigFiles(sandbox, def, options);
 
+    // 4b. If the agentic judge is pinned to a DIFFERENT agent, install its CLI +
+    //     config too — the codegen setup above only installed the codegen agent.
+    //     (npm install of project deps re-runs idempotently; the CLI is the point.)
+    const judgeRuntime = resolveJudgeRuntime(def, options);
+    if (!judgeRuntime.isSelf) {
+      await runInstallSteps(sandbox, judgeRuntime.judgeDef, judgeRuntime.judgeOptions);
+      await writeConfigFiles(sandbox, judgeRuntime.judgeDef, judgeRuntime.judgeOptions);
+    }
+
     // 5. Guard: no stray test files leaked into the workspace before the agent runs.
     await verifyNoTestFiles(sandbox);
 
@@ -273,24 +361,27 @@ export async function runWithDefinition(
     }
 
     // 10. VALIDATION (unchanged shared helpers; parseTranscript runs host-side here).
-    // The auth env is reused for the eval process so EVAL.ts judge matchers can
+    // The JUDGE's auth env is set on the eval process so EVAL.ts judge matchers can
     // re-invoke the agent in-sandbox (the vitest process inherits it to children).
-    const validationEnv = { ...def.authEnv(options), ...neutralWorkspace.env };
+    // By default the judge is the codegen agent+model; options.judge pins a fixed one
+    // (judgeRuntime was resolved at step 4b so its CLI could be installed).
+    const validationEnv = { ...judgeRuntime.authEnv, ...neutralWorkspace.env };
     if (options.validation !== 'none') {
       await sandbox.uploadFiles(testFiles);
       await createVitestConfig(sandbox);
       await injectTranscriptContext(sandbox, transcript, def.o11yAgentName, options.model);
       // Judge runtime: ship the eval helper, materialize the raw transcript as a
-      // file the judge agent can read by path, and record the judge config (same
-      // agent/model + host-computed extra the codegen run used).
-      await sandbox.writeFiles({
+      // file the judge agent can read by path, record the judge config, and — only
+      // when the judge is a DIFFERENT agent — ship its runner alongside run.mjs.
+      const judgeFiles: Record<string, string> = {
         [EVAL_HELPER_PATH]: readFileSync(EVAL_HELPER_DISK_PATH, 'utf8'),
         [JUDGE_TRANSCRIPT_FILE]: transcript ?? '',
-        [JUDGE_CONFIG_PATH]: JSON.stringify({
-          model: options.model ?? null,
-          extra: def.runnerExtra?.(options) ?? null,
-        }),
-      });
+        [JUDGE_CONFIG_PATH]: JSON.stringify(judgeRuntime.config),
+      };
+      if (judgeRuntime.runnerSource) {
+        judgeFiles[JUDGE_RUNNER_PATH] = judgeRuntime.runnerSource;
+      }
+      await sandbox.writeFiles(judgeFiles);
     }
     const validationResults = await runValidation(
       sandbox,

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -31,8 +31,22 @@ export const EVAL_HELPER_PATH = `${TRANSCRIPT_CONTEXT_DIR}/eval-helper.mjs`;
 /** Raw transcript materialized as a file so the judge agent can read it by path. */
 export const JUDGE_TRANSCRIPT_FILE = `${TRANSCRIPT_CONTEXT_DIR}/transcript.txt`;
 
-/** Judge config (`{ model, extra }`) — the same agent/model the codegen used. */
+/** Judge config (`{ runnerPath, model, extra }`) read by eval-helper.mjs. */
 export const JUDGE_CONFIG_PATH = `${TRANSCRIPT_CONTEXT_DIR}/judge-config.json`;
+
+/** The judge agent's runner, shipped separately ONLY when the judge agent differs
+ * from the codegen agent. When they match, the judge reuses the codegen run.mjs. */
+export const JUDGE_RUNNER_PATH = `${TRANSCRIPT_CONTEXT_DIR}/judge-run.mjs`;
+
+/**
+ * Resolve an agent's API key from the host env. Single source of truth shared by
+ * the CLI (codegen agent) and the orchestrator (a pinned judge agent): the agent's
+ * own key env var, falling back to VERCEL_OIDC_TOKEN — which authenticates both the
+ * Vercel Sandbox and the AI Gateway. Returns undefined when neither is set.
+ */
+export function resolveAgentApiKey(getApiKeyEnvVar: () => string): string | undefined {
+  return process.env[getApiKeyEnvVar()] ?? process.env.VERCEL_OIDC_TOKEN;
+}
 
 /**
  * Combined validation results.

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -2,7 +2,8 @@
  * Agent interface and common types for all agents.
  */
 
-import type { ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
+import type { JudgeConfig, ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
+import type { AgentDefinition } from './plugin/contract.js';
 
 /**
  * Common options for all agents.
@@ -46,6 +47,9 @@ export interface AgentRunOptions {
   webResearch?: boolean;
   /** Agent-specific options (e.g., binaryUrl, extraProviders for opencode) */
   agentOptions?: Record<string, unknown>;
+  /** Pin the agentic LLM judge to a fixed agent+model. Undefined → the judge
+   * self-grades with this run's agent+model. */
+  judge?: JudgeConfig;
 }
 
 /**
@@ -102,4 +106,8 @@ export interface Agent {
 
   /** Get the default model for this agent */
   getDefaultModel(): ModelTier;
+
+  /** The host-side definition (auth, runner path, install). Exposed so the
+   * orchestrator can resolve a DIFFERENT agent as the judge via the registry. */
+  definition: AgentDefinition;
 }

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -70,6 +70,32 @@ describe('validateConfig', () => {
     const config = { agent: 'claude-code', webResearch: 'yes' };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
+
+  it('accepts a pinned judge (model only, agent defaults to codegen)', () => {
+    const config = { agent: 'claude-code', judge: { model: 'claude-opus-4-8' } };
+    expect(validateConfig(config).judge).toEqual({ model: 'claude-opus-4-8' });
+  });
+
+  it('accepts a pinned judge with an explicit agent', () => {
+    const config = {
+      agent: 'codex',
+      judge: { agent: 'vercel-ai-gateway/claude-code', model: 'claude-opus-4-8' },
+    };
+    expect(validateConfig(config).judge).toEqual({
+      agent: 'vercel-ai-gateway/claude-code',
+      model: 'claude-opus-4-8',
+    });
+  });
+
+  it('rejects a judge without a model (pinning the model is required)', () => {
+    const config = { agent: 'claude-code', judge: { agent: 'claude-code' } };
+    expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
+  });
+
+  it('rejects a judge with an invalid agent', () => {
+    const config = { agent: 'claude-code', judge: { agent: 'nope', model: 'x' } };
+    expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
+  });
 });
 
 describe('resolveConfig', () => {
@@ -104,6 +130,13 @@ describe('resolveConfig', () => {
   it('passes webResearch through and leaves it undefined by default', () => {
     expect(resolveConfig({ agent: 'claude-code' as const }).webResearch).toBeUndefined();
     expect(resolveConfig({ agent: 'claude-code' as const, webResearch: true }).webResearch).toBe(true);
+  });
+
+  it('passes judge through and leaves it undefined by default', () => {
+    expect(resolveConfig({ agent: 'claude-code' as const }).judge).toBeUndefined();
+    expect(
+      resolveConfig({ agent: 'claude-code' as const, judge: { model: 'claude-opus-4-8' } }).judge
+    ).toEqual({ model: 'claude-opus-4-8' });
   });
 
 });

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -65,6 +65,24 @@ const experimentConfigSchema = z.object({
     isYourBrand: z.boolean().optional(),
   })).optional(),
   onRunComplete: z.function().optional(),
+  // Pin the agentic LLM judge. `agent` defaults to the codegen agent; `model` is
+  // required (pinning the judge model is the point).
+  judge: z
+    .object({
+      agent: z
+        .enum([
+          'vercel-ai-gateway/claude-code',
+          'claude-code',
+          'vercel-ai-gateway/codex',
+          'codex',
+          'vercel-ai-gateway/opencode',
+          'gemini',
+          'cursor',
+        ])
+        .optional(),
+      model: z.string(),
+    })
+    .optional(),
 });
 
 /**
@@ -112,6 +130,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     webResearch: config.webResearch,
     brands: config.brands,
     onRunComplete: config.onRunComplete,
+    judge: config.judge,
   };
 }
 

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -197,4 +197,49 @@ describe('computeFingerprint', () => {
     expect(fpModelB).toBe(fpModelBAfter);
     expect(fpModelA).not.toBe(fpModelB); // different models = different fingerprints
   });
+
+  it('keeps unpinned-judge equivalent to existing fingerprints', () => {
+    const evalDir = createEvalDir('eval-judge-default', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    // Cached results predate the judge field; an unpinned config must hash the same.
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, judge: undefined });
+
+    expect(fp1).toBe(fp2);
+  });
+
+  it('changes when a judge is pinned (judged results must not reuse self-graded ones)', () => {
+    const evalDir = createEvalDir('eval-judge-pinned', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, judge: { model: 'claude-opus-4-8' } });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('changes when the judge model or agent changes', () => {
+    const evalDir = createEvalDir('eval-judge-vary', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const opus = computeFingerprint(evalDir, { ...baseConfig, judge: { model: 'claude-opus-4-8' } });
+    const sonnet = computeFingerprint(evalDir, { ...baseConfig, judge: { model: 'claude-sonnet-4-5' } });
+    const opusGateway = computeFingerprint(evalDir, {
+      ...baseConfig,
+      judge: { agent: 'vercel-ai-gateway/claude-code', model: 'claude-opus-4-8' },
+    });
+
+    expect(opus).not.toBe(sonnet); // different judge model
+    expect(opus).not.toBe(opusGateway); // different judge agent
+  });
 });

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -23,6 +23,7 @@ interface FingerprintableConfig {
   earlyExit: boolean;
   runs: number;
   webResearch?: boolean;
+  judge?: { agent?: string; model: string };
 }
 
 /**
@@ -84,6 +85,11 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   // result for a research run, or vice versa.
   if (config.webResearch) {
     configForHash.webResearch = true;
+  }
+  // Included only when the judge is pinned, so existing (unpinned) fingerprints are
+  // unchanged. Changing the judge agent/model invalidates the cache → re-runs.
+  if (config.judge) {
+    configForHash.judge = { agent: config.judge.agent, model: config.judge.model };
   }
   hash.update(`config:${JSON.stringify(configForHash)}`);
 

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -195,6 +195,7 @@ export async function runExperiment(
         sandbox: config.sandbox,
         agentOptions: config.agentOptions,
         webResearch: config.webResearch,
+        judge: config.judge,
       }),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
@@ -388,6 +389,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     verbose?: boolean;
     agentOptions?: ResolvedExperimentConfig['agentOptions'];
     webResearch?: ResolvedExperimentConfig['webResearch'];
+    judge?: ResolvedExperimentConfig['judge'];
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
@@ -411,6 +413,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		sandbox: options.sandbox,
 		agentOptions: options.agentOptions,
 		webResearch: options.webResearch,
+		judge: options.judge,
 	});
 
     results.push(agentResultToEvalRunData(agentResult));

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -90,6 +90,22 @@ export type RunCompleteHook = (
 export type SandboxBackend = 'vercel' | 'docker';
 
 /**
+ * Configures the agentic LLM judge used by `expect(environment|transcript)`
+ * matchers in EVAL.ts. By default the judge runs as the SAME agent+model that
+ * generated the code (self-grading). Pin it here to grade every model with one
+ * fixed judge — the apples-to-apples choice for cross-model dashboards.
+ */
+export interface JudgeConfig {
+  /** Judge harness. Defaults to the codegen agent (same harness, model pinned).
+   * Set a Claude variant (e.g. 'vercel-ai-gateway/claude-code') to judge codex,
+   * gemini, etc. runs with Claude. */
+  agent?: AgentType;
+  /** Model the judge grades with (e.g. 'claude-opus-4-8'). Required — pinning the
+   * judge model is the whole point. */
+  model: ModelTier;
+}
+
+/**
  * Experiment configuration.
  * Defines what to test and how.
  */
@@ -149,6 +165,10 @@ export interface ExperimentConfig {
 
   /** Optional hook for custom post-run analysis before results are saved. */
   onRunComplete?: RunCompleteHook;
+
+  /** Pin the agentic LLM judge to a fixed agent+model. @default undefined
+   * (judge self-grades with the codegen agent+model). */
+  judge?: JudgeConfig;
 }
 
 /**
@@ -172,6 +192,7 @@ export interface ResolvedExperimentConfig {
   webResearch?: boolean;
   brands?: BrandConfig[];
   onRunComplete?: RunCompleteHook;
+  judge?: JudgeConfig;
 }
 
 /**
@@ -195,6 +216,7 @@ export interface RunnableExperimentConfig {
   webResearch?: boolean;
   brands?: BrandConfig[];
   onRunComplete?: RunCompleteHook;
+  judge?: JudgeConfig;
 }
 
 /**


### PR DESCRIPTION
The `expect(environment|transcript)` judge matchers grade with the same agent and model that generated the code, so comparing models on one dashboard mixes judge quality row-to-row and lets a model grade its own output. `ExperimentConfig.judge = { agent?, model }` pins one fixed judge; `agent` defaults to the codegen agent, so omitting it pins only the model on the same harness. When `judge.agent` names a different agent, its CLI is installed in the sandbox and its key is resolved from its own env var (falling back to `VERCEL_OIDC_TOKEN`), and the judge runs from its own `judge-run.mjs`.

The judge config is folded into the eval fingerprint only when set, so existing cached results stay valid and a pinned run won't reuse a self-graded one. Verified end-to-end in a Vercel sandbox: codegen `claude-sonnet-4-5` with the judge pinned to `claude-opus-4-8` passes, and pinning the judge to a nonexistent model fails attributably at the judge step (the error names the pinned model) while codegen is unaffected.
