### PR TITLE
Add expect(transcript).toContainText() for deterministic transcript assertions

### DIFF
--- a/.changeset/transcript-to-contain-text.md
+++ b/.changeset/transcript-to-contain-text.md
@@ -1,0 +1,5 @@
+---
+'@vercel/agent-eval': minor
+---
+
+Add `expect(transcript).toContainText(needle)` — a deterministic, judge-free EVAL.ts matcher over the materialized transcript. Built for `.not` ("the agent never reached for X"): substring absence checks no longer need a judge run or manual `readFileSync(transcriptPath())`. Misuse (wrong subject, empty needle) and a missing/empty transcript throw instead of returning a failed verdict, so `.not` can never invert them into a silent pass.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ Two matchers, on either subject:
 - `toSatisfyCriterion(criterion)` — passes when the judge decides the criterion is satisfied.
 - `toScoreAtLeast(criterion, threshold)` — passes when the judge's 0–1 score is `>= threshold`.
 
+One deterministic matcher, on `transcript` only — no judge run, free and exact:
+
+- `toContainText(needle)` — passes when the raw transcript contains the substring. Built for `.not`, i.e. asserting the agent *never* said or reached for something:
+
+```typescript
+test('never suggested the pages router API', () => {
+  expect(transcript).not.toContainText('getServerSideProps');
+});
+```
+
+A missing or empty transcript **throws** (fails the test even under `.not`) — an uncaptured transcript is an infra failure, not evidence of absence. Note the transcript is the agent's native format (for `claude-code`, raw session JSONL), so text containing quotes or newlines appears JSON-escaped there; stick to identifier-like needles. For semantic "never did X" checks, phrase the negation *inside* a `toSatisfyCriterion` criterion instead — do not use `.not.toSatisfyCriterion(...)`, which would invert the judge's fail-closed default into a fail-open one.
+
 You supply only the **criterion** string; the framework owns the judge prompt and the verdict contract. On failure the assertion message carries the judge's reasoning, e.g. `[judge:environment] FAIL (score 0.42): product list is a Client Component`, so a failed judge clause is distinguishable from a failed deterministic test or a crash.
 
 By default the judge uses the **same agent and model** as the run under test (self-grading). Because each assertion is a real agent run, it costs time and tokens — keep criteria focused.

--- a/packages/agent-eval/src/lib/agents/eval-helper.mjs
+++ b/packages/agent-eval/src/lib/agents/eval-helper.mjs
@@ -11,6 +11,7 @@
  *     await expect(environment).toSatisfyCriterion('uses Server Components for the list');
  *     await expect(transcript).toSatisfyCriterion('diagnosed with DevTools, not guesswork');
  *     await expect(environment).toScoreAtLeast('code quality', 0.8);
+ *     expect(transcript).not.toContainText('getServerSideProps'); // deterministic, no judge
  *   });
  *
  * It is AGENTIC and reuses the SAME harness: each assertion re-invokes the codegen
@@ -221,6 +222,53 @@ expect.extend({
       pass,
       message: () =>
         `[judge:${subject}] score ${score} ${pass ? '>=' : '<'} ${threshold} — ${criterion}\n  reason: ${v.reason}`,
+    };
+  },
+
+  /**
+   * Deterministic transcript assertion — reads the materialized transcript and
+   * checks for an exact substring. No judge run, so it is free and exact; built
+   * for `.not` ("the agent never reached for X"):
+   *
+   *   expect(transcript).not.toContainText('getServerSideProps');
+   *
+   * Misuse and a missing/empty transcript THROW instead of returning pass:false —
+   * a returned failure would invert into a silent pass under `.not`, and an
+   * uncaptured transcript is an infra failure, not evidence of absence.
+   *
+   * The transcript is the agent's NATIVE format (e.g. claude-code = raw session
+   * JSONL), so text containing quotes/newlines appears JSON-escaped there; stick
+   * to identifier-like needles.
+   */
+  toContainText(received, needle) {
+    if (subjectOf(received) !== 'transcript') {
+      throw new Error('toContainText expects `transcript` from @vercel/agent-eval/eval');
+    }
+    if (typeof needle !== 'string' || needle.length === 0) {
+      throw new Error('toContainText expects a non-empty string to search for');
+    }
+    const text = existsSync(TRANSCRIPT_FILE) ? readFileSync(TRANSCRIPT_FILE, 'utf8') : '';
+    if (!text) {
+      throw new Error(
+        `toContainText: transcript at ${TRANSCRIPT_FILE} is missing or empty — ` +
+          'transcript capture failed, so nothing can be asserted about it'
+      );
+    }
+    const idx = text.indexOf(needle);
+    const pass = idx !== -1;
+    return {
+      pass,
+      message: () => {
+        if (pass) {
+          // Shown when `.not` fails: cite where the needle actually appears.
+          const start = Math.max(0, idx - 60);
+          const context = text
+            .slice(start, idx + needle.length + 60)
+            .replace(/\n/g, '\\n');
+          return `[transcript] expected NOT to contain ${JSON.stringify(needle)}, but found it at char ${idx}: …${context}…`;
+        }
+        return `[transcript] expected to contain ${JSON.stringify(needle)} (searched ${text.length} chars)`;
+      },
     };
   },
 });

--- a/packages/agent-eval/src/lib/agents/eval-helper.test.ts
+++ b/packages/agent-eval/src/lib/agents/eval-helper.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
-// Importing the helper registers the judge matchers on `expect` as a side effect
-// (harmless here); we only exercise the pure exports.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// Importing the helper registers the matchers on `expect` as a side effect; the
+// toContainText suite below relies on that, the rest exercises the pure exports.
 import {
   buildJudgePrompt,
   parseJudgeVerdict,
@@ -8,6 +11,15 @@ import {
   environment,
   transcript,
 } from './eval-helper.mjs';
+
+// The helper ships as plain .mjs (no types), so declare the matcher for this file.
+// The type parameter must match vitest's own `Assertion<T = any>` declaration.
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface Assertion<T = any> {
+    toContainText(needle: string): T;
+  }
+}
 
 describe('buildJudgePrompt', () => {
   it('environment variant: explores cwd, embeds criterion + verdict path + contract', () => {
@@ -77,5 +89,83 @@ describe('subjects', () => {
 
   it('transcriptPath() returns the canonical materialized path', () => {
     expect(transcriptPath()).toBe('__agent_eval__/transcript.txt');
+  });
+});
+
+describe('toContainText', () => {
+  // The matcher reads the transcript relative to cwd (as it does in-sandbox), so
+  // run each test from a temp dir holding a fixture transcript.
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), 'eval-helper-test-'));
+    process.chdir(dir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeTranscript(content: string) {
+    mkdirSync('__agent_eval__', { recursive: true });
+    writeFileSync(transcriptPath(), content);
+  }
+
+  it('passes when the transcript contains the substring', () => {
+    writeTranscript('the agent then added getServerSideProps to page.tsx');
+    expect(transcript).toContainText('getServerSideProps');
+  });
+
+  it('.not passes when the transcript does not contain the substring', () => {
+    writeTranscript('the agent used a Server Component');
+    expect(transcript).not.toContainText('getServerSideProps');
+  });
+
+  it('fails with the searched size when the substring is absent', () => {
+    writeTranscript('clean');
+    expect(() => expect(transcript).toContainText('getServerSideProps')).toThrowError(
+      /expected to contain "getServerSideProps" \(searched 5 chars\)/
+    );
+  });
+
+  it('.not failure cites where the needle appears', () => {
+    writeTranscript('line one\nthen getServerSideProps showed up\nline three');
+    expect(() => expect(transcript).not.toContainText('getServerSideProps')).toThrowError(
+      /expected NOT to contain "getServerSideProps", but found it at char 14: …line one\\nthen getServerSideProps showed up\\nline three…/
+    );
+  });
+
+  it('throws when the transcript file is missing — even under .not', () => {
+    // No vacuous pass: an uncaptured transcript must fail the assertion outright.
+    expect(() => expect(transcript).not.toContainText('anything')).toThrowError(
+      /transcript at __agent_eval__\/transcript\.txt is missing or empty/
+    );
+  });
+
+  it('throws when the transcript file is empty — even under .not', () => {
+    writeTranscript('');
+    expect(() => expect(transcript).not.toContainText('anything')).toThrowError(
+      /missing or empty/
+    );
+  });
+
+  it('throws on a non-transcript subject so .not cannot invert it into a pass', () => {
+    expect(() => expect(environment).toContainText('x')).toThrowError(
+      /toContainText expects `transcript`/
+    );
+    expect(() => expect(environment).not.toContainText('x')).toThrowError(
+      /toContainText expects `transcript`/
+    );
+  });
+
+  it('throws on an empty or non-string needle', () => {
+    writeTranscript('content');
+    expect(() => expect(transcript).toContainText('')).toThrowError(/non-empty string/);
+    expect(() =>
+      expect(transcript).toContainText(/regex/ as unknown as string)
+    ).toThrowError(/non-empty string/);
   });
 });


### PR DESCRIPTION
Asserting the agent never said or reached for something currently needs either a judge run (wasteful, and `.not.toSatisfyCriterion` would invert the judge's fail-closed default into fail-open) or a manual `readFileSync(transcriptPath())`. This adds a deterministic, judge-free matcher on the `transcript` sentinel:

```ts
expect(transcript).not.toContainText('getServerSideProps');
```

Misuse (wrong subject, empty needle) and a missing or empty transcript throw instead of returning `pass: false`, because a returned failure inverts into a silent pass under `.not`, and an uncaptured transcript is an infra failure rather than evidence of absence. A `.not` violation cites where the needle appears: `[transcript] expected NOT to contain "getServerSideProps", but found it at char 34: …context…`. The transcript is the agent's native format (`claude-code` writes raw session JSONL), so quotes and newlines appear JSON-escaped there; the README says to stick to identifier-like needles.