### PR TITLE
[agent-eval] Incremental eval staleness: status / run + content-aware fingerprints

### DIFF
--- a/.changeset/eval-staleness.md
+++ b/.changeset/eval-staleness.md
@@ -1,0 +1,11 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Incremental eval-staleness workflow, so adopting a changed or new eval doesn't force re-running every experiment.
+
+- Fingerprint split: each result stores a content-only hash next to the combined (content+config) one. A real eval change is never masked; a benign config change (e.g. a `timeout` bump, or pinning a judge) is carried forward by `refingerprint` instead of re-running. Existing `fingerprint` values are byte-identical, so caches stay valid. (Fixes the previous re-fingerprinting that silently re-stamped every result and hid eval changes.)
+- `agent-eval status` — read-only: which evals are new vs changed, per experiment (classified by content). `--check` exits non-zero on any new/changed eval (a simple CI gate); `--json` emits per-experiment new/changed so a consumer can apply its own "which staleness is acceptable" policy.
+- `agent-eval run <experiments...>` — run the named experiments' new/changed evals (auto-carries config-only changes first).
+- Bare `agent-eval` shows status, then (in a terminal) lets you multi-select which experiments to run — it never re-runs everything.
+- Removes `run-all` and `--dry` (the run-everything-when-stale behavior). There is no in-framework "acknowledge/keep" — staleness acceptance is the consumer's policy (e.g. filter `status --json` against an accepted-stale list in CI).

--- a/README.md
+++ b/README.md
@@ -541,6 +541,54 @@ On subsequent runs, evals with a matching fingerprint and a valid cached result 
 
 Use `--force` to bypass fingerprinting and re-run everything. Functions like `setup` and `editPrompt` cannot be hashed, so use `--force` when you change those.
 
+Each result also stores a `contentFingerprint` — a hash of the eval files **only**, independent of config. This separates "the eval itself changed" from "a config field changed."
+
+### Carrying forward config-only changes
+
+A benign config change (e.g. bumping `timeout`) changes the combined fingerprint and would otherwise re-run every eval. `agent-eval refingerprint` carries those forward in the cached results **without masking a real eval change**:
+
+```bash
+agent-eval refingerprint            # all experiments
+agent-eval refingerprint cc --dry   # preview one experiment
+```
+
+For each cached result it compares the eval's current `contentFingerprint` to the stored one: if the content is unchanged it re-stamps the combined fingerprint (the result stays cached); if the content **changed** it leaves the result stale so it re-runs. `agent-eval status` already classifies by eval *content*, so it never reports a config-only change as work — run `refingerprint` after editing an experiment config to carry that change into the cache (`run` does this automatically).
+
+### After changing or syncing evals: status → pick what to run
+
+Run `agent-eval` with no arguments. It shows the work, then — in a terminal — lets you multi-select which experiments to run. It never re-runs everything:
+
+```bash
+agent-eval
+```
+```
+Evals needing work:
+  new      agent-026-no-serial-await
+  changed  agent-024-avoid-redundant-usestate
+
+Work to do — 6 run(s) across 3 experiment(s):
+  claude-opus-4.6      2 to run  (22 up to date)
+  ...
+
+Pick experiments to run:
+   1  claude-opus-4.6
+   2  claude-sonnet-4.6
+Numbers (e.g. 1,3), "all", or Enter to skip:
+```
+
+Status classifies each eval by **content**, so a benign config change (e.g. pinning a judge) is never reported as work. The same building blocks work non-interactively:
+
+```bash
+agent-eval status                  # read-only: what's new/changed, per experiment
+agent-eval status --check          # exit non-zero if anything is new/changed (simple CI gate)
+agent-eval status --json           # machine-readable, for custom CI policy
+agent-eval run claude-sonnet-4.6   # run the named experiment(s) — new/changed evals only
+```
+
+**Accepting staleness is the consumer's call, not the framework's.** `agent-eval` only *reports* — it has no `keep`/`acknowledge`. If you want to leave some experiments on an older eval while keeping others fresh, do that in your own CI: read `agent-eval status --json` (per-experiment `new`/`changed`) and fail only on experiments not in your accepted-stale list. (See next-evals-oss's `scripts/check-stale.mjs` for an example.)
+
+> `refingerprint` (carry config-only changes forward) runs automatically inside `run`; your sync script should call `agent-eval refingerprint` after pulling evals so committed results pick up benign config changes without re-running.
+
 ## Failure Classification
 
 When evals fail, the framework optionally classifies each failure as one of:

--- a/packages/agent-eval/src/cli.test.ts
+++ b/packages/agent-eval/src/cli.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { computeContentFingerprint, computeFingerprint } from './lib/fingerprint.js';
+import { loadConfig } from './lib/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -51,9 +53,9 @@ describe('CLI', () => {
   });
 
   describe('run command', () => {
-    it('shows error when config file does not exist', () => {
-      const result = runCli(['run', '/non/existent/config.ts']);
-      expect(result.stderr).toContain('not found');
+    it('shows error when the named experiment does not exist', () => {
+      const result = runCli(['run', 'no-such-experiment']);
+      expect(result.stderr.toLowerCase()).toMatch(/no experiments matched|required/);
       expect(result.exitCode).toBe(1);
     });
 
@@ -168,6 +170,166 @@ describe('CLI', () => {
       const result = runCli(['experiments/cc.ts'], projectDir);
       expect(result.stderr.toLowerCase()).toContain('error');
       expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe('refingerprint command', () => {
+    function setupProject(): { projectDir: string; evalPath: string; summaryPath: string } {
+      const projectDir = join(TEST_DIR, 'refp');
+      const experimentsDir = join(projectDir, 'experiments');
+      mkdirSync(experimentsDir, { recursive: true });
+      writeFileSync(join(experimentsDir, 'cc.ts'), `export default { agent: 'claude-code', model: 'opus' };`);
+      const evalDir = join(projectDir, 'evals', 'eval-1');
+      mkdirSync(evalDir, { recursive: true });
+      writeFileSync(join(evalDir, 'PROMPT.md'), 'do it');
+      writeFileSync(join(evalDir, 'EVAL.ts'), 'test code');
+      writeFileSync(join(evalDir, 'package.json'), '{"type":"module"}');
+      const summaryDir = join(projectDir, 'results', 'cc', '2026-01-01T00-00-00.000Z', 'eval-1');
+      mkdirSync(summaryDir, { recursive: true });
+      return { projectDir, evalPath: evalDir, summaryPath: join(summaryDir, 'summary.json') };
+    }
+
+    it('carries forward a config-only change but never masks a content change', () => {
+      const { projectDir, evalPath, summaryPath } = setupProject();
+      const currentContent = computeContentFingerprint(evalPath);
+
+      // Config-only change: stored content fp matches current, combined is stale.
+      writeFileSync(
+        summaryPath,
+        JSON.stringify({
+          totalRuns: 1, passedRuns: 1, passRate: '100%', meanDuration: 1,
+          fingerprint: 'STALE_COMBINED', contentFingerprint: currentContent,
+        })
+      );
+      let r = runCli(['refingerprint'], projectDir);
+      expect(r.exitCode).toBe(0);
+      let summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+      expect(summary.fingerprint).not.toBe('STALE_COMBINED'); // carried forward
+      expect(summary.fingerprint).toMatch(/^[a-f0-9]{64}$/);
+      expect(summary.contentFingerprint).toBe(currentContent); // content untouched
+
+      // Content change: stored content fp differs → must be left stale, NOT masked.
+      writeFileSync(
+        summaryPath,
+        JSON.stringify({
+          totalRuns: 1, passedRuns: 1, passRate: '100%', meanDuration: 1,
+          fingerprint: 'OLD_COMBINED', contentFingerprint: 'OLD_CONTENT',
+        })
+      );
+      r = runCli(['refingerprint'], projectDir);
+      expect(r.exitCode).toBe(0);
+      summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+      expect(summary.fingerprint).toBe('OLD_COMBINED'); // NOT re-stamped
+      expect(summary.contentFingerprint).toBe('OLD_CONTENT');
+    });
+
+    it('--dry does not write', () => {
+      const { projectDir, evalPath, summaryPath } = setupProject();
+      const currentContent = computeContentFingerprint(evalPath);
+      writeFileSync(
+        summaryPath,
+        JSON.stringify({
+          totalRuns: 1, passedRuns: 1, passRate: '100%', meanDuration: 1,
+          fingerprint: 'STALE_COMBINED', contentFingerprint: currentContent,
+        })
+      );
+      const r = runCli(['refingerprint', '--dry'], projectDir);
+      expect(r.exitCode).toBe(0);
+      const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+      expect(summary.fingerprint).toBe('STALE_COMBINED'); // unchanged under --dry
+    });
+  });
+
+  describe('staleness flow (status / refingerprint / --check / --json)', () => {
+    it('fresh → change → status + --check + --json flag it; refingerprint stays honest; a rerun clears it', async () => {
+      const projectDir = join(TEST_DIR, 'flow');
+      const experimentsDir = join(projectDir, 'experiments');
+      mkdirSync(experimentsDir, { recursive: true });
+      writeFileSync(join(experimentsDir, 'cc.ts'), `export default { agent: 'claude-code', model: 'opus' };`);
+      const evalDir = join(projectDir, 'evals', 'eval-1');
+      mkdirSync(evalDir, { recursive: true });
+      writeFileSync(join(evalDir, 'PROMPT.md'), 'do it');
+      writeFileSync(join(evalDir, 'EVAL.ts'), 'v1');
+      writeFileSync(join(evalDir, 'package.json'), '{"type":"module"}');
+      const summaryPath = join(projectDir, 'results', 'cc', '2026-01-01T00-00-00.000Z', 'eval-1', 'summary.json');
+      mkdirSync(dirname(summaryPath), { recursive: true });
+
+      const config = await loadConfig(join(experimentsDir, 'cc.ts'));
+      const modelConfig = { ...config, model: Array.isArray(config.model) ? config.model[0] : config.model };
+      const seedFresh = () =>
+        writeFileSync(
+          summaryPath,
+          JSON.stringify({
+            totalRuns: 1, passedRuns: 1, passRate: '100%', meanDuration: 1,
+            fingerprint: computeFingerprint(evalDir, modelConfig as never),
+            contentFingerprint: computeContentFingerprint(evalDir),
+          })
+        );
+
+      // 1. Fresh → status clean, --check passes.
+      seedFresh();
+      expect(runCli(['status'], projectDir).stdout).toContain('up to date');
+      expect(runCli(['status', '--check'], projectDir).exitCode).toBe(0);
+
+      // 2. Eval content changes → status flags it, --check fails, --json reports it.
+      writeFileSync(join(evalDir, 'EVAL.ts'), 'v2');
+      const s = runCli(['status'], projectDir).stdout;
+      expect(s).toContain('changed');
+      expect(s).toContain('eval-1');
+      expect(runCli(['status', '--check'], projectDir).exitCode).toBe(1);
+      const json = JSON.parse(runCli(['status', '--json'], projectDir).stdout);
+      expect(json.work).toEqual([{ experiment: 'cc', new: [], changed: ['eval-1'] }]);
+
+      // 3. refingerprint must NOT mask a content change — still failing.
+      runCli(['refingerprint'], projectDir);
+      expect(runCli(['status', '--check'], projectDir).exitCode).toBe(1);
+
+      // 4. A rerun (simulated by re-seeding fresh for the new content) clears it.
+      seedFresh();
+      expect(runCli(['status', '--check'], projectDir).exitCode).toBe(0);
+    });
+
+    it('status reports new and changed evals as the work to do', async () => {
+      const projectDir = join(TEST_DIR, 'status');
+      const experimentsDir = join(projectDir, 'experiments');
+      mkdirSync(experimentsDir, { recursive: true });
+      writeFileSync(join(experimentsDir, 'cc.ts'), `export default { agent: 'claude-code', model: 'opus' };`);
+      const evalDir = join(projectDir, 'evals', 'eval-1');
+      mkdirSync(evalDir, { recursive: true });
+      writeFileSync(join(evalDir, 'PROMPT.md'), 'do it');
+      writeFileSync(join(evalDir, 'EVAL.ts'), 'v1');
+      writeFileSync(join(evalDir, 'package.json'), '{"type":"module"}');
+
+      const config = await loadConfig(join(experimentsDir, 'cc.ts'));
+      const modelConfig = { ...config, model: Array.isArray(config.model) ? config.model[0] : config.model };
+      const sp = join(projectDir, 'results', 'cc', '2026-01-01T00-00-00.000Z', 'eval-1', 'summary.json');
+      mkdirSync(dirname(sp), { recursive: true });
+      writeFileSync(
+        sp,
+        JSON.stringify({
+          totalRuns: 1, passedRuns: 1, passRate: '100%', meanDuration: 1,
+          fingerprint: computeFingerprint(evalDir, modelConfig as never),
+          contentFingerprint: computeContentFingerprint(evalDir),
+        })
+      );
+
+      // Up to date.
+      expect(runCli(['status'], projectDir).stdout).toContain('up to date');
+
+      // Add a NEW eval (no result) + CHANGE the existing one.
+      const evalDir2 = join(projectDir, 'evals', 'eval-2');
+      mkdirSync(evalDir2, { recursive: true });
+      writeFileSync(join(evalDir2, 'PROMPT.md'), 'do it');
+      writeFileSync(join(evalDir2, 'EVAL.ts'), 'x');
+      writeFileSync(join(evalDir2, 'package.json'), '{"type":"module"}');
+      writeFileSync(join(evalDir, 'EVAL.ts'), 'v2');
+
+      const out = runCli(['status'], projectDir).stdout;
+      expect(out).toContain('new'); // eval-2
+      expect(out).toContain('eval-2');
+      expect(out).toContain('changed'); // eval-1
+      expect(out).toContain('eval-1');
+      expect(out).toContain('to run');
     });
   });
 });

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -6,8 +6,9 @@
 
 import { Command } from 'commander';
 import { config as dotenvConfig } from 'dotenv';
-import { resolve, dirname, basename } from 'path';
-import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve, dirname, basename, join } from 'path';
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync, statSync } from 'fs';
+import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'url';
 import chalk from 'chalk';
 import { loadConfig, resolveEvalNames } from './lib/config.js';
@@ -19,7 +20,7 @@ import { initProject, getPostInitInstructions } from './lib/init.js';
 import { getAgent } from './lib/agents/index.js';
 import { resolveAgentApiKey } from './lib/agents/shared.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
-import { computeFingerprint } from './lib/fingerprint.js';
+import { computeFingerprint, computeContentFingerprint, decideRefingerprint } from './lib/fingerprint.js';
 import { scanReusableResults } from './lib/results.js';
 import { isClassifierEnabled, classifyFailure } from './lib/classifier.js';
 import { housekeep } from './lib/housekeeping.js';
@@ -335,94 +336,6 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
         process.exit(1);
       }
 
-      // --- Dry run: collect info and print a single summary table ---
-      if (options.dry) {
-        interface DryRunInfo { name: string; toRun: string[]; cached: number; total: number }
-        const dryResults: DryRunInfo[] = [];
-
-        for (const file of selectedFiles) {
-          const configPath = resolve(experimentsDir, file);
-          const baseExperimentName = file.replace(/\.ts$/, '');
-
-          let config;
-          try {
-            config = await loadConfig(configPath);
-          } catch (err) {
-            console.error(chalk.red(`Failed to load ${file}: ${err instanceof Error ? err.message : err}`));
-            continue;
-          }
-
-          const models = Array.isArray(config.model) ? config.model : [config.model];
-          const availableNames = fixtures.map((f) => f.name);
-          let evalNames: string[];
-          try {
-            evalNames = resolveEvalNames(config.evals, availableNames);
-          } catch {
-            evalNames = availableNames;
-          }
-
-          if (options.smoke) {
-            evalNames = [evalNames.sort()[0]];
-          }
-
-          for (const model of models) {
-            const experimentName = models.length > 1
-              ? `${baseExperimentName}/${model}`
-              : baseExperimentName;
-
-            const modelConfig = { ...config, model, runs: options.smoke ? 1 : config.runs };
-            const selectedFixtures = fixtures.filter((f) => evalNames.includes(f.name));
-            const fingerprints: Record<string, string> = {};
-            for (const fixture of selectedFixtures) {
-              fingerprints[fixture.name] = computeFingerprint(fixture.path, modelConfig);
-            }
-
-            let fixturesToRun = selectedFixtures;
-            if (!options.force && !options.smoke) {
-              const reusable = scanReusableResults(resultsDir, experimentName, fingerprints);
-              if (reusable.size > 0) {
-                fixturesToRun = selectedFixtures.filter((f) => !reusable.has(f.name));
-              }
-            }
-
-            dryResults.push({
-              name: experimentName,
-              toRun: fixturesToRun.map((f) => f.name),
-              cached: selectedFixtures.length - fixturesToRun.length,
-              total: selectedFixtures.length,
-            });
-          }
-        }
-
-        // Print summary
-        const totalToRun = dryResults.reduce((sum, d) => sum + d.toRun.length, 0);
-        const totalCached = dryResults.reduce((sum, d) => sum + d.cached, 0);
-        const nameWidth = Math.max(...dryResults.map((d) => d.name.length)) + 2;
-
-        console.log('');
-        if (totalToRun === 0) {
-          console.log(chalk.green(`  All ${totalCached} evals cached across ${dryResults.length} experiments. Nothing to run.`));
-        } else {
-          console.log(chalk.bold(`  ${totalToRun} evals to run, ${totalCached} cached\n`));
-          for (const d of dryResults) {
-            const label = d.name.padEnd(nameWidth);
-            if (d.toRun.length === 0) {
-              console.log(chalk.gray(`  ${label} ${d.total} cached`));
-            } else {
-              console.log(
-                chalk.white(`  ${label}`) +
-                chalk.blue(` ${d.toRun.length} to run`) +
-                (d.cached > 0 ? chalk.gray(`, ${d.cached} cached`) : '')
-              );
-              for (const name of d.toRun) {
-                console.log(chalk.green(`  ${' '.repeat(nameWidth)} → ${name}`));
-              }
-            }
-          }
-        }
-        console.log('');
-        return;
-      }
 
       // --- Live run ---
       const useDashboard = process.stdout.isTTY && selectedFiles.length > 1;
@@ -494,13 +407,15 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
 
           const selectedFixtures = fixtures.filter((f) => evalNames.includes(f.name));
           const fingerprints: Record<string, string> = {};
+          const contentFingerprints: Record<string, string> = {};
           for (const fixture of selectedFixtures) {
             fingerprints[fixture.name] = computeFingerprint(fixture.path, modelConfig);
+            contentFingerprints[fixture.name] = computeContentFingerprint(fixture.path);
           }
 
           const classifierOn = isClassifierEnabled();
 
-          // Scan for reusable results
+          // Scan for reusable (fresh) results.
           let fixturesToRun = selectedFixtures;
           if (!options.force && !options.smoke) {
             const reusable = scanReusableResults(resultsDir, experimentName, fingerprints);
@@ -532,6 +447,7 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
                 resultsDir,
                 experimentName,
                 fingerprints,
+                contentFingerprints,
                 smoke: options.smoke,
                 onProgress,
                 rateLimiter,
@@ -689,37 +605,358 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
 }
 
 /**
- * run-all subcommand (explicit)
+ * Resolve and validate the standard project layout (experiments/, evals/, results/).
+ * Shared by `status`, `run`, and `refingerprint`.
  */
+function resolveProjectDirs(): { experimentsDir: string; evalsDir: string; resultsDir: string } {
+  const projectDir = process.cwd();
+  const experimentsDir = resolve(projectDir, 'experiments');
+  const evalsDir = resolve(projectDir, 'evals');
+  const resultsDir = resolve(projectDir, 'results');
+  if (!existsSync(experimentsDir) || !existsSync(resultsDir)) {
+    console.error(chalk.red('experiments/ and results/ directories are required'));
+    process.exit(1);
+  }
+  return { experimentsDir, evalsDir, resultsDir };
+}
+
+/** Select experiment config files, optionally filtered by name/glob args. */
+function selectExperimentFiles(experimentsDir: string, experimentArgs: string[]): string[] {
+  const allFiles = readdirSync(experimentsDir)
+    .filter((f) => f.endsWith('.ts') && !f.startsWith('_temp_'))
+    .sort();
+  return experimentArgs.length > 0
+    ? allFiles.filter((f) => {
+        const name = f.replace(/\.ts$/, '');
+        return experimentArgs.some((arg) => (arg.includes('*') ? minimatch(name, arg) : name === arg));
+      })
+    : allFiles;
+}
+
+/** The newest result summary for an (experiment, eval), or null if never run. */
+function findNewestSummary(experimentResultsDir: string, evalName: string): Record<string, unknown> | null {
+  if (!existsSync(experimentResultsDir)) return null;
+  const timestamps = readdirSync(experimentResultsDir)
+    .filter((t) => !t.startsWith('.'))
+    .sort()
+    .reverse();
+  for (const ts of timestamps) {
+    const sp = join(experimentResultsDir, ts, evalName, 'summary.json');
+    if (existsSync(sp)) {
+      try {
+        return JSON.parse(readFileSync(sp, 'utf-8'));
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Status handler: the one read-only command to answer "what's the work to be done?"
+ * after editing or syncing evals. For each (experiment, eval) it classifies the newest
+ * result by EVAL CONTENT (so a benign config-only change isn't reported as work):
+ *
+ *   - new      → the eval was never run for this experiment
+ *   - changed  → the eval's content changed since it was run
+ *   - up to date
+ *
+ * The framework only REPORTS; it has no opinion on which staleness is acceptable —
+ * that policy lives in the consumer (e.g. `agent-eval status --json` in CI, filtered
+ * against the repo's own accepted-stale list). `--check` is a simple gate that fails
+ * on any new/changed eval. Writes nothing.
+ */
+interface StatusRow { name: string; baseName: string; newEvals: string[]; changedEvals: string[]; cached: number }
+
+async function statusCommand(
+  experimentArgs: string[],
+  options: { check?: boolean; json?: boolean } = {}
+): Promise<{ rows: StatusRow[]; totalRun: number }> {
+  const { experimentsDir, evalsDir, resultsDir } = resolveProjectDirs();
+  const selectedFiles = selectExperimentFiles(experimentsDir, experimentArgs);
+  const { fixtures } = loadAllFixtures(evalsDir);
+  const availableNames = fixtures.map((f) => f.name);
+  const fixtureByName = new Map(fixtures.map((f) => [f.name, f]));
+
+  const allNew = new Set<string>();
+  const allChanged = new Set<string>();
+  const rows: StatusRow[] = [];
+
+  for (const file of selectedFiles) {
+    let config;
+    try {
+      config = await loadConfig(resolve(experimentsDir, file));
+    } catch (err) {
+      if (!options.json) console.warn(chalk.yellow(`Skipping ${file}: ${err instanceof Error ? err.message : err}`));
+      continue;
+    }
+    const baseName = file.replace(/\.ts$/, '');
+    const models = Array.isArray(config.model) ? config.model : [config.model];
+    let evalNames: string[];
+    try {
+      evalNames = resolveEvalNames(config.evals, availableNames);
+    } catch {
+      evalNames = availableNames;
+    }
+
+    for (const model of models) {
+      const experimentName = models.length > 1 ? `${baseName}/${model}` : baseName;
+      const modelConfig = { ...config, model };
+      const expResultsDir = join(resultsDir, experimentName);
+      const newEvals: string[] = [];
+      const changedEvals: string[] = [];
+      let cached = 0;
+
+      for (const ev of evalNames) {
+        const fx = fixtureByName.get(ev);
+        if (!fx) continue;
+        const summary = findNewestSummary(expResultsDir, ev);
+        if (!summary) {
+          newEvals.push(ev);
+          allNew.add(ev);
+          continue;
+        }
+        const content = computeContentFingerprint(fx.path);
+        const storedContent = summary.contentFingerprint as string | undefined;
+        // Content-based: a config-only change isn't work (refingerprint carries it).
+        // Legacy results (no content hash) fall back to the combined fingerprint.
+        const fresh = storedContent !== undefined
+          ? storedContent === content
+          : summary.fingerprint === computeFingerprint(fx.path, modelConfig as never);
+        if (fresh) cached++;
+        else {
+          changedEvals.push(ev);
+          allChanged.add(ev);
+        }
+      }
+      rows.push({ name: experimentName, baseName, newEvals, changedEvals, cached });
+    }
+  }
+
+  const totalRun = rows.reduce((s, r) => s + r.newEvals.length + r.changedEvals.length, 0);
+
+  if (options.json) {
+    const work = rows
+      .filter((r) => r.newEvals.length || r.changedEvals.length)
+      .map((r) => ({ experiment: r.name, new: r.newEvals, changed: r.changedEvals }));
+    console.log(JSON.stringify({ totalRun, work }, null, 2));
+    return { rows, totalRun };
+  }
+
+  console.log('');
+  if (allNew.size > 0 || allChanged.size > 0) {
+    console.log(chalk.bold('Evals needing work:'));
+    for (const e of [...allNew].sort()) console.log(`  ${chalk.green('new')}      ${e}`);
+    for (const e of [...allChanged].sort()) console.log(`  ${chalk.yellow('changed')}  ${e}`);
+    console.log('');
+  }
+
+  if (totalRun === 0) {
+    console.log(chalk.green('Everything up to date — nothing to run.\n'));
+    return { rows, totalRun: 0 };
+  }
+
+  const nameWidth = Math.max(...rows.map((r) => r.name.length)) + 2;
+  console.log(chalk.bold(`Work to do — ${totalRun} run(s) across ${rows.filter((r) => r.newEvals.length + r.changedEvals.length).length} experiment(s):`));
+  for (const r of rows) {
+    const n = r.newEvals.length + r.changedEvals.length;
+    if (n === 0) continue;
+    const extra = r.cached ? chalk.gray(`  (${r.cached} up to date)`) : '';
+    console.log(`  ${r.name.padEnd(nameWidth)}${chalk.yellow(`${n} to run`)}${extra}`);
+  }
+  console.log('');
+  console.log(chalk.gray('Run:  agent-eval run <experiment...>   (or run `agent-eval` to pick interactively)'));
+  console.log('');
+
+  if (options.check) {
+    console.log(chalk.red(`✗ ${totalRun} eval-run(s) outstanding.`));
+    process.exitCode = 1;
+  }
+  return { rows, totalRun };
+}
+
+/**
+ * Refingerprint handler: carry forward CONFIG-only changes in existing results so
+ * benign edits (e.g. a timeout bump) don't trigger reruns — WITHOUT masking real
+ * eval changes. For each committed result we compare the eval's current content
+ * fingerprint to the one the result was produced with:
+ *
+ *   - content unchanged → re-stamp the combined fingerprint (carry the config change)
+ *   - content changed    → leave it stale (an honest "this eval changed, rerun me")
+ *   - legacy result (no stored content fingerprint) → adopt the current content
+ *     fingerprint only if the result is already fully current; otherwise leave stale
+ *
+ * This replaces the old consumer-side `updateFingerprints`, which re-stamped every
+ * result unconditionally and so silently hid eval changes.
+ */
+async function carryForwardConfigChanges(
+  experimentsDir: string,
+  evalsDir: string,
+  resultsDir: string,
+  selectedFiles: string[],
+  dry = false
+): Promise<{ carried: number; stale: number }> {
+  let carried = 0;
+  let stale = 0;
+  for (const file of selectedFiles) {
+    let config;
+    try {
+      config = await loadConfig(resolve(experimentsDir, file));
+    } catch {
+      continue;
+    }
+    const baseName = file.replace(/\.ts$/, '');
+    const models = Array.isArray(config.model) ? config.model : [config.model];
+    for (const model of models) {
+      const experimentName = models.length > 1 ? `${baseName}/${model}` : baseName;
+      const modelConfig = { ...config, model };
+      const expResultsDir = join(resultsDir, experimentName);
+      if (!existsSync(expResultsDir)) continue;
+      for (const timestamp of readdirSync(expResultsDir)) {
+        const tsDir = join(expResultsDir, timestamp);
+        if (!statSync(tsDir).isDirectory()) continue;
+        for (const evalName of readdirSync(tsDir)) {
+          const summaryPath = join(tsDir, evalName, 'summary.json');
+          const evalPath = join(evalsDir, evalName);
+          if (!existsSync(summaryPath) || !existsSync(evalPath)) continue;
+          const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+          const decision = decideRefingerprint(
+            { fingerprint: summary.fingerprint, contentFingerprint: summary.contentFingerprint },
+            {
+              fingerprint: computeFingerprint(evalPath, modelConfig as never),
+              contentFingerprint: computeContentFingerprint(evalPath),
+            }
+          );
+          let changed = false;
+          if (decision.fingerprint !== undefined) {
+            summary.fingerprint = decision.fingerprint;
+            changed = true;
+          }
+          if (decision.contentFingerprint !== undefined) {
+            summary.contentFingerprint = decision.contentFingerprint;
+            changed = true;
+          }
+          if (decision.stale) stale++;
+          if (changed) {
+            carried++;
+            if (!dry) writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+          }
+        }
+      }
+    }
+  }
+  return { carried, stale };
+}
+
+async function refingerprintCommand(experimentArgs: string[], options: { dry?: boolean }) {
+  const { experimentsDir, evalsDir, resultsDir } = resolveProjectDirs();
+  const selectedFiles = selectExperimentFiles(experimentsDir, experimentArgs);
+  const { carried, stale } = await carryForwardConfigChanges(experimentsDir, evalsDir, resultsDir, selectedFiles, options.dry);
+  const verb = options.dry ? 'would carry forward' : 'carried forward';
+  console.log(chalk.green(`Refingerprint: ${verb} ${carried} config-only result(s).`));
+  if (stale > 0) {
+    console.log(chalk.yellow(`${stale} result(s) have a changed eval and were left stale — run them to refresh.`));
+  }
+}
+
+/** Run the chosen experiments: carry config-only changes forward, then run their
+ * new/changed evals (reuse handles the rest). Selection is explicit — there is no
+ * "run everything." */
+async function runSelected(
+  experimentArgs: string[],
+  options: { force?: boolean; smoke?: boolean; ackFailures?: boolean }
+): Promise<void> {
+  const { experimentsDir, evalsDir, resultsDir } = resolveProjectDirs();
+  const files = selectExperimentFiles(experimentsDir, experimentArgs);
+  if (files.length === 0) {
+    console.error(chalk.red(`No experiments matched: ${experimentArgs.join(', ')}`));
+    process.exit(1);
+  }
+  // Carry config-only changes forward first so a config edit (e.g. pinning a judge)
+  // doesn't make every eval look changed.
+  await carryForwardConfigChanges(experimentsDir, evalsDir, resultsDir, files);
+  await runAllCommand(experimentArgs, options);
+}
+
+/** Read one line from the user (interactive multi-select uses this). */
+function promptLine(question: string): Promise<string> {
+  return new Promise((res) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (ans) => {
+      rl.close();
+      res(ans.trim());
+    });
+  });
+}
+
+/** Numbered multi-select over experiment names. Returns the picked names. */
+async function pickExperiments(choices: string[]): Promise<string[]> {
+  console.log(chalk.bold('Pick experiments to run:'));
+  choices.forEach((c, i) => console.log(`  ${chalk.cyan(String(i + 1).padStart(2))}  ${c}`));
+  const ans = await promptLine(chalk.bold('\nNumbers (e.g. 1,3), "all", or Enter to skip: '));
+  if (!ans) return [];
+  if (ans.toLowerCase() === 'all') return choices;
+  const picked = new Set<string>();
+  for (const tok of ans.split(/[\s,]+/)) {
+    const n = Number(tok);
+    if (Number.isInteger(n) && n >= 1 && n <= choices.length) picked.add(choices[n - 1]);
+  }
+  return [...picked];
+}
+
 program
-  .command('run-all')
-  .description('Discover and run all experiments with fingerprint reuse and classification')
-  .argument('[experiments...]', 'Experiment names or glob patterns (default: all)')
-  .option('--dry', 'Preview what would run without executing')
+  .command('run')
+  .description('Run new/changed evals for the named experiment(s). You must name what to run')
+  .argument('<experiments...>', 'Experiment names or glob patterns')
   .option('--force', 'Ignore fingerprints, re-run everything')
   .option('--smoke', 'Run 1 eval per experiment for sanity checking')
   .option('--ack-failures', 'Keep non-model failures (infra/timeout) as final results instead of deleting them')
-  .action(runAllCommand);
+  .action(runSelected);
+
+program
+  .command('status')
+  .description('Show new/changed evals and the work to do, per experiment. Read-only')
+  .argument('[experiments...]', 'Experiment names or glob patterns (default: all)')
+  .option('--check', 'Exit non-zero if any new/changed eval is outstanding (for CI)')
+  .option('--json', 'Machine-readable output (for custom CI policy / ignore lists)')
+  .action(async (experimentArgs, options) => {
+    await statusCommand(experimentArgs, options);
+  });
+
+program
+  .command('refingerprint')
+  .description('(internal) Carry config-only changes forward in cached results; run by sync')
+  .argument('[experiments...]', 'Experiment names or glob patterns (default: all)')
+  .option('--dry', 'Preview without writing')
+  .action(refingerprintCommand);
 
 /**
- * Default command - run a single experiment, or run-all if no args given.
- * Usage:
- *   agent-eval           # runs all experiments (same as run-all)
- *   agent-eval cc        # runs single experiment
- *   agent-eval cc --dry  # preview single experiment
+ * Default command (bare `agent-eval`): show status, then — in a terminal — let the
+ * user multi-select which experiments to run. Never auto-runs everything. A config
+ * path/name still runs that single experiment (back-compat).
  */
 program
-  .argument('[config]', 'Experiment name (e.g., "cc") or path. Omit to run all experiments.')
-  .option('--dry', 'Preview what would run without executing')
+  .argument('[config]', 'Experiment name or path to run directly. Omit to show status + pick.')
+  .option('--dry', 'Preview a single experiment without executing')
   .option('--smoke', 'Run a single eval to verify setup (API keys, model IDs, sandbox)')
-  .option('--force', 'Ignore fingerprints, re-run everything (only applies when running all)')
+  .option('--force', 'Ignore fingerprints, re-run everything')
   .option('--ack-failures', 'Keep non-model failures (infra/timeout) as final results instead of deleting them')
   .action(async (configInput: string | undefined, options: { dry?: boolean; smoke?: boolean; force?: boolean; ackFailures?: boolean }) => {
-    if (!configInput) {
-      await runAllCommand([], options);
+    if (configInput) {
+      await runExperimentCommand(configInput, options);
       return;
     }
-    await runExperimentCommand(configInput, options);
+    const plan = await statusCommand([]);
+    if (plan.totalRun === 0) return;
+    if (!process.stdin.isTTY || !process.stdout.isTTY) return; // non-interactive (CI): status only
+    const choices = [...new Set(plan.rows.filter((r) => r.newEvals.length + r.changedEvals.length > 0).map((r) => r.baseName))];
+    const selected = await pickExperiments(choices);
+    if (selected.length === 0) {
+      console.log(chalk.gray('Nothing selected — run `agent-eval run <experiment...>` anytime.\n'));
+      return;
+    }
+    await runSelected(selected, options);
   });
 
 program.parse();

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
-import { computeFingerprint } from './fingerprint.js';
+import { computeFingerprint, computeContentFingerprint, decideRefingerprint } from './fingerprint.js';
 import type { RunnableExperimentConfig } from './types.js';
 
 const TEST_DIR = '/tmp/eval-framework-fingerprint-test';
@@ -241,5 +241,84 @@ describe('computeFingerprint', () => {
 
     expect(opus).not.toBe(sonnet); // different judge model
     expect(opus).not.toBe(opusGateway); // different judge agent
+  });
+});
+
+describe('computeContentFingerprint', () => {
+  beforeEach(() => mkdirSync(TEST_DIR, { recursive: true }));
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+  });
+
+  it('is stable for the same eval files and changes when a file changes', () => {
+    const evalDir = createEvalDir('content-1', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'v1',
+      'package.json': '{"type":"module"}',
+    });
+
+    const a = computeContentFingerprint(evalDir);
+    expect(computeContentFingerprint(evalDir)).toBe(a);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+
+    writeFileSync(join(evalDir, 'EVAL.ts'), 'v2');
+    expect(computeContentFingerprint(evalDir)).not.toBe(a);
+  });
+
+  it('is NOT affected by config — a timeout bump leaves the content fingerprint unchanged', () => {
+    const evalDir = createEvalDir('content-2', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'v1',
+      'package.json': '{"type":"module"}',
+    });
+
+    // The combined fingerprint changes with timeout; the content one must not.
+    const contentBefore = computeContentFingerprint(evalDir);
+    const combinedA = computeFingerprint(evalDir, baseConfig);
+    const combinedB = computeFingerprint(evalDir, { ...baseConfig, timeout: 1200 });
+
+    expect(combinedA).not.toBe(combinedB); // config affects combined
+    expect(computeContentFingerprint(evalDir)).toBe(contentBefore); // ...but not content
+  });
+});
+
+describe('decideRefingerprint', () => {
+  it('carries forward a config-only change (content unchanged)', () => {
+    const d = decideRefingerprint(
+      { fingerprint: 'old-combined', contentFingerprint: 'C' },
+      { fingerprint: 'new-combined', contentFingerprint: 'C' }
+    );
+    expect(d).toEqual({ fingerprint: 'new-combined', stale: false });
+  });
+
+  it('is a no-op when nothing changed', () => {
+    const d = decideRefingerprint(
+      { fingerprint: 'same', contentFingerprint: 'C' },
+      { fingerprint: 'same', contentFingerprint: 'C' }
+    );
+    expect(d).toEqual({ stale: false });
+  });
+
+  it('leaves a changed eval STALE — never masks it', () => {
+    const d = decideRefingerprint(
+      { fingerprint: 'old-combined', contentFingerprint: 'C_old' },
+      { fingerprint: 'new-combined', contentFingerprint: 'C_new' }
+    );
+    expect(d).toEqual({ stale: true });
+    expect(d.fingerprint).toBeUndefined(); // not re-stamped
+  });
+
+  it('legacy result (no content fp): adopts content fp only when already fully current', () => {
+    const current = decideRefingerprint(
+      { fingerprint: 'X' },
+      { fingerprint: 'X', contentFingerprint: 'C' }
+    );
+    expect(current).toEqual({ contentFingerprint: 'C', stale: false });
+
+    const behind = decideRefingerprint(
+      { fingerprint: 'X_old' },
+      { fingerprint: 'X_new', contentFingerprint: 'C' }
+    );
+    expect(behind).toEqual({ stale: true });
   });
 });

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -51,21 +51,48 @@ function collectFiles(dir: string, basePath: string = ''): Array<{ relativePath:
 }
 
 /**
- * Compute a fingerprint for an (eval, config) pair.
- *
- * Hashes: all eval directory files + config fields that affect results.
- * Returns a hex SHA-256 digest.
+ * Hash every eval-directory file into the given hash, in deterministic order.
+ * Shared by {@link computeContentFingerprint} and {@link computeFingerprint} so
+ * the two stay in lockstep — the combined fingerprint's file bytes are byte-for-byte
+ * what the content fingerprint hashes, just with config appended.
  */
-export function computeFingerprint(evalPath: string, config: RunnableExperimentConfig): string {
-  const hash = createHash('sha256');
-
-  // Hash all files in the eval directory (sorted for determinism)
+function hashEvalFiles(hash: ReturnType<typeof createHash>, evalPath: string): void {
   const files = collectFiles(evalPath);
   for (const file of files) {
     hash.update(`file:${file.relativePath}\n`);
     hash.update(file.content);
     hash.update('\0');
   }
+}
+
+/**
+ * Compute a fingerprint of ONLY the eval's files (no config).
+ *
+ * This is the "did the eval itself change" signal: it changes when an eval is
+ * edited or re-synced with different content, but NOT when a benign config field
+ * (e.g. timeout) is bumped. Result reuse/refingerprinting uses it to carry forward
+ * config-only changes without ever masking a real eval change. Hex SHA-256.
+ */
+export function computeContentFingerprint(evalPath: string): string {
+  const hash = createHash('sha256');
+  hashEvalFiles(hash, evalPath);
+  return hash.digest('hex');
+}
+
+/**
+ * Compute a fingerprint for an (eval, config) pair.
+ *
+ * Hashes: all eval directory files + config fields that affect results.
+ * Returns a hex SHA-256 digest. The file-hashing is identical to
+ * {@link computeContentFingerprint}; config is appended after, so this value is
+ * byte-for-byte unchanged from before the content/config split (existing cached
+ * fingerprints stay valid).
+ */
+export function computeFingerprint(evalPath: string, config: RunnableExperimentConfig): string {
+  const hash = createHash('sha256');
+
+  // Hash all files in the eval directory (sorted for determinism)
+  hashEvalFiles(hash, evalPath);
 
   // Hash config fields that affect results
   const configForHash: FingerprintableConfig = {
@@ -94,4 +121,43 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   hash.update(`config:${JSON.stringify(configForHash)}`);
 
   return hash.digest('hex');
+}
+
+/** What `refingerprint` should do to one cached result's summary. */
+export interface RefingerprintDecision {
+  /** New combined fingerprint to write, or undefined to leave as-is. */
+  fingerprint?: string;
+  /** New content fingerprint to write, or undefined to leave as-is. */
+  contentFingerprint?: string;
+  /** True when the eval content changed and the result was left stale (not re-stamped). */
+  stale: boolean;
+}
+
+/**
+ * Decide how to refingerprint one cached result — the content-aware replacement for
+ * the old "re-stamp everything" behavior. The whole point: carry forward benign
+ * config changes WITHOUT masking a real eval-content change.
+ *
+ *   - content unchanged → carry the new combined fingerprint (a config-only change)
+ *   - content changed    → leave it stale (don't touch); honest "this eval changed"
+ *   - legacy (no stored content fp) → adopt the current content fp only if the result
+ *     is already fully current; otherwise leave stale (we can't prove content matches)
+ */
+export function decideRefingerprint(
+  stored: { fingerprint?: string; contentFingerprint?: string },
+  current: { fingerprint: string; contentFingerprint: string }
+): RefingerprintDecision {
+  if (stored.contentFingerprint === undefined) {
+    if (stored.fingerprint === current.fingerprint) {
+      return { contentFingerprint: current.contentFingerprint, stale: false };
+    }
+    return { stale: true };
+  }
+  if (stored.contentFingerprint === current.contentFingerprint) {
+    if (stored.fingerprint !== current.fingerprint) {
+      return { fingerprint: current.fingerprint, stale: false };
+    }
+    return { stale: false };
+  }
+  return { stale: true };
 }

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -121,6 +121,10 @@ export interface SaveResultsOptions {
 	experimentName: string;
 	/** Per-eval fingerprints (eval name -> fingerprint hash) */
 	fingerprints?: Record<string, string>;
+	/** Per-eval content fingerprints (eval name -> eval-files-only hash). Lets
+	 * refingerprinting carry forward config-only changes without masking a real
+	 * eval change, and lets staleness be detected against the eval content alone. */
+	contentFingerprints?: Record<string, string>;
 	/** Per-eval validity flags (eval name -> valid). Defaults to true. */
 	validity?: Record<string, boolean>;
 	/** Whether this is a smoke test run. Smoke results are excluded from reuse. */
@@ -165,6 +169,7 @@ export function saveResults(
 
 		// Save summary (simplified format per design)
 		const fingerprint = options.fingerprints?.[evalSummary.name];
+		const contentFingerprint = options.contentFingerprints?.[evalSummary.name];
 		const valid = options.validity?.[evalSummary.name];
 		const summaryForFile: Record<string, unknown> = {
 			totalRuns: evalSummary.totalRuns,
@@ -174,6 +179,9 @@ export function saveResults(
 		};
 		if (fingerprint) {
 			summaryForFile.fingerprint = fingerprint;
+		}
+		if (contentFingerprint) {
+			summaryForFile.contentFingerprint = contentFingerprint;
 		}
 		if (valid === false) {
 			summaryForFile.valid = false;
@@ -476,7 +484,7 @@ export interface ReusableResult {
  * Scan existing results for an experiment to find reusable eval results.
  *
  * A result is reusable if:
- * 1. Its fingerprint matches the current fingerprint
+ * 1. Its fingerprint matches the current fingerprint (fresh)
  * 2. It is "valid" (not marked as invalid by the classifier)
  * 3. It has passedRuns > 0 (successful result worth reusing)
  *
@@ -526,7 +534,9 @@ export function scanReusableResults(
 			try {
 				const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
 
-				// Check fingerprint match
+				// Reuse only when fresh (fingerprint matches). A changed eval is left to
+				// re-run; "which staleness is acceptable" is the consumer's policy (via
+				// `agent-eval status --json` in CI), not the framework's.
 				if (summary.fingerprint !== expectedFingerprint) continue;
 
 				// Check validity (valid defaults to true if not explicitly set to false)

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -86,6 +86,8 @@ export interface RunExperimentOptions {
   experimentName: string;
   /** Per-eval fingerprints (eval name -> hash) for result reuse */
   fingerprints?: Record<string, string>;
+  /** Per-eval content fingerprints (eval name -> eval-files-only hash) */
+  contentFingerprints?: Record<string, string>;
   /** Callback for progress updates */
   onProgress?: (event: ProgressEvent) => void;
   /** Whether to run in verbose mode */
@@ -121,7 +123,7 @@ interface AttemptResult {
 export async function runExperiment(
   options: RunExperimentOptions
 ): Promise<ExperimentResults> {
-  const { config, fixtures, apiKey, resultsDir, experimentName, fingerprints, onProgress, smoke, rateLimiter } = options;
+  const { config, fixtures, apiKey, resultsDir, experimentName, fingerprints, contentFingerprints, onProgress, smoke, rateLimiter } = options;
   const startedAt = new Date();
 
   // Get the agent from registry
@@ -361,6 +363,7 @@ export async function runExperiment(
     resultsDir,
     experimentName,
     fingerprints,
+    contentFingerprints,
     smoke,
     fixturePaths,
   });


### PR DESCRIPTION
Adopting a changed or new eval shouldn't force re-running every model. This adds a small, explicit workflow for it and fixes the fingerprinting that made incremental adoption impossible.

**The problem.** Evals live in `vercel/next.js` and sync into next-evals-oss, which runs each experiment (model) and publishes nextjs.org/evals. When an eval changes, every experiment's cached result for it is stale. The previous re-fingerprinting silently re-stamped every result to the new eval, hiding the change — so you couldn't tell what needed re-running, and the "run everything stale" command made adoption all-or-nothing.

**The fix.** Each result now stores a content-only fingerprint (a hash of the eval files) next to the existing combined (content+config) one. A real eval-content change is never masked (it shows up as work and re-runs), while a benign config change (a `timeout` bump, or pinning a judge) is carried forward by `refingerprint` instead of re-running. Existing `fingerprint` values are byte-for-byte unchanged, so caches stay valid.

The commands:

- `agent-eval` (bare) — shows status, then in a terminal lets you multi-select which experiments to run. Never re-runs everything.
- `agent-eval status` — read-only: new vs changed evals, per experiment (classified by content). `--check` exits non-zero on any new/changed eval (a simple CI gate). `--json` emits per-experiment `new`/`changed`.
- `agent-eval run <experiments...>` — run the named experiments' new/changed evals (auto-carries config-only changes first).

`run-all` and `--dry` are removed in favor of explicit selection + `status`.

**No in-framework "keep"/"acknowledge".** The framework only reports staleness; *which* staleness is acceptable is the consumer's policy. A consumer that wants to leave some experiments on an older eval reads `agent-eval status --json` in CI and fails only on experiments outside its own accepted-stale list (see the companion next-evals-oss PR).

Tested with 242 unit tests + a CLI flow test (fresh → change → status/`--check`/`--json` flag it → `refingerprint` stays honest → a rerun clears it), and end-to-end against real next.js evals with a local build.

Stacked on #164.
