### PR TITLE
fix: codex transciprt fallback in runner

### DIFF
--- a/.changeset/codex-transcript-fallback.md
+++ b/.changeset/codex-transcript-fallback.md
@@ -1,0 +1,9 @@
+---
+'@vercel/agent-eval': patch
+---
+
+Fall back to the saved Codex session transcript when `codex exec --json` does not
+echo the full JSONL to stdout. The runner already read the session file under
+`~/.codex/sessions` to detect the observed model, but discarded it for result
+capture, so those runs recorded no transcript at all. `observedModel` now also
+falls back to the stdout transcript when the session file is missing.

--- a/packages/agent-eval/src/lib/agents/codex/run.mjs
+++ b/packages/agent-eval/src/lib/agents/codex/run.mjs
@@ -529,12 +529,14 @@ export async function runAgent(input) {
   const agentExitCode = res.status == null ? -1 : res.status;
 
   // Capture transcript + observed model regardless of success (the old adapter did
-  // this even on the non-zero-exit path). The inline --json on stdout is the
-  // transcript; observedModel comes from the saved session file under ~/.codex.
-  const transcript = extractTranscriptFromOutput(output) ?? null;
+  // this even on the non-zero-exit path). Prefer the inline --json stdout, but
+  // fall back to the saved session file under ~/.codex; newer Codex builds may
+  // write the session transcript there without echoing the full JSONL to stdout.
+  const stdoutTranscript = extractTranscriptFromOutput(output);
   const threadId = extractCodexThreadId(output);
   const sessionTranscript = captureCodexSessionTranscript(threadId);
-  const observedModel = extractObservedModelFromCodexSession(sessionTranscript) ?? null;
+  const transcript = stdoutTranscript ?? sessionTranscript ?? null;
+  const observedModel = extractObservedModelFromCodexSession(sessionTranscript ?? stdoutTranscript) ?? null;
 
   if (res.error || agentExitCode !== 0) {
     // Mirror the old error string: last 5 lines of output, else a coded fallback.


### PR DESCRIPTION
Fixes Codex eval runs losing transcript data when `codex exec --json` does not emit the full JSONL transcript on stdout.

The runner already reads the saved Codex session transcript from `~/.codex/sessions` to detect the observed model, but previously discarded that session transcript for result capture. This change falls back to the saved session transcript when stdout transcript extraction returns empty.