### PR TITLE
Add natural multi-turn simulated user interaction

### DIFF
--- a/.changeset/fuzzy-clouds-interact.md
+++ b/.changeset/fuzzy-clouds-interact.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add natural multi-turn simulated user interaction for capable registered agents, with a reusable completed-turn coordinator and persisted interaction history.

--- a/.changeset/tidy-apes-register.md
+++ b/.changeset/tidy-apes-register.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Allow experiment modules to register custom `Agent` implementations under arbitrary stable string IDs.

--- a/README.md
+++ b/README.md
@@ -344,11 +344,23 @@ import {
   type ExperimentConfig,
 } from '@vercel/agent-eval';
 
-const myAgent: Agent = {
+const definition = {
   name: 'my-agent',
   displayName: 'My Agent',
+  defaultModel: 'default-model',
+  o11yAgentName: 'claude-code',
+  runnerPath: '/path/to/run.mjs',
   getApiKeyEnvVar: () => 'MY_AGENT_API_KEY',
-  getDefaultModel: () => 'default-model',
+  install: () => [],
+  configFiles: () => [],
+  authEnv: () => ({}),
+} satisfies Agent['definition'];
+
+const myAgent: Agent = {
+  name: definition.name,
+  displayName: definition.displayName,
+  getApiKeyEnvVar: definition.getApiKeyEnvVar,
+  getDefaultModel: () => definition.defaultModel,
   run: async (fixturePath, options) => {
     // Invoke the agent and return an AgentRunResult.
     return {
@@ -357,6 +369,7 @@ const myAgent: Agent = {
       duration: 1000,
     };
   },
+  definition,
 };
 
 registerAgent(myAgent);
@@ -370,8 +383,9 @@ export default config;
 
 Agent IDs must be non-empty. A later registration with the same ID replaces the
 previous one, which allows shared registration modules to be evaluated by
-multiple experiment files. Custom agents may omit the built-in plugin
-`definition`; without one they cannot be selected as a pinned agentic judge.
+multiple experiment files. Registered agents conform to the complete `Agent`
+contract, including the definition used for installation, authentication,
+invocation, transcript parsing, and pinned judging.
 
 ### Multi-model experiments
 

--- a/README.md
+++ b/README.md
@@ -459,6 +459,78 @@ const config: ExperimentConfig = {
 Response-only fixtures still need `PROMPT.md` and `package.json`, but they do
 not need `EVAL.ts` or `EVAL.tsx`.
 
+## Simulated User Interaction
+
+Registered agents can opt into natural multi-turn interaction by declaring the
+`naturalMultiTurn` capability and consuming the interaction options passed to
+`Agent.run`. The exported `runNaturalInteraction` helper drives completed turns
+without introducing a separate event protocol:
+
+```typescript
+import {
+  registerAgent,
+  runNaturalInteraction,
+  type Agent,
+  type ExperimentConfig,
+} from '@vercel/agent-eval';
+
+const interactiveAgent: Agent = {
+  // ...the rest of the complete Agent implementation
+  capabilities: { naturalMultiTurn: true },
+
+  async run(fixturePath, options) {
+    const session = await harnessAgent.createSession();
+    try {
+      const { result, turns } = await runNaturalInteraction({
+        initialPrompt: options.prompt,
+        interaction: options.interaction,
+        fixture: options.fixture!,
+        runIndex: options.runIndex!,
+        // Reusing `session` here retains the harness's native conversation history.
+        generate: prompt => harnessAgent.generate({ session, prompt }),
+      });
+
+      return {
+        success: true,
+        output: result.text,
+        duration: 1000,
+        interaction: { turns },
+      };
+    } finally {
+      await session.destroy();
+    }
+  },
+};
+
+registerAgent(interactiveAgent);
+
+const config: ExperimentConfig = {
+  agent: interactiveAgent.name,
+  interaction: {                              // NEW
+    maxTurns: 2,
+    respond: async ({ turn, result }) => {
+      if (turn === 1) {
+        if (!/deployment region/i.test(result.text)) {
+          throw new Error('Expected a deployment-region question');
+        }
+        return 'Use iad1.';                    // start another user turn
+      }
+      return null;                             // conversation complete
+    },
+  },
+};
+```
+
+`respond` runs after each naturally completed assistant turn. Returning a string
+starts a new user turn in the same native session; returning `null` proceeds to
+validation. Errors and exceeding `maxTurns` fail the run. The full interaction
+history is saved in `result.json` and is available to capable agents for
+materialization into `__agent_eval__/results.json`.
+
+Built-in one-shot agents currently reject `interaction` clearly. This additive
+seam is intended for registered HarnessAgent-backed agents; no custom event or
+structured-tool protocol is introduced.
+
 ## A/B Testing
 
 The real power is comparing different approaches. Create multiple experiment configs:

--- a/README.md
+++ b/README.md
@@ -331,6 +331,48 @@ agent: 'gemini'       // requires GEMINI_API_KEY
 agent: 'cursor'       // requires CURSOR_API_KEY
 ```
 
+### Custom agents
+
+Register an implementation of the exported `Agent` interface before exporting
+an experiment config. Custom IDs are valid anywhere a built-in agent ID is
+accepted:
+
+```typescript
+import {
+  registerAgent,
+  type Agent,
+  type ExperimentConfig,
+} from '@vercel/agent-eval';
+
+const myAgent: Agent = {
+  name: 'my-agent',
+  displayName: 'My Agent',
+  getApiKeyEnvVar: () => 'MY_AGENT_API_KEY',
+  getDefaultModel: () => 'default-model',
+  run: async (fixturePath, options) => {
+    // Invoke the agent and return an AgentRunResult.
+    return {
+      success: true,
+      output: 'done',
+      duration: 1000,
+    };
+  },
+};
+
+registerAgent(myAgent);
+
+const config: ExperimentConfig = {
+  agent: 'my-agent',
+};
+
+export default config;
+```
+
+Agent IDs must be non-empty. A later registration with the same ID replaces the
+previous one, which allows shared registration modules to be evaluated by
+multiple experiment files. Custom agents may omit the built-in plugin
+`definition`; without one they cannot be selected as a pinned agentic judge.
+
 ### Multi-model experiments
 
 Provide an array of models to run the same experiment on each one. Results are stored under separate directories (`experiment-name/model-name`):

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -7,6 +7,7 @@
 // Re-export types
 export type {
   AgentType,
+  BuiltInAgentType,
   ModelTier,
   ModelPolicy,
   EvalFilter,

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -12,6 +12,10 @@ export type {
   ModelPolicy,
   EvalFilter,
   ValidationMode,
+  CompletedTurnResult,
+  InteractionConfig,
+  InteractionContext,
+  InteractionTurn,
   BrandConfig,
   Sandbox,
   SetupFunction,
@@ -80,6 +84,8 @@ export { DockerSandboxManager } from './lib/docker-sandbox.js';
 
 // Re-export agent utilities
 export type { AgentRunOptions, AgentRunResult } from './lib/agents/types.js';
+export type { RunNaturalInteractionOptions } from './lib/agents/interaction.js';
+export { runNaturalInteraction } from './lib/agents/interaction.js';
 
 // Re-export transcript context constants
 export { TRANSCRIPT_CONTEXT_DIR, TRANSCRIPT_CONTEXT_PATH } from './lib/agents/shared.js';

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -15,6 +15,8 @@ import { loadFixture, loadAllFixtures } from './lib/fixture.js';
 import { runSingleEval } from './lib/runner.js';
 import { loadConfig } from './lib/config.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
+import { registerAgent } from './lib/agents/index.js';
+import type { Agent } from './lib/agents/types.js';
 
 // Load .env file (try .env.local first, then .env)
 dotenvConfig({ path: '.env.local' });
@@ -62,6 +64,45 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
+  });
+
+  describe('custom agent registration', () => {
+    it('runs an eval through an agent registered under a custom ID', async () => {
+      const agent: Agent = {
+        name: 'integration-custom-agent',
+        displayName: 'Integration Custom Agent',
+        getApiKeyEnvVar: () => 'INTEGRATION_CUSTOM_AGENT_KEY',
+        getDefaultModel: () => 'custom-default',
+        run: async (_fixturePath, options) => ({
+          success: true,
+          output: `handled: ${options.prompt}`,
+          duration: 1,
+          testResult: { success: true, output: 'custom validation passed' },
+          scriptsResults: {},
+        }),
+      };
+      registerAgent(agent);
+
+      const fixtureDir = join(TEST_DIR, 'custom-agent-eval');
+      mkdirSync(fixtureDir, { recursive: true });
+      writeFileSync(join(fixtureDir, 'PROMPT.md'), 'Use the custom agent');
+      writeFileSync(join(fixtureDir, 'EVAL.ts'), '');
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'custom-agent-eval', type: 'module' })
+      );
+
+      const result = await runSingleEval(loadFixture(TEST_DIR, 'custom-agent-eval'), {
+        agent: agent.name,
+        model: 'custom-model',
+        timeout: 10,
+        apiKey: 'test-key',
+        scripts: [],
+      });
+
+      expect(result.result.status).toBe('passed');
+      expect(result.result.duration).toBeGreaterThan(0);
+    });
   });
 
   describe('project initialization', () => {

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -17,6 +17,7 @@ import { loadConfig } from './lib/config.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
 import { registerAgent } from './lib/agents/index.js';
 import type { Agent } from './lib/agents/types.js';
+import type { AgentDefinition } from './lib/agents/plugin/contract.js';
 
 // Load .env file (try .env.local first, then .env)
 dotenvConfig({ path: '.env.local' });
@@ -68,11 +69,22 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
 
   describe('custom agent registration', () => {
     it('runs an eval through an agent registered under a custom ID', async () => {
-      const agent: Agent = {
+      const definition: AgentDefinition = {
         name: 'integration-custom-agent',
         displayName: 'Integration Custom Agent',
+        defaultModel: 'custom-default',
+        o11yAgentName: 'claude-code',
+        runnerPath: '/custom/run.mjs',
         getApiKeyEnvVar: () => 'INTEGRATION_CUSTOM_AGENT_KEY',
-        getDefaultModel: () => 'custom-default',
+        install: () => [],
+        configFiles: () => [],
+        authEnv: () => ({}),
+      };
+      const agent: Agent = {
+        name: definition.name,
+        displayName: definition.displayName,
+        getApiKeyEnvVar: definition.getApiKeyEnvVar,
+        getDefaultModel: () => definition.defaultModel,
         run: async (_fixturePath, options) => ({
           success: true,
           output: `handled: ${options.prompt}`,
@@ -80,6 +92,7 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
           testResult: { success: true, output: 'custom validation passed' },
           scriptsResults: {},
         }),
+        definition,
       };
       registerAgent(agent);
 

--- a/packages/agent-eval/src/lib/agents/interaction.test.ts
+++ b/packages/agent-eval/src/lib/agents/interaction.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runNaturalInteraction } from './interaction.js';
+import type { EvalFixture } from '../types.js';
+
+const fixture: EvalFixture = {
+  name: 'deploy',
+  path: '/fixture',
+  prompt: 'Deploy this',
+  isModule: true,
+};
+
+describe('runNaturalInteraction', () => {
+  it('runs one turn when interaction is omitted', async () => {
+    const generate = vi.fn(async (prompt: string) => ({ text: `answer: ${prompt}` }));
+
+    const outcome = await runNaturalInteraction({
+      initialPrompt: fixture.prompt,
+      fixture,
+      runIndex: 0,
+      generate,
+    });
+
+    expect(generate).toHaveBeenCalledOnce();
+    expect(outcome.result.text).toBe('answer: Deploy this');
+    expect(outcome.turns).toHaveLength(1);
+  });
+
+  it('sends returned responses as new turns using the same generator', async () => {
+    const generate = vi
+      .fn<(prompt: string) => Promise<{ text: string }>>()
+      .mockResolvedValueOnce({ text: 'Which region?' })
+      .mockResolvedValueOnce({ text: 'Deployed to iad1.' });
+    const respond = vi.fn(async ({ turn }: { turn: number }) =>
+      turn === 1 ? 'Use iad1.' : null
+    );
+
+    const outcome = await runNaturalInteraction({
+      initialPrompt: fixture.prompt,
+      fixture,
+      runIndex: 2,
+      interaction: { maxTurns: 2, respond },
+      generate,
+    });
+
+    expect(generate).toHaveBeenNthCalledWith(1, 'Deploy this');
+    expect(generate).toHaveBeenNthCalledWith(2, 'Use iad1.');
+    expect(outcome.turns[0].userResponse).toBe('Use iad1.');
+    expect(outcome.result.text).toBe('Deployed to iad1.');
+  });
+
+  it('passes completed-turn history and run context to respond', async () => {
+    const respond = vi.fn(() => null);
+
+    await runNaturalInteraction({
+      initialPrompt: fixture.prompt,
+      fixture,
+      runIndex: 4,
+      interaction: { respond },
+      generate: async () => ({ text: 'done', native: true }),
+    });
+
+    expect(respond).toHaveBeenCalledWith({
+      turn: 1,
+      result: { text: 'done', native: true },
+      history: [{ turn: 1, result: { text: 'done', native: true } }],
+      fixture,
+      runIndex: 4,
+    });
+  });
+
+  it('fails instead of starting a turn beyond maxTurns', async () => {
+    const generate = vi.fn(async () => ({ text: 'more?' }));
+
+    await expect(
+      runNaturalInteraction({
+        initialPrompt: fixture.prompt,
+        fixture,
+        runIndex: 0,
+        interaction: { maxTurns: 1, respond: () => 'continue' },
+        generate,
+      })
+    ).rejects.toThrow('Interaction exceeded maxTurns (1).');
+    expect(generate).toHaveBeenCalledOnce();
+  });
+
+  it('rejects empty simulated user prompts', async () => {
+    await expect(
+      runNaturalInteraction({
+        initialPrompt: fixture.prompt,
+        fixture,
+        runIndex: 0,
+        interaction: { respond: () => '  ' },
+        generate: async () => ({ text: 'question' }),
+      })
+    ).rejects.toThrow('Interaction respond() must return a non-empty prompt or null.');
+  });
+});

--- a/packages/agent-eval/src/lib/agents/interaction.ts
+++ b/packages/agent-eval/src/lib/agents/interaction.ts
@@ -1,0 +1,59 @@
+import type {
+  CompletedTurnResult,
+  EvalFixture,
+  InteractionConfig,
+  InteractionTurn,
+} from '../types.js';
+
+export interface RunNaturalInteractionOptions<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  initialPrompt: string;
+  interaction?: InteractionConfig<TResult>;
+  fixture: EvalFixture;
+  runIndex: number;
+  generate(prompt: string): Promise<TResult>;
+}
+
+/**
+ * Drive natural completed assistant turns. The supplied `generate` function is
+ * responsible for retaining one native agent session across calls.
+ */
+export async function runNaturalInteraction<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+>(options: RunNaturalInteractionOptions<TResult>): Promise<{
+  result: TResult;
+  turns: InteractionTurn<TResult>[];
+}> {
+  const maxTurns = options.interaction?.maxTurns ?? 3;
+  const turns: InteractionTurn<TResult>[] = [];
+  let prompt = options.initialPrompt;
+
+  for (let turn = 1; turn <= maxTurns; turn++) {
+    const result = await options.generate(prompt);
+    const completed: InteractionTurn<TResult> = { turn, result };
+    turns.push(completed);
+
+    if (!options.interaction) return { result, turns };
+
+    const response = await options.interaction.respond({
+      turn,
+      result,
+      history: turns,
+      fixture: options.fixture,
+      runIndex: options.runIndex,
+    });
+    if (response === null) return { result, turns };
+    if (!response.trim()) {
+      throw new Error('Interaction respond() must return a non-empty prompt or null.');
+    }
+
+    completed.userResponse = response;
+    if (turn === maxTurns) {
+      throw new Error(`Interaction exceeded maxTurns (${maxTurns}).`);
+    }
+    prompt = response;
+  }
+
+  throw new Error(`Interaction exceeded maxTurns (${maxTurns}).`);
+}

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -118,13 +118,7 @@ export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptio
   }
 
   // Pinned to a DIFFERENT agent — resolve its definition + key + runner.
-  const judgeAgent = getAgent(spec.agent!);
-  const judgeDef = judgeAgent.definition;
-  if (!judgeDef) {
-    throw new Error(
-      `Agent "${spec.agent}" cannot be used as a pinned judge because it does not expose an agent definition.`
-    );
-  }
+  const judgeDef = getAgent(spec.agent!).definition;
   const judgeApiKey = resolveAgentApiKey(judgeDef.getApiKeyEnvVar) ?? '';
   const judgeOptions: AgentRunOptions = { ...options, model: spec.model, apiKey: judgeApiKey };
   return {

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -118,7 +118,13 @@ export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptio
   }
 
   // Pinned to a DIFFERENT agent — resolve its definition + key + runner.
-  const judgeDef = getAgent(spec.agent!).definition;
+  const judgeAgent = getAgent(spec.agent!);
+  const judgeDef = judgeAgent.definition;
+  if (!judgeDef) {
+    throw new Error(
+      `Agent "${spec.agent}" cannot be used as a pinned judge because it does not expose an agent definition.`
+    );
+  }
   const judgeApiKey = resolveAgentApiKey(judgeDef.getApiKeyEnvVar) ?? '';
   const judgeOptions: AgentRunOptions = { ...options, model: spec.model, apiKey: judgeApiKey };
   return {

--- a/packages/agent-eval/src/lib/agents/registry.test.ts
+++ b/packages/agent-eval/src/lib/agents/registry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { Agent } from './types.js';
+import { getAgent, hasAgent, registerAgent } from './registry.js';
+
+function customAgent(name: string): Agent {
+  return {
+    name,
+    displayName: name,
+    getApiKeyEnvVar: () => 'CUSTOM_API_KEY',
+    getDefaultModel: () => 'custom-default',
+    run: async () => ({ success: true, output: '', duration: 0 }),
+  };
+}
+
+describe('agent registry', () => {
+  it('registers a custom one-shot agent without requiring a plugin definition', () => {
+    const agent = customAgent('registry-test-custom');
+
+    registerAgent(agent);
+
+    expect(hasAgent(agent.name)).toBe(true);
+    expect(getAgent(agent.name)).toBe(agent);
+  });
+
+  it('allows a registration to be refreshed under the same stable name', () => {
+    const replacement = customAgent('registry-test-replacement');
+
+    registerAgent(customAgent('registry-test-replacement'));
+    registerAgent(replacement);
+
+    expect(getAgent(replacement.name)).toBe(replacement);
+  });
+
+  it('rejects empty names', () => {
+    expect(() => registerAgent(customAgent(''))).toThrow(
+      'Agent name must be a non-empty string.'
+    );
+  });
+});

--- a/packages/agent-eval/src/lib/agents/registry.test.ts
+++ b/packages/agent-eval/src/lib/agents/registry.test.ts
@@ -1,25 +1,43 @@
 import { describe, expect, it } from 'vitest';
 import type { Agent } from './types.js';
 import { getAgent, hasAgent, registerAgent } from './registry.js';
+import type { AgentDefinition } from './plugin/contract.js';
 
-function customAgent(name: string): Agent {
+function customDefinition(name: string): AgentDefinition {
   return {
     name,
     displayName: name,
+    defaultModel: 'custom-default',
+    o11yAgentName: 'claude-code',
+    runnerPath: '/custom/run.mjs',
     getApiKeyEnvVar: () => 'CUSTOM_API_KEY',
-    getDefaultModel: () => 'custom-default',
+    install: () => [],
+    configFiles: () => [],
+    authEnv: () => ({}),
+  };
+}
+
+function customAgent(name: string): Agent {
+  const definition = customDefinition(name);
+  return {
+    name,
+    displayName: name,
+    getApiKeyEnvVar: definition.getApiKeyEnvVar,
+    getDefaultModel: () => definition.defaultModel,
     run: async () => ({ success: true, output: '', duration: 0 }),
+    definition,
   };
 }
 
 describe('agent registry', () => {
-  it('registers a custom one-shot agent without requiring a plugin definition', () => {
+  it('registers a custom agent and preserves its required definition', () => {
     const agent = customAgent('registry-test-custom');
 
     registerAgent(agent);
 
     expect(hasAgent(agent.name)).toBe(true);
     expect(getAgent(agent.name)).toBe(agent);
+    expect(getAgent(agent.name).definition).toBe(agent.definition);
   });
 
   it('allows a registration to be refreshed under the same stable name', () => {

--- a/packages/agent-eval/src/lib/agents/registry.ts
+++ b/packages/agent-eval/src/lib/agents/registry.ts
@@ -11,6 +11,13 @@ const agents = new Map<string, Agent>();
  * Register an agent in the registry.
  */
 export function registerAgent(agent: Agent): void {
+  if (!agent.name.trim()) {
+    throw new Error('Agent name must be a non-empty string.');
+  }
+
+  // Preserve the registry's existing replacement behavior. This also makes
+  // shared registration modules safe when config loading evaluates them more
+  // than once (for example, across multiple experiment files).
   agents.set(agent.name, agent);
 }
 

--- a/packages/agent-eval/src/lib/agents/shared.test.ts
+++ b/packages/agent-eval/src/lib/agents/shared.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it, vi } from 'vitest';
-import { prepareNeutralWorkspace } from './shared.js';
+import { injectTranscriptContext, prepareNeutralWorkspace, TRANSCRIPT_CONTEXT_PATH } from './shared.js';
+
+describe('injectTranscriptContext', () => {
+  it('materializes natural interaction history for EVAL.ts assertions', async () => {
+    const writeFiles = vi.fn();
+    const turns = [{ turn: 1, result: { text: 'Which region?' }, userResponse: 'iad1' }];
+
+    await injectTranscriptContext(
+      { writeFiles } as never,
+      undefined,
+      'claude-code',
+      undefined,
+      turns
+    );
+
+    expect(writeFiles).toHaveBeenCalledWith({
+      [TRANSCRIPT_CONTEXT_PATH]: JSON.stringify(
+        { o11y: null, interaction: { turns } },
+        null,
+        2
+      ),
+    });
+  });
+});
 
 describe('prepareNeutralWorkspace', () => {
   it('copies Vercel sandboxes into /workspace and switches the working directory', async () => {

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -271,6 +271,7 @@ export async function injectTranscriptContext(
   rawTranscript: string | undefined,
   agentName: string,
   model?: string,
+  interaction?: import('../types.js').InteractionTurn[],
 ): Promise<void> {
   try {
     const transcript = rawTranscript
@@ -279,6 +280,7 @@ export async function injectTranscriptContext(
 
     const context = {
       o11y: transcript?.summary ?? null,
+      interaction: interaction ? { turns: interaction } : undefined,
     };
 
     await sandbox.writeFiles({

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -109,7 +109,8 @@ export interface Agent {
   /** Get the default model for this agent */
   getDefaultModel(): ModelTier;
 
-  /** The host-side definition (auth, runner path, install). Exposed so the
-   * orchestrator can resolve a DIFFERENT agent as the judge via the registry. */
-  definition: AgentDefinition;
+  /** The host-side definition (auth, runner path, install). Built-in plugin
+   * agents expose this so the orchestrator can use them as judges. Custom
+   * one-shot agents may omit it unless they support that integration. */
+  definition?: AgentDefinition;
 }

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -109,8 +109,7 @@ export interface Agent {
   /** Get the default model for this agent */
   getDefaultModel(): ModelTier;
 
-  /** The host-side definition (auth, runner path, install). Built-in plugin
-   * agents expose this so the orchestrator can use them as judges. Custom
-   * one-shot agents may omit it unless they support that integration. */
-  definition?: AgentDefinition;
+  /** The host-side definition (auth, runner path, install). Exposed so the
+   * orchestrator can resolve a DIFFERENT agent as the judge via the registry. */
+  definition: AgentDefinition;
 }

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -2,7 +2,17 @@
  * Agent interface and common types for all agents.
  */
 
-import type { JudgeConfig, ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
+import type {
+  InteractionConfig,
+  InteractionTurn,
+  JudgeConfig,
+  ModelPolicy,
+  ModelTier,
+  SetupFunction,
+  SandboxBackend,
+  ValidationMode,
+  EvalFixture,
+} from '../types.js';
 import type { AgentDefinition } from './plugin/contract.js';
 
 /**
@@ -21,6 +31,11 @@ export interface AgentRunOptions {
   apiKey: string;
   /** Optional setup function to run before agent */
   setup?: SetupFunction;
+  /** Natural completed-turn interaction controlled by this agent implementation. */
+  interaction?: InteractionConfig;
+  /** Context for interaction callbacks. Present when run through the experiment runner. */
+  fixture?: EvalFixture;
+  runIndex?: number;
   /** npm scripts to run after agent completes */
   scripts?: string[];
   /** Validation mode after agent completes */
@@ -88,6 +103,8 @@ export interface AgentRunResult {
   observedModel?: string;
   /** Codex only: model re-stated explicitly by the shell-tool repair (see RunnerResult.modelRepair) */
   modelRepair?: string;
+  /** Natural interaction history coordinated by the agent implementation. */
+  interaction?: { turns: InteractionTurn[] };
 }
 
 /**
@@ -99,6 +116,11 @@ export interface Agent {
 
   /** Human-readable display name */
   displayName: string;
+
+  /** Optional capabilities beyond the legacy one-shot contract. */
+  capabilities?: {
+    naturalMultiTurn?: boolean;
+  };
 
   /** Run the agent on a fixture */
   run(fixturePath: string, options: AgentRunOptions): Promise<AgentRunResult>;

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -7,6 +7,7 @@ import {
 } from './config.js';
 import { registerAgent } from './agents/index.js';
 import type { Agent } from './agents/types.js';
+import type { AgentDefinition } from './agents/plugin/contract.js';
 
 describe('validateConfig', () => {
   it('accepts valid minimal config', () => {
@@ -135,12 +136,24 @@ describe('resolveConfig', () => {
   });
 
   it('resolves an agent registered by an experiment module', () => {
-    const customAgent: Agent = {
+    const definition: AgentDefinition = {
       name: 'config-test-custom-agent',
       displayName: 'Config Test Custom Agent',
+      defaultModel: 'custom-default',
+      o11yAgentName: 'claude-code',
+      runnerPath: '/custom/run.mjs',
       getApiKeyEnvVar: () => 'CUSTOM_AGENT_API_KEY',
-      getDefaultModel: () => 'custom-default',
+      install: () => [],
+      configFiles: () => [],
+      authEnv: () => ({}),
+    };
+    const customAgent: Agent = {
+      name: definition.name,
+      displayName: definition.displayName,
+      getApiKeyEnvVar: definition.getApiKeyEnvVar,
+      getDefaultModel: () => definition.defaultModel,
       run: async () => ({ success: true, output: '', duration: 0 }),
+      definition,
     };
     registerAgent(customAgent);
 

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -5,6 +5,8 @@ import {
   resolveEvalNames,
   CONFIG_DEFAULTS,
 } from './config.js';
+import { registerAgent } from './agents/index.js';
+import type { Agent } from './agents/types.js';
 
 describe('validateConfig', () => {
   it('accepts valid minimal config', () => {
@@ -51,8 +53,13 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
-  it('rejects invalid agent', () => {
-    const config = { agent: 'invalid-agent' };
+  it('accepts a custom agent identifier for registry resolution', () => {
+    const config = { agent: 'my-custom-agent' };
+    expect(validateConfig(config).agent).toBe('my-custom-agent');
+  });
+
+  it('rejects an empty agent identifier', () => {
+    const config = { agent: '' };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
 
@@ -125,6 +132,25 @@ describe('resolveConfig', () => {
     expect(resolved.modelPolicy).toBe('agent-default');
     expect(resolved.runs).toBe(10);
     expect(resolved.earlyExit).toBe(false);
+  });
+
+  it('resolves an agent registered by an experiment module', () => {
+    const customAgent: Agent = {
+      name: 'config-test-custom-agent',
+      displayName: 'Config Test Custom Agent',
+      getApiKeyEnvVar: () => 'CUSTOM_AGENT_API_KEY',
+      getDefaultModel: () => 'custom-default',
+      run: async () => ({ success: true, output: '', duration: 0 }),
+    };
+    registerAgent(customAgent);
+
+    expect(resolveConfig({ agent: customAgent.name }).agent).toBe(customAgent.name);
+  });
+
+  it('rejects an unregistered custom agent during resolution', () => {
+    expect(() => resolveConfig({ agent: 'unregistered-config-test-agent' })).toThrow(
+      'Unknown agent: unregistered-config-test-agent'
+    );
   });
 
   it('passes webResearch through and leaves it undefined by default', () => {

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -38,6 +38,19 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
+  it('accepts natural interaction config', () => {
+    const interaction = { maxTurns: 2, respond: async () => null };
+    const validated = validateConfig({ agent: 'claude-code', interaction }).interaction;
+    expect(validated?.maxTurns).toBe(2);
+    expect(validated?.respond).toBeTypeOf('function');
+  });
+
+  it('rejects a non-positive interaction maxTurns', () => {
+    expect(() =>
+      validateConfig({ agent: 'claude-code', interaction: { maxTurns: 0, respond: () => null } })
+    ).toThrow('Invalid experiment configuration');
+  });
+
   it('accepts array of models', () => {
     const config = {
       agent: 'claude-code',
@@ -163,6 +176,14 @@ describe('resolveConfig', () => {
   it('rejects an unregistered custom agent during resolution', () => {
     expect(() => resolveConfig({ agent: 'unregistered-config-test-agent' })).toThrow(
       'Unknown agent: unregistered-config-test-agent'
+    );
+  });
+
+  it('passes interaction through and leaves it undefined by default', () => {
+    const interaction = { maxTurns: 2, respond: async () => null };
+    expect(resolveConfig({ agent: 'claude-code' as const }).interaction).toBeUndefined();
+    expect(resolveConfig({ agent: 'claude-code' as const, interaction }).interaction).toBe(
+      interaction
     );
   });
 

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -30,15 +30,9 @@ export const CONFIG_DEFAULTS = {
  * Zod schema for validating experiment configuration.
  */
 const experimentConfigSchema = z.object({
-  agent: z.enum([
-    'vercel-ai-gateway/claude-code',
-    'claude-code',
-    'vercel-ai-gateway/codex',
-    'codex',
-    'vercel-ai-gateway/opencode',
-    'gemini',
-    'cursor',
-  ]),
+  // Agent modules may register custom implementations while the experiment
+  // config is being imported. Registry membership is checked in resolveConfig.
+  agent: z.string().min(1),
   model: z.union([z.string(), z.array(z.string())]).optional(),
   evals: z
     .union([z.string(), z.array(z.string()), z.function().args(z.string()).returns(z.boolean())])

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -44,6 +44,12 @@ const experimentConfigSchema = z.object({
   timeout: z.number().positive().optional(),
   setup: z.function().optional(),
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
+  interaction: z
+    .object({
+      maxTurns: z.number().int().positive().optional(),
+      respond: z.function(),
+    })
+    .optional(),
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
   copyFiles: z.enum(['none', 'changed', 'all']).optional(),
   agentOptions: z.record(z.unknown()).optional(),
@@ -118,6 +124,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     timeout: config.timeout ?? CONFIG_DEFAULTS.timeout,
     setup: config.setup,
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
+    interaction: config.interaction,
     editPrompt: config.editPrompt,
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
     agentOptions: config.agentOptions,

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -67,6 +67,22 @@ describe('computeFingerprint', () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it('changes when natural interaction is configured', () => {
+    const evalDir = createEvalDir('eval-interaction', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, {
+      ...baseConfig,
+      interaction: { maxTurns: 2, respond: () => null },
+    });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
   it('changes when config model changes', () => {
     const evalDir = createEvalDir('eval-3', {
       'PROMPT.md': 'Do something',

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -24,6 +24,7 @@ interface FingerprintableConfig {
   runs: number;
   webResearch?: boolean;
   judge?: { agent?: string; model: string };
+  interaction?: { maxTurns: number };
 }
 
 /**
@@ -117,6 +118,9 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   // unchanged. Changing the judge agent/model invalidates the cache → re-runs.
   if (config.judge) {
     configForHash.judge = { agent: config.judge.agent, model: config.judge.model };
+  }
+  if (config.interaction) {
+    configForHash.interaction = { maxTurns: config.interaction.maxTurns ?? 3 };
   }
   hash.update(`config:${JSON.stringify(configForHash)}`);
 

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -67,6 +67,22 @@ describe('results utilities', () => {
       expect(runData.result.modelRepair).toBe('gpt-5.6-sol');
     });
 
+    it('preserves natural interaction history', () => {
+      const turns = [
+        { turn: 1, result: { text: 'Which region?' }, userResponse: 'Use iad1.' },
+        { turn: 2, result: { text: 'Done.' } },
+      ];
+      const runData = agentResultToEvalRunData({
+        success: true,
+        output: 'Done.',
+        duration: 100,
+        interaction: { turns },
+      });
+
+      expect(runData.interaction).toEqual({ turns });
+      expect(runData.result.interaction).toEqual({ turns });
+    });
+
     it('converts failed agent result', () => {
       const agentResult: AgentRunResult = {
         success: false,

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -65,6 +65,9 @@ export function agentResultToEvalRunData(
 	if (agentResult.modelRepair) {
 		result.modelRepair = agentResult.modelRepair;
 	}
+	if (agentResult.interaction) {
+		result.interaction = agentResult.interaction;
+	}
 
 	return {
 		result,
@@ -73,6 +76,7 @@ export function agentResultToEvalRunData(
 			Object.keys(outputContent).length > 0 ? outputContent : undefined,
 		generatedFiles: agentResult.generatedFiles,
 		deletedFiles: agentResult.deletedFiles,
+		interaction: agentResult.interaction,
 	};
 }
 

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -550,6 +550,9 @@ describe('runExperiment', () => {
         timeout: 600000, // Should be converted to milliseconds
         apiKey: 'my-api-key',
         setup: mockSetup,
+        interaction: undefined,
+        fixture: fixtures[0],
+        runIndex: 0,
         scripts: ['build', 'lint'],
         validation: undefined,
         signal: expect.any(AbortSignal), // Signal always passed for timeout cleanup
@@ -557,6 +560,82 @@ describe('runExperiment', () => {
         agentOptions: undefined,
         webResearch: undefined,
       });
+    });
+
+    it('fails clearly when interaction is configured for a one-shot agent', async () => {
+      const mockAgent = {
+        name: 'one-shot-agent',
+        displayName: 'One-shot Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn(),
+      } as unknown as Agent;
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+
+      const results = await runExperiment({
+        config: {
+          agent: 'one-shot-agent',
+          model: 'model',
+          evals: '*',
+          runs: 1,
+          earlyExit: false,
+          scripts: [],
+          timeout: 600,
+          interaction: { respond: () => null },
+        },
+        fixtures: [{
+          name: 'test-eval',
+          path: '/fake/path',
+          prompt: 'prompt',
+          isModule: true,
+        }],
+        apiKey: 'key',
+        resultsDir: TEST_DIR,
+        experimentName: 'interaction-unsupported',
+      });
+
+      expect(mockAgent.run).not.toHaveBeenCalled();
+      expect(results.evals[0].runs[0].result.error).toContain(
+        'does not support natural multi-turn interaction'
+      );
+    });
+
+    it('forwards interaction and run context to a capable agent', async () => {
+      const run = vi.fn().mockResolvedValue({ success: true, output: 'done', duration: 1 });
+      const mockAgent = {
+        name: 'multi-turn-agent',
+        displayName: 'Multi-turn Agent',
+        capabilities: { naturalMultiTurn: true },
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run,
+      } as unknown as Agent;
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+      const fixture = { name: 'test-eval', path: '/fake/path', prompt: 'prompt', isModule: true };
+      const interaction = { maxTurns: 2, respond: () => null };
+
+      await runExperiment({
+        config: {
+          agent: 'multi-turn-agent',
+          model: 'model',
+          evals: '*',
+          runs: 1,
+          earlyExit: false,
+          scripts: [],
+          timeout: 600,
+          interaction,
+        },
+        fixtures: [fixture],
+        apiKey: 'key',
+        resultsDir: TEST_DIR,
+        experimentName: 'interaction-supported',
+      });
+
+      expect(run).toHaveBeenCalledWith('/fake/path', expect.objectContaining({
+        interaction,
+        fixture,
+        runIndex: 0,
+      }));
     });
 
     it('forwards webResearch to agent.run when set', async () => {

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -181,6 +181,20 @@ export async function runExperiment(
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
+    if (config.interaction && !agent.capabilities?.naturalMultiTurn) {
+      return {
+        fixtureName: fixture.name,
+        runIndex,
+        runData: {
+          result: {
+            status: 'failed',
+            error: `Agent "${agent.name}" does not support natural multi-turn interaction.`,
+            duration: 0,
+          },
+        },
+      };
+    }
+
     const modelPolicy = config.modelPolicy ?? 'agent-default';
     const requestedModel = modelPolicy === 'native-default' ? undefined : config.model;
     const agentResult = await Promise.race([
@@ -191,6 +205,9 @@ export async function runExperiment(
         timeout: timeoutMs,
         apiKey,
         setup: config.setup,
+        interaction: config.interaction,
+        fixture,
+        runIndex,
         scripts: config.scripts,
         validation: config.validation,
         signal: attemptController.signal,
@@ -279,7 +296,8 @@ export async function runExperiment(
         !result.aborted &&
         result.runData.result.status === 'failed' &&
         result.runData.result.duration < ANOMALY_THRESHOLD_S &&
-        !result.runData.result.error?.includes('timed out');
+        !result.runData.result.error?.includes('timed out') &&
+        !result.runData.result.error?.includes('does not support natural multi-turn interaction');
 
       if (!isSuspiciouslyFast || retry >= MAX_RETRIES) {
         return result;
@@ -385,6 +403,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     timeout: number;
     apiKey: string;
     setup?: ResolvedExperimentConfig['setup'];
+    interaction?: ResolvedExperimentConfig['interaction'];
     scripts?: string[];
     validation?: ResolvedExperimentConfig['validation'];
     sandbox?: ResolvedExperimentConfig['sandbox'];
@@ -396,6 +415,9 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
+  if (options.interaction && !agent.capabilities?.naturalMultiTurn) {
+    throw new Error(`Agent "${agent.name}" does not support natural multi-turn interaction.`);
+  }
 
   const models: string[] = Array.isArray(options.model) ? options.model : [options.model];
   const prompt = options.editPrompt ? options.editPrompt(fixture.prompt) : fixture.prompt;
@@ -411,6 +433,9 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		timeout: options.timeout * 1000,
 		apiKey: options.apiKey,
 		setup: options.setup,
+		interaction: options.interaction,
+		fixture,
+		runIndex: 0,
 		scripts: options.scripts,
 		validation: options.validation,
 		sandbox: options.sandbox,

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -43,6 +43,44 @@ export type EvalFilter = (name: string) => boolean;
 
 export type ValidationMode = 'vitest' | 'none';
 
+/** Minimal result shared by AI SDK and HarnessAgent completed turns. */
+export interface CompletedTurnResult {
+  text: string;
+  [key: string]: unknown;
+}
+
+export interface InteractionTurn<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  turn: number;
+  result: TResult;
+  userResponse?: string;
+}
+
+export interface InteractionContext<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  /** One-based number of the completed assistant turn. */
+  turn: number;
+  /** The completed generate result. The original object is passed through. */
+  result: TResult;
+  /** Previous completed turns plus the current turn. */
+  history: readonly InteractionTurn<TResult>[];
+  fixture: EvalFixture;
+  runIndex: number;
+}
+
+export interface InteractionConfig<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  /** Maximum assistant turns, including the initial turn. @default 3 */
+  maxTurns?: number;
+  /** Return the next user prompt, or null to finish and begin validation. */
+  respond(
+    context: InteractionContext<TResult>
+  ): string | null | Promise<string | null>;
+}
+
 export interface BrandConfig {
   id?: string;
   name: string;
@@ -147,6 +185,10 @@ export interface ExperimentConfig {
   /** Sandbox backend to use. @default 'auto' (Vercel if token present, else Docker) */
   sandbox?: SandboxBackend | 'auto';
 
+  /** Continue natural completed turns with simulated user responses. Registered
+   * agents opt into this by consuming `AgentRunOptions.interaction`. @default undefined */
+  interaction?: InteractionConfig;
+
   /** Optional function to modify the prompt before running the experiment. @default undefined */
   editPrompt?: (prompt: string) => string;
 
@@ -192,6 +234,7 @@ export interface ResolvedExperimentConfig {
   timeout: number;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
+  interaction?: InteractionConfig;
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
@@ -216,6 +259,7 @@ export interface RunnableExperimentConfig {
   timeout: number;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
+  interaction?: InteractionConfig;
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
@@ -287,6 +331,8 @@ export interface EvalRunResult {
   analysis?: Record<string, unknown>;
   /** Optional user-defined metadata attached by post-run hooks */
   metadata?: Record<string, unknown>;
+  /** Natural completed turns and simulated user responses. */
+  interaction?: { turns: InteractionTurn[] };
 }
 
 /**
@@ -308,6 +354,8 @@ export interface EvalRunData {
   generatedFiles?: Record<string, string>;
   /** Files deleted by the agent. Used for copyFiles option. */
   deletedFiles?: string[];
+  /** Natural completed turns and simulated user responses. */
+  interaction?: { turns: InteractionTurn[] };
 }
 
 /**

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -5,7 +5,7 @@
 /**
  * Supported AI agent types.
  */
-export type AgentType =
+export type BuiltInAgentType =
   | 'vercel-ai-gateway/claude-code'
   | 'claude-code'
   | 'vercel-ai-gateway/codex'
@@ -13,6 +13,12 @@ export type AgentType =
   | 'vercel-ai-gateway/opencode'
   | 'gemini'
   | 'cursor';
+
+/**
+ * An agent identifier. Built-in identifiers are suggested by TypeScript, while
+ * registered agents may use any non-empty string.
+ */
+export type AgentType = BuiltInAgentType | (string & {});
 
 /**
  * Model identifier - any string accepted.


### PR DESCRIPTION
## Summary

- add natural completed-turn simulated user interaction for capable registered agents
- provide `runNaturalInteraction` to coordinate repeated HarnessAgent `generate()` calls over one retained native session
- persist completed turns and simulated user responses with run results
- reject interaction configs clearly for legacy one-shot agents

## Dependency

Depends on #178. This branch contains #178's commits because GitHub cannot use a branch in the contributor fork as the base of an upstream PR. Once #178 merges, this PR's diff will reduce to only the interaction changes (after rebasing if needed).

## Example

```ts
const interactiveAgent: Agent = {
  // ...complete Agent implementation
  capabilities: { naturalMultiTurn: true },

  async run(fixturePath, options) {
    const session = await harnessAgent.createSession();
    try {
      const { result, turns } = await runNaturalInteraction({
        initialPrompt: options.prompt,
        interaction: options.interaction,
        fixture: options.fixture!,
        runIndex: options.runIndex!,
        generate: prompt => harnessAgent.generate({ session, prompt }),
      });

      return {
        success: true,
        output: result.text,
        duration: 1000,
        interaction: { turns },
      };
    } finally {
      await session.destroy();
    }
  },
};

const config: ExperimentConfig = {
  agent: interactiveAgent.name,
  interaction: {
    maxTurns: 2,
    respond: async ({ turn, result }) => {
      if (turn === 1) {
        if (!/deployment region/i.test(result.text)) {
          throw new Error('Expected a deployment-region question');
        }
        return 'Use iad1.';
      }
      return null;
    },
  },
};
```

## Semantics

- `respond` runs after a natural assistant turn completes.
- A string starts another user turn in the same native session.
- `null` completes the conversation and allows validation to proceed.
- Empty responses, callback errors, and exceeding `maxTurns` fail the run.
- No new event protocol or structured tool/approval API is introduced.
- Interaction configuration changes result fingerprints.

## Validation

- 96 targeted tests passing
- `npm run build`
- `npm run lint`
