### PR TITLE
Add reusable sandbox templates

### DIFF
--- a/.changeset/green-boxes-snapshot.md
+++ b/.changeset/green-boxes-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add reusable sandbox templates that snapshot expensive Vercel Sandbox preparation and clone an independent prepared environment for each eval attempt.

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ out/
 *.log
 .DS_Store
 coverage/
+.agent-eval/
 .vercel
 .env*.local

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ const config: ExperimentConfig = {
   // Expensive setup reused through immutable Vercel Sandbox snapshots
   sandboxTemplate: defineSandboxTemplate({
     key: 'dependencies-v1',
-    identity: ({ hashFiles }) => ({
-      dependencies: hashFiles(['package.json', 'package-lock.json']),
+    identity: ({ config }) => ({
+      frameworkVersion: config.agentOptions?.frameworkVersion ?? 'local',
     }),
     prepare: async ({ sandbox }) => {
       await sandbox.runCommand('npm', ['install']);
@@ -487,10 +487,10 @@ import {
 const dependencies = defineSandboxTemplate({
   key: 'dependencies-v1',
 
-  // Optional. The returned value defines when prepared states are equivalent.
-  // Without this callback, all agent-visible fixture files are hashed.
-  identity: ({ hashFiles }) => ({
-    dependencies: hashFiles(['package.json', 'package-lock.json']),
+  // Optional additional context, such as an external framework version.
+  // The complete agent-visible fixture is always hashed regardless.
+  identity: ({ config }) => ({
+    frameworkVersion: config.agentOptions?.frameworkVersion ?? 'local',
   }),
 
   prepare: async ({ sandbox }) => {
@@ -512,13 +512,17 @@ const config: ExperimentConfig = {
 export default config;
 ```
 
-The framework combines the returned identity with the template `key`, backend,
-runtime, and template format version. Change `key` whenever preparation logic
-changes in a way not represented by `identity`.
+The complete agent-visible fixture always participates in the snapshot identity.
+Fixtures that differ only in withheld `PROMPT.md` and `EVAL.ts` files therefore
+share prepared state naturally, while different starting projects never do.
+The optional `identity` callback only adds contextual inputs; it cannot collapse
+different visible fixtures into one snapshot.
 
-A custom identity is an assertion that equal values produce interchangeable
-prepared states. Templates currently require the Vercel sandbox backend; Docker
-fails explicitly rather than silently repeating preparation.
+The framework combines the fixture and additional identities with the template
+`key`, backend, runtime, and template format version. Change `key` whenever
+preparation logic changes in a way not otherwise represented. Templates currently
+require the Vercel sandbox backend; Docker fails explicitly rather than silently
+repeating preparation.
 
 ## A/B Testing
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,10 @@ const config: ExperimentConfig = {
 
 ```typescript
 // experiments/my-experiment.ts
-import type { ExperimentConfig } from '@vercel/agent-eval';
+import {
+  defineSandboxTemplate,
+  type ExperimentConfig,
+} from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
   // Required: which agent to use
@@ -270,7 +273,18 @@ const config: ExperimentConfig = {
   // evals: ['specific-eval'],
   // evals: (name) => name.startsWith('api-'),
 
-  // Setup function for sandbox pre-configuration
+  // Expensive setup reused through immutable Vercel Sandbox snapshots
+  sandboxTemplate: defineSandboxTemplate({
+    key: 'dependencies-v1',
+    identity: ({ hashFiles }) => ({
+      dependencies: hashFiles(['package.json', 'package-lock.json']),
+    }),
+    prepare: async ({ sandbox }) => {
+      await sandbox.runCommand('npm', ['install']);
+    },
+  }),
+
+  // Per-attempt sandbox setup (runs after cloning the prepared snapshot)
   setup: async (sandbox) => {
     await sandbox.writeFiles({ '.env': 'API_KEY=test' });
     await sandbox.runCommand('npm', ['run', 'setup']);
@@ -458,6 +472,53 @@ const config: ExperimentConfig = {
 
 Response-only fixtures still need `PROMPT.md` and `package.json`, but they do
 not need `EVAL.ts` or `EVAL.tsx`.
+
+## Reusable Sandbox Preparation
+
+Use `defineSandboxTemplate` to run expensive setup once and give every eval
+attempt an independent sandbox cloned from the prepared state:
+
+```typescript
+import {
+  defineSandboxTemplate,
+  type ExperimentConfig,
+} from '@vercel/agent-eval';
+
+const dependencies = defineSandboxTemplate({
+  key: 'dependencies-v1',
+
+  // Optional. The returned value defines when prepared states are equivalent.
+  // Without this callback, all agent-visible fixture files are hashed.
+  identity: ({ hashFiles }) => ({
+    dependencies: hashFiles(['package.json', 'package-lock.json']),
+  }),
+
+  prepare: async ({ sandbox }) => {
+    await sandbox.runCommand('npm', ['install']);
+  },
+});
+
+const config: ExperimentConfig = {
+  agent: 'vercel-ai-gateway/claude-code',
+  sandbox: 'vercel',
+  sandboxTemplate: dependencies,
+
+  // Existing per-attempt setup still runs for every independent clone.
+  setup: async sandbox => {
+    await sandbox.writeFiles({ '.env.local': 'FEATURE_FLAG=true' });
+  },
+};
+
+export default config;
+```
+
+The framework combines the returned identity with the template `key`, backend,
+runtime, and template format version. Change `key` whenever preparation logic
+changes in a way not represented by `identity`.
+
+A custom identity is an assertion that equal values produce interchangeable
+prepared states. Templates currently require the Vercel sandbox backend; Docker
+fails explicitly rather than silently repeating preparation.
 
 ## A/B Testing
 

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -53,6 +53,18 @@ export {
   readFixtureFiles,
 } from './lib/fixture.js';
 
+// Re-export reusable sandbox templates
+export type {
+  SandboxTemplate,
+  SandboxTemplateIdentityContext,
+  SandboxTemplateIdentityValue,
+  SandboxTemplatePrepareContext,
+} from './lib/sandbox-template.js';
+export {
+  defineSandboxTemplate,
+  SANDBOX_TEMPLATE_CACHE_PATH,
+} from './lib/sandbox-template.js';
+
 // Re-export sandbox utilities
 export type {
   SandboxOptions,

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -15,8 +15,7 @@ import { loadFixture, loadAllFixtures } from './lib/fixture.js';
 import { runSingleEval } from './lib/runner.js';
 import { loadConfig } from './lib/config.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
-import { registerAgent } from './lib/agents/index.js';
-import type { Agent } from './lib/agents/types.js';
+import { runWithDefinition } from './lib/agents/plugin/orchestrator.js';
 import type { AgentDefinition } from './lib/agents/plugin/contract.js';
 
 // Load .env file (try .env.local first, then .env)
@@ -67,55 +66,85 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
     }
   });
 
-  describe('custom agent registration', () => {
-    it('runs an eval through an agent registered under a custom ID', async () => {
+  describe.skipIf(!process.env.SANDBOX_TEMPLATE_INTEGRATION_TEST)('reusable sandbox templates', () => {
+    it('reuses prepared state while isolating attempt mutations', async () => {
+      const fixtureDir = join(TEST_DIR, 'sandbox-template-eval');
+      mkdirSync(fixtureDir, { recursive: true });
+      writeFileSync(join(fixtureDir, 'PROMPT.md'), 'Use prepared state');
+      writeFileSync(join(fixtureDir, 'EVAL.ts'), '');
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'sandbox-template-eval', type: 'module' })
+      );
+
+      let prepareCalls = 0;
+      const sandboxTemplate = {
+        key: `integration-template-${Date.now()}`,
+        prepare: async ({ sandbox }: { sandbox: import('./lib/types.js').Sandbox }) => {
+          prepareCalls++;
+          await sandbox.writeFiles({ 'prepared.txt': 'prepared once' });
+        },
+      };
+      const setup = async (sandbox: import('./lib/types.js').Sandbox) => {
+        expect(await sandbox.readFile('prepared.txt')).toBe('prepared once');
+        const mutation = await sandbox.runCommand('test', ['-f', 'attempt-mutation.txt']);
+        expect(mutation.exitCode).not.toBe(0);
+        await sandbox.writeFiles({ 'attempt-mutation.txt': 'attempt only' });
+      };
+      const runnerPath = join(TEST_DIR, 'template-runner.mjs');
+      writeFileSync(
+        runnerPath,
+        `import { writeFileSync } from 'node:fs';
+const input = JSON.parse(process.argv[2]);
+writeFileSync(input.resultPath, JSON.stringify({ ok: true, output: 'done', transcript: null, observedModel: null, error: null, agentExitCode: 0 }));`
+      );
       const definition: AgentDefinition = {
-        name: 'integration-custom-agent',
-        displayName: 'Integration Custom Agent',
-        defaultModel: 'custom-default',
+        name: 'template-test-agent',
+        displayName: 'Template Test Agent',
+        defaultModel: 'test',
         o11yAgentName: 'claude-code',
-        runnerPath: '/custom/run.mjs',
-        getApiKeyEnvVar: () => 'INTEGRATION_CUSTOM_AGENT_KEY',
+        runnerPath,
+        getApiKeyEnvVar: () => 'TEST_KEY',
         install: () => [],
         configFiles: () => [],
         authEnv: () => ({}),
       };
-      const agent: Agent = {
-        name: definition.name,
-        displayName: definition.displayName,
-        getApiKeyEnvVar: definition.getApiKeyEnvVar,
-        getDefaultModel: () => definition.defaultModel,
-        run: async (_fixturePath, options) => ({
-          success: true,
-          output: `handled: ${options.prompt}`,
-          duration: 1,
-          testResult: { success: true, output: 'custom validation passed' },
-          scriptsResults: {},
-        }),
-        definition,
-      };
-      registerAgent(agent);
-
-      const fixtureDir = join(TEST_DIR, 'custom-agent-eval');
-      mkdirSync(fixtureDir, { recursive: true });
-      writeFileSync(join(fixtureDir, 'PROMPT.md'), 'Use the custom agent');
-      writeFileSync(join(fixtureDir, 'EVAL.ts'), '');
-      writeFileSync(
-        join(fixtureDir, 'package.json'),
-        JSON.stringify({ name: 'custom-agent-eval', type: 'module' })
-      );
-
-      const result = await runSingleEval(loadFixture(TEST_DIR, 'custom-agent-eval'), {
-        agent: agent.name,
-        model: 'custom-model',
-        timeout: 10,
-        apiKey: 'test-key',
+      const fixture = loadFixture(TEST_DIR, 'sandbox-template-eval');
+      const experimentConfig = {
+        agent: definition.name,
+        model: 'test',
+        evals: [fixture.name],
+        runs: 2,
+        earlyExit: false,
         scripts: [],
-      });
+        validation: 'none' as const,
+        timeout: 120,
+        sandbox: 'vercel' as const,
+        sandboxTemplate,
+        setup,
+        copyFiles: 'none' as const,
+      };
+      const options = {
+        prompt: fixture.prompt,
+        model: 'test',
+        timeout: 120000,
+        apiKey: 'unused',
+        scripts: [],
+        validation: 'none' as const,
+        sandbox: 'vercel' as const,
+        sandboxTemplate,
+        fixture,
+        experimentConfig,
+        setup,
+      };
 
-      expect(result.result.status).toBe('passed');
-      expect(result.result.duration).toBeGreaterThan(0);
-    });
+      const first = await runWithDefinition(definition, fixture.path, options);
+      const second = await runWithDefinition(definition, fixture.path, options);
+
+      expect(first.success, first.error).toBe(true);
+      expect(second.success, second.error).toBe(true);
+      expect(prepareCalls).toBe(1);
+    }, 300000);
   });
 
   describe('project initialization', () => {

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -15,8 +15,10 @@ import { loadFixture, loadAllFixtures } from './lib/fixture.js';
 import { runSingleEval } from './lib/runner.js';
 import { loadConfig } from './lib/config.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
-import { runWithDefinition } from './lib/agents/plugin/orchestrator.js';
+import { registerAgent } from './lib/agents/index.js';
+import type { Agent } from './lib/agents/types.js';
 import type { AgentDefinition } from './lib/agents/plugin/contract.js';
+import { runWithDefinition } from './lib/agents/plugin/orchestrator.js';
 
 // Load .env file (try .env.local first, then .env)
 dotenvConfig({ path: '.env.local' });
@@ -64,6 +66,57 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
+  });
+
+  describe('custom agent registration', () => {
+    it('runs an eval through an agent registered under a custom ID', async () => {
+      const definition: AgentDefinition = {
+        name: 'integration-custom-agent',
+        displayName: 'Integration Custom Agent',
+        defaultModel: 'custom-default',
+        o11yAgentName: 'claude-code',
+        runnerPath: '/custom/run.mjs',
+        getApiKeyEnvVar: () => 'INTEGRATION_CUSTOM_AGENT_KEY',
+        install: () => [],
+        configFiles: () => [],
+        authEnv: () => ({}),
+      };
+      const agent: Agent = {
+        name: definition.name,
+        displayName: definition.displayName,
+        getApiKeyEnvVar: definition.getApiKeyEnvVar,
+        getDefaultModel: () => definition.defaultModel,
+        run: async (_fixturePath, options) => ({
+          success: true,
+          output: `handled: ${options.prompt}`,
+          duration: 1,
+          testResult: { success: true, output: 'custom validation passed' },
+          scriptsResults: {},
+        }),
+        definition,
+      };
+      registerAgent(agent);
+
+      const fixtureDir = join(TEST_DIR, 'custom-agent-eval');
+      mkdirSync(fixtureDir, { recursive: true });
+      writeFileSync(join(fixtureDir, 'PROMPT.md'), 'Use the custom agent');
+      writeFileSync(join(fixtureDir, 'EVAL.ts'), '');
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'custom-agent-eval', type: 'module' })
+      );
+
+      const result = await runSingleEval(loadFixture(TEST_DIR, 'custom-agent-eval'), {
+        agent: agent.name,
+        model: 'custom-model',
+        timeout: 10,
+        apiKey: 'test-key',
+        scripts: [],
+      });
+
+      expect(result.result.status).toBe('passed');
+      expect(result.result.duration).toBeGreaterThan(0);
+    });
   });
 
   describe.skipIf(!process.env.SANDBOX_TEMPLATE_INTEGRATION_TEST)('reusable sandbox templates', () => {
@@ -146,6 +199,7 @@ writeFileSync(input.resultPath, JSON.stringify({ ok: true, output: 'done', trans
       expect(prepareCalls).toBe(1);
     }, 300000);
   });
+
 
   describe('project initialization', () => {
     // Create test project before all tests in this block

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -22,8 +22,15 @@ import {
   collectLocalFiles,
   splitTestFiles,
   verifyNoTestFiles,
+  resolveBackend,
   type SandboxManager,
 } from '../../sandbox.js';
+import {
+  cacheSnapshotId,
+  computeSandboxTemplateIdentity,
+  getCachedSnapshotId,
+  removeCachedSnapshotId,
+} from '../../sandbox-template.js';
 import type { DockerSandboxManager } from '../../docker-sandbox.js';
 import {
   runValidation,
@@ -49,6 +56,10 @@ type CommandResult = { stdout: string; stderr: string; exitCode: number };
 
 /** Well-known paths inside the sandbox for the runner + its result file. */
 const RUNNER_PATH = '__agent_eval__/run.mjs';
+const TEMPLATE_RUNTIME = 'node24';
+
+// Deduplicate preparation when concurrent attempts request the same identity.
+const templatePreparations = new Map<string, Promise<string>>();
 const RESULT_PATH = '__agent_eval__/agent-result.json';
 
 /**
@@ -266,16 +277,80 @@ export async function runWithDefinition(
       return { success: false, output: '', error: 'Aborted', duration: Date.now() - startTime };
     }
 
-    // 2. Create the sandbox. One sandbox serves the codegen run AND every judge
-    //    re-invocation of the runner (eval-helper.mjs); codex's shell-canary
-    //    memoization (~/.codex/agent-eval-canary.json, see codex/run.mjs) relies
-    //    on that shared lifetime — a sandbox-per-invocation change would make
-    //    every judge assertion re-pay the canary exec.
-    sandbox = await createSandbox({
-      timeout: options.timeout,
-      runtime: 'node24',
-      backend: options.sandbox,
-    });
+    // 2. Create the sandbox. With a template, prepare and snapshot once per
+    //    identity, then give every attempt an independent sandbox from it.
+    if (options.sandboxTemplate) {
+      if (!options.fixture || !options.experimentConfig) {
+        throw new Error('Reusable sandbox templates require fixture and experiment config context.');
+      }
+      const backend = resolveBackend({ backend: options.sandbox });
+      if (backend !== 'vercel') {
+        throw new Error('Reusable sandbox templates currently require the Vercel sandbox backend.');
+      }
+      const identity = await computeSandboxTemplateIdentity({
+        template: options.sandboxTemplate,
+        fixture: options.fixture,
+        config: options.experimentConfig,
+        workspaceFiles,
+        backend,
+        runtime: TEMPLATE_RUNTIME,
+      });
+
+      const prepareSnapshot = async (): Promise<string> => {
+        const cached = getCachedSnapshotId(identity);
+        if (cached) return cached;
+
+        const preparing = templatePreparations.get(identity);
+        if (preparing) return preparing;
+
+        const promise = (async () => {
+          const preparationSandbox = await createSandbox({
+            timeout: options.timeout,
+            runtime: TEMPLATE_RUNTIME,
+            backend,
+          });
+          try {
+            await preparationSandbox.uploadFiles(workspaceFiles);
+            await options.sandboxTemplate!.prepare({
+              sandbox: preparationSandbox,
+              fixture: options.fixture!,
+              config: options.experimentConfig!,
+            });
+            const snapshotId = await (preparationSandbox as SandboxManager).snapshot();
+            cacheSnapshotId(identity, snapshotId);
+            return snapshotId;
+          } catch (error) {
+            await preparationSandbox.stop().catch(() => {});
+            throw error;
+          }
+        })().finally(() => templatePreparations.delete(identity));
+        templatePreparations.set(identity, promise);
+        return promise;
+      };
+
+      let snapshotId = await prepareSnapshot();
+      try {
+        sandbox = await createSandbox({
+          timeout: options.timeout,
+          backend,
+          snapshotId,
+        });
+      } catch {
+        // Snapshots expire or may be manually deleted. Rebuild transparently.
+        removeCachedSnapshotId(identity);
+        snapshotId = await prepareSnapshot();
+        sandbox = await createSandbox({ timeout: options.timeout, backend, snapshotId });
+      }
+    } else {
+      sandbox = await createSandbox({
+        timeout: options.timeout,
+        runtime: TEMPLATE_RUNTIME,
+        backend: options.sandbox,
+      });
+    }
+
+    // One sandbox serves codegen and every judge re-invocation.
+    // codex's shell-canary memoization relies on that shared lifetime.
 
     if (aborted) {
       return {
@@ -287,8 +362,9 @@ export async function runWithDefinition(
       };
     }
 
-    // 3. Upload workspace, establish the git baseline, run user setup, relocate to
-    //    the neutral workspace. (All agent-agnostic; unchanged shared helpers.)
+    // 3. Overlay the current fixture even when the template was prepared from an
+    //    equivalent context, then establish this attempt's baseline. Prepared
+    //    artifacts remain available; fixture files always reflect this attempt.
     await sandbox.uploadFiles(workspaceFiles);
     await initGitAndCommit(sandbox);
     if (options.setup) {

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -61,7 +61,6 @@ const TEMPLATE_RUNTIME = 'node24';
 // Deduplicate preparation when concurrent attempts request the same identity.
 const templatePreparations = new Map<string, Promise<string>>();
 const RESULT_PATH = '__agent_eval__/agent-result.json';
-const TEMPLATE_WORKSPACE_MANIFEST = '__agent_eval_template__/workspace-files.json';
 
 /**
  * Host-disk path to the in-sandbox eval helper, resolved next to the compiled
@@ -312,9 +311,6 @@ export async function runWithDefinition(
           });
           try {
             await preparationSandbox.uploadFiles(workspaceFiles);
-            await preparationSandbox.writeFiles({
-              [TEMPLATE_WORKSPACE_MANIFEST]: JSON.stringify(workspaceFiles.map((file) => file.path)),
-            });
             await options.sandboxTemplate!.prepare({
               sandbox: preparationSandbox,
               fixture: options.fixture!,
@@ -366,26 +362,11 @@ export async function runWithDefinition(
       };
     }
 
-    // 3. Overlay the current fixture even when the template was prepared from an
-    //    equivalent context. Remove files belonging to the fixture that originally
-    //    produced the snapshot first, so a file absent from this attempt cannot
-    //    leak across contexts. Artifacts created by prepare (node_modules, build
-    //    caches, etc.) remain available.
-    if (options.sandboxTemplate) {
-      try {
-        const originalPaths = JSON.parse(
-          await sandbox.readFile(TEMPLATE_WORKSPACE_MANIFEST)
-        ) as string[];
-        for (const path of originalPaths) {
-          await sandbox.runCommand('rm', ['-f', '--', path]);
-        }
-        await sandbox.runCommand('rm', ['-rf', '--', '__agent_eval_template__']);
-      } catch {
-        // A malformed/missing manifest means the snapshot is unsafe to overlay.
-        throw new Error('Reusable sandbox template is missing its workspace manifest. Bump the template key to rebuild it.');
-      }
+    // 3. A template clone already contains the exact agent-visible fixture that
+    //    produced its identity. Non-template runs still need the initial upload.
+    if (!options.sandboxTemplate) {
+      await sandbox.uploadFiles(workspaceFiles);
     }
-    await sandbox.uploadFiles(workspaceFiles);
     await initGitAndCommit(sandbox);
     if (options.setup) {
       await options.setup(sandbox);

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -61,6 +61,7 @@ const TEMPLATE_RUNTIME = 'node24';
 // Deduplicate preparation when concurrent attempts request the same identity.
 const templatePreparations = new Map<string, Promise<string>>();
 const RESULT_PATH = '__agent_eval__/agent-result.json';
+const TEMPLATE_WORKSPACE_MANIFEST = '__agent_eval_template__/workspace-files.json';
 
 /**
  * Host-disk path to the in-sandbox eval helper, resolved next to the compiled
@@ -311,6 +312,9 @@ export async function runWithDefinition(
           });
           try {
             await preparationSandbox.uploadFiles(workspaceFiles);
+            await preparationSandbox.writeFiles({
+              [TEMPLATE_WORKSPACE_MANIFEST]: JSON.stringify(workspaceFiles.map((file) => file.path)),
+            });
             await options.sandboxTemplate!.prepare({
               sandbox: preparationSandbox,
               fixture: options.fixture!,
@@ -363,8 +367,24 @@ export async function runWithDefinition(
     }
 
     // 3. Overlay the current fixture even when the template was prepared from an
-    //    equivalent context, then establish this attempt's baseline. Prepared
-    //    artifacts remain available; fixture files always reflect this attempt.
+    //    equivalent context. Remove files belonging to the fixture that originally
+    //    produced the snapshot first, so a file absent from this attempt cannot
+    //    leak across contexts. Artifacts created by prepare (node_modules, build
+    //    caches, etc.) remain available.
+    if (options.sandboxTemplate) {
+      try {
+        const originalPaths = JSON.parse(
+          await sandbox.readFile(TEMPLATE_WORKSPACE_MANIFEST)
+        ) as string[];
+        for (const path of originalPaths) {
+          await sandbox.runCommand('rm', ['-f', '--', path]);
+        }
+        await sandbox.runCommand('rm', ['-rf', '--', '__agent_eval_template__']);
+      } catch {
+        // A malformed/missing manifest means the snapshot is unsafe to overlay.
+        throw new Error('Reusable sandbox template is missing its workspace manifest. Bump the template key to rebuild it.');
+      }
+    }
     await sandbox.uploadFiles(workspaceFiles);
     await initGitAndCommit(sandbox);
     if (options.setup) {

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -2,7 +2,8 @@
  * Agent interface and common types for all agents.
  */
 
-import type { JudgeConfig, ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode } from '../types.js';
+import type { JudgeConfig, ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode, EvalFixture, RunnableExperimentConfig } from '../types.js';
+import type { SandboxTemplate } from '../sandbox-template.js';
 import type { AgentDefinition } from './plugin/contract.js';
 
 /**
@@ -19,7 +20,12 @@ export interface AgentRunOptions {
   timeout: number;
   /** API key for the agent */
   apiKey: string;
-  /** Optional setup function to run before agent */
+  /** Optional expensive reusable sandbox preparation. */
+  sandboxTemplate?: SandboxTemplate;
+  /** Fixture/config context used to compute and prepare the reusable template. */
+  fixture?: EvalFixture;
+  experimentConfig?: RunnableExperimentConfig;
+  /** Optional setup function to run before agent for every attempt. */
   setup?: SetupFunction;
   /** npm scripts to run after agent completes */
   scripts?: string[];

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -5,6 +5,9 @@ import {
   resolveEvalNames,
   CONFIG_DEFAULTS,
 } from './config.js';
+import { registerAgent } from './agents/index.js';
+import type { Agent } from './agents/types.js';
+import type { AgentDefinition } from './agents/plugin/contract.js';
 
 describe('validateConfig', () => {
   it('accepts valid minimal config', () => {
@@ -69,8 +72,13 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
-  it('rejects invalid agent', () => {
-    const config = { agent: 'invalid-agent' };
+  it('accepts a custom agent identifier for registry resolution', () => {
+    const config = { agent: 'my-custom-agent' };
+    expect(validateConfig(config).agent).toBe('my-custom-agent');
+  });
+
+  it('rejects an empty agent identifier', () => {
+    const config = { agent: '' };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
 
@@ -143,6 +151,37 @@ describe('resolveConfig', () => {
     expect(resolved.modelPolicy).toBe('agent-default');
     expect(resolved.runs).toBe(10);
     expect(resolved.earlyExit).toBe(false);
+  });
+
+  it('resolves an agent registered by an experiment module', () => {
+    const definition: AgentDefinition = {
+      name: 'config-test-custom-agent',
+      displayName: 'Config Test Custom Agent',
+      defaultModel: 'custom-default',
+      o11yAgentName: 'claude-code',
+      runnerPath: '/custom/run.mjs',
+      getApiKeyEnvVar: () => 'CUSTOM_AGENT_API_KEY',
+      install: () => [],
+      configFiles: () => [],
+      authEnv: () => ({}),
+    };
+    const customAgent: Agent = {
+      name: definition.name,
+      displayName: definition.displayName,
+      getApiKeyEnvVar: definition.getApiKeyEnvVar,
+      getDefaultModel: () => definition.defaultModel,
+      run: async () => ({ success: true, output: '', duration: 0 }),
+      definition,
+    };
+    registerAgent(customAgent);
+
+    expect(resolveConfig({ agent: customAgent.name }).agent).toBe(customAgent.name);
+  });
+
+  it('rejects an unregistered custom agent during resolution', () => {
+    expect(() => resolveConfig({ agent: 'unregistered-config-test-agent' })).toThrow(
+      'Unknown agent: unregistered-config-test-agent'
+    );
   });
 
   it('passes sandboxTemplate through and leaves it undefined by default', () => {

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -5,9 +5,6 @@ import {
   resolveEvalNames,
   CONFIG_DEFAULTS,
 } from './config.js';
-import { registerAgent } from './agents/index.js';
-import type { Agent } from './agents/types.js';
-import type { AgentDefinition } from './agents/plugin/contract.js';
 
 describe('validateConfig', () => {
   it('accepts valid minimal config', () => {
@@ -38,6 +35,24 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
+  it('accepts a reusable sandbox template', () => {
+    const sandboxTemplate = {
+      key: 'deps-v1',
+      identity: () => 'shared-deps',
+      prepare: async () => {},
+    };
+    const validated = validateConfig({ agent: 'claude-code', sandboxTemplate }).sandboxTemplate;
+    expect(validated?.key).toBe('deps-v1');
+    expect(validated?.identity).toBeTypeOf('function');
+    expect(validated?.prepare).toBeTypeOf('function');
+  });
+
+  it('rejects a sandbox template without a non-empty key', () => {
+    expect(() =>
+      validateConfig({ agent: 'claude-code', sandboxTemplate: { key: '', prepare: async () => {} } })
+    ).toThrow('Invalid experiment configuration');
+  });
+
   it('accepts array of models', () => {
     const config = {
       agent: 'claude-code',
@@ -54,13 +69,8 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
-  it('accepts a custom agent identifier for registry resolution', () => {
-    const config = { agent: 'my-custom-agent' };
-    expect(validateConfig(config).agent).toBe('my-custom-agent');
-  });
-
-  it('rejects an empty agent identifier', () => {
-    const config = { agent: '' };
+  it('rejects invalid agent', () => {
+    const config = { agent: 'invalid-agent' };
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
 
@@ -135,34 +145,11 @@ describe('resolveConfig', () => {
     expect(resolved.earlyExit).toBe(false);
   });
 
-  it('resolves an agent registered by an experiment module', () => {
-    const definition: AgentDefinition = {
-      name: 'config-test-custom-agent',
-      displayName: 'Config Test Custom Agent',
-      defaultModel: 'custom-default',
-      o11yAgentName: 'claude-code',
-      runnerPath: '/custom/run.mjs',
-      getApiKeyEnvVar: () => 'CUSTOM_AGENT_API_KEY',
-      install: () => [],
-      configFiles: () => [],
-      authEnv: () => ({}),
-    };
-    const customAgent: Agent = {
-      name: definition.name,
-      displayName: definition.displayName,
-      getApiKeyEnvVar: definition.getApiKeyEnvVar,
-      getDefaultModel: () => definition.defaultModel,
-      run: async () => ({ success: true, output: '', duration: 0 }),
-      definition,
-    };
-    registerAgent(customAgent);
-
-    expect(resolveConfig({ agent: customAgent.name }).agent).toBe(customAgent.name);
-  });
-
-  it('rejects an unregistered custom agent during resolution', () => {
-    expect(() => resolveConfig({ agent: 'unregistered-config-test-agent' })).toThrow(
-      'Unknown agent: unregistered-config-test-agent'
+  it('passes sandboxTemplate through and leaves it undefined by default', () => {
+    const sandboxTemplate = { key: 'deps-v1', prepare: async () => {} };
+    expect(resolveConfig({ agent: 'claude-code' as const }).sandboxTemplate).toBeUndefined();
+    expect(resolveConfig({ agent: 'claude-code' as const, sandboxTemplate }).sandboxTemplate).toBe(
+      sandboxTemplate
     );
   });
 

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -42,6 +42,13 @@ const experimentConfigSchema = z.object({
   scripts: z.array(z.string()).optional(),
   validation: z.enum(['vitest', 'none']).optional(),
   timeout: z.number().positive().optional(),
+  sandboxTemplate: z
+    .object({
+      key: z.string().min(1),
+      identity: z.function().optional(),
+      prepare: z.function(),
+    })
+    .optional(),
   setup: z.function().optional(),
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
@@ -116,6 +123,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     scripts: config.scripts ?? CONFIG_DEFAULTS.scripts,
     validation: config.validation ?? CONFIG_DEFAULTS.validation,
     timeout: config.timeout ?? CONFIG_DEFAULTS.timeout,
+    sandboxTemplate: config.sandboxTemplate,
     setup: config.setup,
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
     editPrompt: config.editPrompt,

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -67,6 +67,26 @@ describe('computeFingerprint', () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it('changes when sandbox template key changes', () => {
+    const evalDir = createEvalDir('eval-template', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+    const prepare = async () => {};
+
+    const fp1 = computeFingerprint(evalDir, {
+      ...baseConfig,
+      sandboxTemplate: { key: 'deps-v1', prepare },
+    });
+    const fp2 = computeFingerprint(evalDir, {
+      ...baseConfig,
+      sandboxTemplate: { key: 'deps-v2', prepare },
+    });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
   it('changes when config model changes', () => {
     const evalDir = createEvalDir('eval-3', {
       'PROMPT.md': 'Do something',

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -24,6 +24,7 @@ interface FingerprintableConfig {
   runs: number;
   webResearch?: boolean;
   judge?: { agent?: string; model: string };
+  sandboxTemplate?: { key: string };
 }
 
 /**
@@ -117,6 +118,9 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   // unchanged. Changing the judge agent/model invalidates the cache → re-runs.
   if (config.judge) {
     configForHash.judge = { agent: config.judge.agent, model: config.judge.model };
+  }
+  if (config.sandboxTemplate) {
+    configForHash.sandboxTemplate = { key: config.sandboxTemplate.key };
   }
   hash.update(`config:${JSON.stringify(configForHash)}`);
 

--- a/packages/agent-eval/src/lib/init.ts
+++ b/packages/agent-eval/src/lib/init.ts
@@ -85,6 +85,7 @@ dist/
 .env
 .env.local
 results/
+.agent-eval/
 *.log
 .DS_Store
 `;

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -549,6 +549,9 @@ describe('runExperiment', () => {
         modelPolicy: 'agent-default',
         timeout: 600000, // Should be converted to milliseconds
         apiKey: 'my-api-key',
+        sandboxTemplate: undefined,
+        fixture: fixtures[0],
+        experimentConfig: config,
         setup: mockSetup,
         scripts: ['build', 'lint'],
         validation: undefined,

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -190,6 +190,9 @@ export async function runExperiment(
         modelPolicy,
         timeout: timeoutMs,
         apiKey,
+        sandboxTemplate: config.sandboxTemplate,
+        fixture,
+        experimentConfig: config,
         setup: config.setup,
         scripts: config.scripts,
         validation: config.validation,
@@ -384,6 +387,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     model: T;
     timeout: number;
     apiKey: string;
+    sandboxTemplate?: ResolvedExperimentConfig['sandboxTemplate'];
     setup?: ResolvedExperimentConfig['setup'];
     scripts?: string[];
     validation?: ResolvedExperimentConfig['validation'];
@@ -410,6 +414,22 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		modelPolicy: 'agent-default',
 		timeout: options.timeout * 1000,
 		apiKey: options.apiKey,
+		sandboxTemplate: options.sandboxTemplate,
+		fixture,
+		experimentConfig: {
+			agent: options.agent ?? 'vercel-ai-gateway/claude-code',
+			model,
+			evals: [fixture.name],
+			runs: 1,
+			earlyExit: false,
+			scripts: options.scripts ?? [],
+			validation: options.validation ?? 'vitest',
+			timeout: options.timeout,
+			sandboxTemplate: options.sandboxTemplate,
+			setup: options.setup,
+			sandbox: options.sandbox ?? 'auto',
+			copyFiles: 'none',
+		},
 		setup: options.setup,
 		scripts: options.scripts,
 		validation: options.validation,

--- a/packages/agent-eval/src/lib/sandbox-template.test.ts
+++ b/packages/agent-eval/src/lib/sandbox-template.test.ts
@@ -76,7 +76,7 @@ describe('sandbox templates', () => {
     expect(first).not.toBe(second);
   });
 
-  it('lets identity define which contexts share prepared state', async () => {
+  it('does not let a custom identity collapse different visible fixtures', async () => {
     const evalFixture = fixture();
     const template = defineSandboxTemplate({
       key: 'deps-v1',
@@ -101,7 +101,31 @@ describe('sandbox templates', () => {
       workspaceFiles: [{ path: 'source.ts', content: 'two' }],
     });
 
-    expect(first).toBe(second);
+    expect(first).not.toBe(second);
+  });
+
+  it('uses a custom identity as an additional contextual input', async () => {
+    const evalFixture = fixture();
+    let version = 'v1';
+    const template = defineSandboxTemplate({
+      key: 'deps-v1',
+      identity: () => ({ version }),
+      prepare: async () => {},
+    });
+    const options = {
+      template,
+      fixture: evalFixture,
+      config,
+      workspaceFiles: [{ path: 'source.ts', content: 'same' }],
+      backend: 'vercel' as const,
+      runtime: 'node24',
+    };
+
+    const first = await computeSandboxTemplateIdentity(options);
+    version = 'v2';
+    const second = await computeSandboxTemplateIdentity(options);
+
+    expect(first).not.toBe(second);
   });
 
   it('rejects non-serializable custom identities', async () => {

--- a/packages/agent-eval/src/lib/sandbox-template.test.ts
+++ b/packages/agent-eval/src/lib/sandbox-template.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  cacheSnapshotId,
+  computeSandboxTemplateIdentity,
+  defineSandboxTemplate,
+  resetSandboxTemplateCacheForTests,
+  SANDBOX_TEMPLATE_CACHE_PATH,
+} from './sandbox-template.js';
+import type { EvalFixture, RunnableExperimentConfig } from './types.js';
+
+const root = '/tmp/agent-eval-sandbox-template-test';
+const config: RunnableExperimentConfig = {
+  agent: 'claude-code',
+  model: 'sonnet',
+  evals: '*',
+  runs: 1,
+  earlyExit: false,
+  scripts: [],
+  validation: 'vitest',
+  timeout: 600,
+  sandbox: 'vercel',
+  copyFiles: 'none',
+};
+
+function fixture(): EvalFixture {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, 'package.json'), '{"type":"module"}');
+  writeFileSync(join(root, 'source.ts'), 'one');
+  return { name: 'test', path: root, prompt: 'do it', isModule: true };
+}
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  rmSync(join(process.cwd(), '.agent-eval'), { recursive: true, force: true });
+  resetSandboxTemplateCacheForTests();
+});
+
+describe('sandbox templates', () => {
+  it('persists snapshot IDs in the project-local cache', () => {
+    cacheSnapshotId('identity', 'snapshot-id');
+
+    const saved = JSON.parse(
+      readFileSync(join(process.cwd(), SANDBOX_TEMPLATE_CACHE_PATH), 'utf8')
+    );
+    expect(saved.snapshots.identity).toBe('snapshot-id');
+  });
+
+  it('rejects an empty key', () => {
+    expect(() => defineSandboxTemplate({ key: '', prepare: async () => {} })).toThrow(
+      'Sandbox template key must be a non-empty string.'
+    );
+  });
+
+  it('uses all visible workspace files by default', async () => {
+    const evalFixture = fixture();
+    const template = defineSandboxTemplate({ key: 'deps-v1', prepare: async () => {} });
+    const options = {
+      template,
+      fixture: evalFixture,
+      config,
+      backend: 'vercel' as const,
+      runtime: 'node24',
+    };
+
+    const first = await computeSandboxTemplateIdentity({
+      ...options,
+      workspaceFiles: [{ path: 'source.ts', content: 'one' }],
+    });
+    const second = await computeSandboxTemplateIdentity({
+      ...options,
+      workspaceFiles: [{ path: 'source.ts', content: 'two' }],
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it('lets identity define which contexts share prepared state', async () => {
+    const evalFixture = fixture();
+    const template = defineSandboxTemplate({
+      key: 'deps-v1',
+      identity: ({ hashFiles }) => ({ dependencies: hashFiles(['package.json']) }),
+      prepare: async () => {},
+    });
+    const options = {
+      template,
+      fixture: evalFixture,
+      config,
+      backend: 'vercel' as const,
+      runtime: 'node24',
+    };
+
+    const first = await computeSandboxTemplateIdentity({
+      ...options,
+      workspaceFiles: [{ path: 'source.ts', content: 'one' }],
+    });
+    writeFileSync(join(root, 'source.ts'), 'two');
+    const second = await computeSandboxTemplateIdentity({
+      ...options,
+      workspaceFiles: [{ path: 'source.ts', content: 'two' }],
+    });
+
+    expect(first).toBe(second);
+  });
+
+  it('rejects non-serializable custom identities', async () => {
+    const evalFixture = fixture();
+    const template = defineSandboxTemplate({
+      key: 'invalid',
+      // Deliberately bypass the public serializable type to verify the runtime boundary.
+      identity: () => (() => 'nope') as never,
+      prepare: async () => {},
+    });
+
+    await expect(
+      computeSandboxTemplateIdentity({
+        template,
+        fixture: evalFixture,
+        config,
+        workspaceFiles: [],
+        backend: 'vercel',
+        runtime: 'node24',
+      })
+    ).rejects.toThrow('Sandbox template identity must be JSON-serializable.');
+  });
+
+  it('includes framework-owned backend, runtime, and key invariants', async () => {
+    const evalFixture = fixture();
+    const base = {
+      fixture: evalFixture,
+      config,
+      workspaceFiles: [],
+      backend: 'vercel' as const,
+      runtime: 'node24',
+    };
+    const one = await computeSandboxTemplateIdentity({
+      ...base,
+      template: defineSandboxTemplate({ key: 'v1', identity: () => 'same', prepare: async () => {} }),
+    });
+    const two = await computeSandboxTemplateIdentity({
+      ...base,
+      runtime: 'node22',
+      template: defineSandboxTemplate({ key: 'v2', identity: () => 'same', prepare: async () => {} }),
+    });
+
+    expect(one).not.toBe(two);
+  });
+});

--- a/packages/agent-eval/src/lib/sandbox-template.ts
+++ b/packages/agent-eval/src/lib/sandbox-template.ts
@@ -98,20 +98,25 @@ export async function computeSandboxTemplateIdentity(options: {
   runtime: string;
 }): Promise<string> {
   const { template, fixture, config, workspaceFiles, backend, runtime } = options;
-  const userIdentity = template.identity
+  // The complete visible workspace is always part of the identity. A custom
+  // identity can add external/contextual inputs, but can never make different
+  // fixture starting states share a snapshot.
+  const workspaceIdentity = hashSandboxFiles(workspaceFiles);
+  const additionalIdentity = template.identity
     ? await template.identity({
         fixture,
         config,
         hashFiles: (patterns) => hashFixturePatterns(fixture.path, patterns),
       })
-    : hashSandboxFiles(workspaceFiles);
+    : null;
 
   return createHash('sha256')
     .update(
       canonicalize({
         format: 1,
         key: template.key,
-        identity: userIdentity,
+        workspaceIdentity,
+        additionalIdentity,
         backend,
         runtime,
       })

--- a/packages/agent-eval/src/lib/sandbox-template.ts
+++ b/packages/agent-eval/src/lib/sandbox-template.ts
@@ -1,0 +1,172 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { globSync } from 'glob';
+import type { Sandbox, EvalFixture, RunnableExperimentConfig } from './types.js';
+import type { SandboxFile } from './sandbox.js';
+
+/** Persistent cache location, relative to the eval project cwd. */
+export const SANDBOX_TEMPLATE_CACHE_PATH = '.agent-eval/sandbox-templates.json';
+
+export type SandboxTemplateIdentityValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly SandboxTemplateIdentityValue[]
+  | { readonly [key: string]: SandboxTemplateIdentityValue | undefined };
+
+export interface SandboxTemplateIdentityContext {
+  fixture: EvalFixture;
+  config: RunnableExperimentConfig;
+  hashFiles(patterns: string[]): string;
+}
+
+export interface SandboxTemplatePrepareContext {
+  sandbox: Sandbox;
+  fixture: EvalFixture;
+  config: RunnableExperimentConfig;
+}
+
+export interface SandboxTemplate {
+  key: string;
+  identity?: (
+    context: SandboxTemplateIdentityContext
+  ) => SandboxTemplateIdentityValue | Promise<SandboxTemplateIdentityValue>;
+  prepare(context: SandboxTemplatePrepareContext): void | Promise<void>;
+}
+
+/** Define expensive, reusable sandbox preparation for an experiment. */
+export function defineSandboxTemplate(template: SandboxTemplate): SandboxTemplate {
+  if (!template.key.trim()) {
+    throw new Error('Sandbox template key must be a non-empty string.');
+  }
+  return template;
+}
+
+function hashSandboxFiles(files: SandboxFile[]): string {
+  const hash = createHash('sha256');
+  for (const file of [...files].sort((a, b) => a.path.localeCompare(b.path))) {
+    hash.update(`file:${file.path}\n`);
+    hash.update(file.content);
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+function hashFixturePatterns(fixturePath: string, patterns: string[]): string {
+  const paths = globSync(patterns, { cwd: fixturePath, nodir: true, dot: true }).sort();
+  const hash = createHash('sha256');
+  for (const path of paths) {
+    hash.update(`file:${path}\n`);
+    hash.update(readFileSync(join(fixturePath, path)));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+function canonicalize(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Sandbox template identity must be JSON-serializable.');
+    return JSON.stringify(value);
+  }
+  if (typeof value !== 'object') {
+    throw new Error('Sandbox template identity must be JSON-serializable.');
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error('Sandbox template identity must be JSON-serializable.');
+  }
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(object[key])}`)
+    .join(',')}}`;
+}
+
+export async function computeSandboxTemplateIdentity(options: {
+  template: SandboxTemplate;
+  fixture: EvalFixture;
+  config: RunnableExperimentConfig;
+  workspaceFiles: SandboxFile[];
+  backend: 'vercel' | 'docker';
+  runtime: string;
+}): Promise<string> {
+  const { template, fixture, config, workspaceFiles, backend, runtime } = options;
+  const userIdentity = template.identity
+    ? await template.identity({
+        fixture,
+        config,
+        hashFiles: (patterns) => hashFixturePatterns(fixture.path, patterns),
+      })
+    : hashSandboxFiles(workspaceFiles);
+
+  return createHash('sha256')
+    .update(
+      canonicalize({
+        format: 1,
+        key: template.key,
+        identity: userIdentity,
+        backend,
+        runtime,
+      })
+    )
+    .digest('hex');
+}
+
+interface TemplateCacheFile {
+  version: 1;
+  snapshots: Record<string, string>;
+}
+
+let cache: TemplateCacheFile | undefined;
+
+function getCachePath(): string {
+  return join(process.cwd(), SANDBOX_TEMPLATE_CACHE_PATH);
+}
+
+function readCache(): TemplateCacheFile {
+  if (cache) return cache;
+  try {
+    const parsed = JSON.parse(readFileSync(getCachePath(), 'utf8')) as TemplateCacheFile;
+    cache = parsed.version === 1 && parsed.snapshots ? parsed : { version: 1, snapshots: {} };
+  } catch {
+    cache = { version: 1, snapshots: {} };
+  }
+  return cache;
+}
+
+function writeCache(value: TemplateCacheFile): void {
+  const cachePath = getCachePath();
+  mkdirSync(dirname(cachePath), { recursive: true });
+  const temporary = `${cachePath}.${process.pid}.tmp`;
+  writeFileSync(temporary, JSON.stringify(value, null, 2));
+  renameSync(temporary, cachePath);
+}
+
+export function getCachedSnapshotId(identity: string): string | undefined {
+  return readCache().snapshots[identity];
+}
+
+export function cacheSnapshotId(identity: string, snapshotId: string): void {
+  const value = readCache();
+  value.snapshots[identity] = snapshotId;
+  writeCache(value);
+}
+
+export function removeCachedSnapshotId(identity: string): void {
+  const value = readCache();
+  if (!(identity in value.snapshots)) return;
+  delete value.snapshots[identity];
+  writeCache(value);
+}
+
+/** @internal Test helper. */
+export function resetSandboxTemplateCacheForTests(): void {
+  cache = undefined;
+}

--- a/packages/agent-eval/src/lib/sandbox.ts
+++ b/packages/agent-eval/src/lib/sandbox.ts
@@ -73,6 +73,8 @@ export interface SandboxOptions {
   teamId?: string;
   /** Optional explicit Vercel project ID for sandbox API auth */
   projectId?: string;
+  /** Create a Vercel sandbox from an immutable snapshot. */
+  snapshotId?: string;
 }
 
 /**
@@ -154,7 +156,9 @@ export class SandboxManager implements Sandbox {
     const credentials = resolveVercelSandboxCredentials(options);
 
     const sandbox = await VercelSandbox.create({
-      runtime,
+      ...(options.snapshotId
+        ? { source: { type: 'snapshot' as const, snapshotId: options.snapshotId } }
+        : { runtime }),
       timeout,
       ...(credentials ?? {}),
     });
@@ -273,6 +277,12 @@ export class SandboxManager implements Sandbox {
   async stop(): Promise<void> {
     await this.sandbox.stop();
   }
+
+  /** Snapshot this sandbox. Snapshotting stops it. */
+  async snapshot(): Promise<string> {
+    const snapshot = await this.sandbox.snapshot();
+    return snapshot.snapshotId;
+  }
 }
 
 function resolveVercelSandboxCredentials(options: SandboxOptions): {
@@ -364,6 +374,9 @@ export async function createSandbox(
   const backend = resolveBackend(options);
 
   if (backend === 'docker') {
+    if (options.snapshotId) {
+      throw new Error('Reusable sandbox templates are not supported by the Docker backend yet.');
+    }
     return DockerSandboxManager.create({
       timeout: options.timeout,
       runtime: options.runtime,
@@ -373,6 +386,10 @@ export async function createSandbox(
   return SandboxManager.create({
     timeout: options.timeout,
     runtime: options.runtime,
+    snapshotId: options.snapshotId,
+    token: options.token,
+    teamId: options.teamId,
+    projectId: options.projectId,
   });
 }
 

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -2,6 +2,8 @@
  * Core types for the eval framework.
  */
 
+import type { SandboxTemplate } from './sandbox-template.js';
+
 /**
  * Supported AI agent types.
  */
@@ -141,7 +143,10 @@ export interface ExperimentConfig {
   /** Maximum time in seconds for agent to complete. @default 300 (5 minutes) */
   timeout?: number;
 
-  /** Setup function that runs before agent starts. @default undefined */
+  /** Expensive reusable sandbox preparation. Vercel snapshots the prepared state. @default undefined */
+  sandboxTemplate?: SandboxTemplate;
+
+  /** Setup function that runs before agent starts for every attempt. @default undefined */
   setup?: SetupFunction;
 
   /** Sandbox backend to use. @default 'auto' (Vercel if token present, else Docker) */
@@ -190,6 +195,7 @@ export interface ResolvedExperimentConfig {
   scripts: string[];
   validation: ValidationMode;
   timeout: number;
+  sandboxTemplate?: SandboxTemplate;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;
@@ -214,6 +220,7 @@ export interface RunnableExperimentConfig {
   scripts: string[];
   validation: ValidationMode;
   timeout: number;
+  sandboxTemplate?: SandboxTemplate;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
   editPrompt?: (prompt: string) => string;


### PR DESCRIPTION
Supersedes #179 with an organization-owned stacked branch.\n\nDepends on the custom-agent registration PR. Adds context-keyed Vercel Sandbox snapshots and independent per-attempt clones.