### PR TITLE
Add natural multi-turn simulated user interaction

### DIFF
--- a/.changeset/fuzzy-clouds-interact.md
+++ b/.changeset/fuzzy-clouds-interact.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add natural multi-turn simulated user interaction for capable registered agents, with a reusable completed-turn coordinator and persisted interaction history.

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ const config: ExperimentConfig = {
 Response-only fixtures still need `PROMPT.md` and `package.json`, but they do
 not need `EVAL.ts` or `EVAL.tsx`.
 
+
 ## Reusable Sandbox Preparation
 
 Use `defineSandboxTemplate` to run expensive setup once and give every eval
@@ -523,6 +524,79 @@ The framework combines the fixture and additional identities with the template
 preparation logic changes in a way not otherwise represented. Templates currently
 require the Vercel sandbox backend; Docker fails explicitly rather than silently
 repeating preparation.
+
+## Simulated User Interaction
+
+Registered agents can opt into natural multi-turn interaction by declaring the
+`naturalMultiTurn` capability and consuming the interaction options passed to
+`Agent.run`. The exported `runNaturalInteraction` helper drives completed turns
+without introducing a separate event protocol:
+
+```typescript
+import {
+  registerAgent,
+  runNaturalInteraction,
+  type Agent,
+  type ExperimentConfig,
+} from '@vercel/agent-eval';
+
+const interactiveAgent: Agent = {
+  // ...the rest of the complete Agent implementation
+  capabilities: { naturalMultiTurn: true },
+
+  async run(fixturePath, options) {
+    const session = await harnessAgent.createSession();
+    try {
+      const { result, turns } = await runNaturalInteraction({
+        initialPrompt: options.prompt,
+        interaction: options.interaction,
+        fixture: options.fixture!,
+        runIndex: options.runIndex!,
+        // Reusing `session` here retains the harness's native conversation history.
+        generate: prompt => harnessAgent.generate({ session, prompt }),
+      });
+
+      return {
+        success: true,
+        output: result.text,
+        duration: 1000,
+        interaction: { turns },
+      };
+    } finally {
+      await session.destroy();
+    }
+  },
+};
+
+registerAgent(interactiveAgent);
+
+const config: ExperimentConfig = {
+  agent: interactiveAgent.name,
+  interaction: {                              // NEW
+    maxTurns: 2,
+    respond: async ({ turn, result }) => {
+      if (turn === 1) {
+        if (!/deployment region/i.test(result.text)) {
+          throw new Error('Expected a deployment-region question');
+        }
+        return 'Use iad1.';                    // start another user turn
+      }
+      return null;                             // conversation complete
+    },
+  },
+};
+```
+
+`respond` runs after each naturally completed assistant turn. Returning a string
+starts a new user turn in the same native session; returning `null` proceeds to
+validation. Errors and exceeding `maxTurns` fail the run. The full interaction
+history is saved in `result.json` and is available to capable agents for
+materialization into `__agent_eval__/results.json`.
+
+Built-in one-shot agents currently reject `interaction` clearly. This additive
+seam is intended for registered HarnessAgent-backed agents; no custom event or
+structured-tool protocol is introduced.
+
 
 ## A/B Testing
 

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -12,6 +12,10 @@ export type {
   ModelPolicy,
   EvalFilter,
   ValidationMode,
+  CompletedTurnResult,
+  InteractionConfig,
+  InteractionContext,
+  InteractionTurn,
   BrandConfig,
   Sandbox,
   SetupFunction,
@@ -92,6 +96,8 @@ export { DockerSandboxManager } from './lib/docker-sandbox.js';
 
 // Re-export agent utilities
 export type { AgentRunOptions, AgentRunResult } from './lib/agents/types.js';
+export type { RunNaturalInteractionOptions } from './lib/agents/interaction.js';
+export { runNaturalInteraction } from './lib/agents/interaction.js';
 
 // Re-export transcript context constants
 export { TRANSCRIPT_CONTEXT_DIR, TRANSCRIPT_CONTEXT_PATH } from './lib/agents/shared.js';

--- a/packages/agent-eval/src/lib/agents/interaction.test.ts
+++ b/packages/agent-eval/src/lib/agents/interaction.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runNaturalInteraction } from './interaction.js';
+import type { EvalFixture } from '../types.js';
+
+const fixture: EvalFixture = {
+  name: 'deploy',
+  path: '/fixture',
+  prompt: 'Deploy this',
+  isModule: true,
+};
+
+describe('runNaturalInteraction', () => {
+  it('runs one turn when interaction is omitted', async () => {
+    const generate = vi.fn(async (prompt: string) => ({ text: `answer: ${prompt}` }));
+
+    const outcome = await runNaturalInteraction({
+      initialPrompt: fixture.prompt,
+      fixture,
+      runIndex: 0,
+      generate,
+    });
+
+    expect(generate).toHaveBeenCalledOnce();
+    expect(outcome.result.text).toBe('answer: Deploy this');
+    expect(outcome.turns).toHaveLength(1);
+  });
+
+  it('sends returned responses as new turns using the same generator', async () => {
+    const generate = vi
+      .fn<(prompt: string) => Promise<{ text: string }>>()
+      .mockResolvedValueOnce({ text: 'Which region?' })
+      .mockResolvedValueOnce({ text: 'Deployed to iad1.' });
+    const respond = vi.fn(async ({ turn }: { turn: number }) =>
+      turn === 1 ? 'Use iad1.' : null
+    );
+
+    const outcome = await runNaturalInteraction({
+      initialPrompt: fixture.prompt,
+      fixture,
+      runIndex: 2,
+      interaction: { maxTurns: 2, respond },
+      generate,
+    });
+
+    expect(generate).toHaveBeenNthCalledWith(1, 'Deploy this');
+    expect(generate).toHaveBeenNthCalledWith(2, 'Use iad1.');
+    expect(outcome.turns[0].userResponse).toBe('Use iad1.');
+    expect(outcome.result.text).toBe('Deployed to iad1.');
+  });
+
+  it('passes completed-turn history and run context to respond', async () => {
+    const respond = vi.fn(() => null);
+
+    await runNaturalInteraction({
+      initialPrompt: fixture.prompt,
+      fixture,
+      runIndex: 4,
+      interaction: { respond },
+      generate: async () => ({ text: 'done', native: true }),
+    });
+
+    expect(respond).toHaveBeenCalledWith({
+      turn: 1,
+      result: { text: 'done', native: true },
+      history: [{ turn: 1, result: { text: 'done', native: true } }],
+      fixture,
+      runIndex: 4,
+    });
+  });
+
+  it('fails instead of starting a turn beyond maxTurns', async () => {
+    const generate = vi.fn(async () => ({ text: 'more?' }));
+
+    await expect(
+      runNaturalInteraction({
+        initialPrompt: fixture.prompt,
+        fixture,
+        runIndex: 0,
+        interaction: { maxTurns: 1, respond: () => 'continue' },
+        generate,
+      })
+    ).rejects.toThrow('Interaction exceeded maxTurns (1).');
+    expect(generate).toHaveBeenCalledOnce();
+  });
+
+  it('rejects empty simulated user prompts', async () => {
+    await expect(
+      runNaturalInteraction({
+        initialPrompt: fixture.prompt,
+        fixture,
+        runIndex: 0,
+        interaction: { respond: () => '  ' },
+        generate: async () => ({ text: 'question' }),
+      })
+    ).rejects.toThrow('Interaction respond() must return a non-empty prompt or null.');
+  });
+});

--- a/packages/agent-eval/src/lib/agents/interaction.ts
+++ b/packages/agent-eval/src/lib/agents/interaction.ts
@@ -1,0 +1,59 @@
+import type {
+  CompletedTurnResult,
+  EvalFixture,
+  InteractionConfig,
+  InteractionTurn,
+} from '../types.js';
+
+export interface RunNaturalInteractionOptions<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  initialPrompt: string;
+  interaction?: InteractionConfig<TResult>;
+  fixture: EvalFixture;
+  runIndex: number;
+  generate(prompt: string): Promise<TResult>;
+}
+
+/**
+ * Drive natural completed assistant turns. The supplied `generate` function is
+ * responsible for retaining one native agent session across calls.
+ */
+export async function runNaturalInteraction<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+>(options: RunNaturalInteractionOptions<TResult>): Promise<{
+  result: TResult;
+  turns: InteractionTurn<TResult>[];
+}> {
+  const maxTurns = options.interaction?.maxTurns ?? 3;
+  const turns: InteractionTurn<TResult>[] = [];
+  let prompt = options.initialPrompt;
+
+  for (let turn = 1; turn <= maxTurns; turn++) {
+    const result = await options.generate(prompt);
+    const completed: InteractionTurn<TResult> = { turn, result };
+    turns.push(completed);
+
+    if (!options.interaction) return { result, turns };
+
+    const response = await options.interaction.respond({
+      turn,
+      result,
+      history: turns,
+      fixture: options.fixture,
+      runIndex: options.runIndex,
+    });
+    if (response === null) return { result, turns };
+    if (!response.trim()) {
+      throw new Error('Interaction respond() must return a non-empty prompt or null.');
+    }
+
+    completed.userResponse = response;
+    if (turn === maxTurns) {
+      throw new Error(`Interaction exceeded maxTurns (${maxTurns}).`);
+    }
+    prompt = response;
+  }
+
+  throw new Error(`Interaction exceeded maxTurns (${maxTurns}).`);
+}

--- a/packages/agent-eval/src/lib/agents/shared.test.ts
+++ b/packages/agent-eval/src/lib/agents/shared.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it, vi } from 'vitest';
-import { prepareNeutralWorkspace } from './shared.js';
+import { injectTranscriptContext, prepareNeutralWorkspace, TRANSCRIPT_CONTEXT_PATH } from './shared.js';
+
+describe('injectTranscriptContext', () => {
+  it('materializes natural interaction history for EVAL.ts assertions', async () => {
+    const writeFiles = vi.fn();
+    const turns = [{ turn: 1, result: { text: 'Which region?' }, userResponse: 'iad1' }];
+
+    await injectTranscriptContext(
+      { writeFiles } as never,
+      undefined,
+      'claude-code',
+      undefined,
+      turns
+    );
+
+    expect(writeFiles).toHaveBeenCalledWith({
+      [TRANSCRIPT_CONTEXT_PATH]: JSON.stringify(
+        { o11y: null, interaction: { turns } },
+        null,
+        2
+      ),
+    });
+  });
+});
 
 describe('prepareNeutralWorkspace', () => {
   it('copies Vercel sandboxes into /workspace and switches the working directory', async () => {

--- a/packages/agent-eval/src/lib/agents/shared.ts
+++ b/packages/agent-eval/src/lib/agents/shared.ts
@@ -271,6 +271,7 @@ export async function injectTranscriptContext(
   rawTranscript: string | undefined,
   agentName: string,
   model?: string,
+  interaction?: import('../types.js').InteractionTurn[],
 ): Promise<void> {
   try {
     const transcript = rawTranscript
@@ -279,6 +280,7 @@ export async function injectTranscriptContext(
 
     const context = {
       o11y: transcript?.summary ?? null,
+      interaction: interaction ? { turns: interaction } : undefined,
     };
 
     await sandbox.writeFiles({

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -2,8 +2,21 @@
  * Agent interface and common types for all agents.
  */
 
-import type { JudgeConfig, ModelPolicy, ModelTier, SetupFunction, SandboxBackend, ValidationMode, EvalFixture, RunnableExperimentConfig } from '../types.js';
+
+import type {
+  EvalFixture,
+  InteractionConfig,
+  InteractionTurn,
+  JudgeConfig,
+  ModelPolicy,
+  ModelTier,
+  RunnableExperimentConfig,
+  SandboxBackend,
+  SetupFunction,
+  ValidationMode,
+} from '../types.js';
 import type { SandboxTemplate } from '../sandbox-template.js';
+
 import type { AgentDefinition } from './plugin/contract.js';
 
 /**
@@ -22,11 +35,14 @@ export interface AgentRunOptions {
   apiKey: string;
   /** Optional expensive reusable sandbox preparation. */
   sandboxTemplate?: SandboxTemplate;
-  /** Fixture/config context used to compute and prepare the reusable template. */
+  /** Fixture/config context used by reusable templates and interaction callbacks. */
   fixture?: EvalFixture;
   experimentConfig?: RunnableExperimentConfig;
+  runIndex?: number;
   /** Optional setup function to run before agent for every attempt. */
   setup?: SetupFunction;
+  /** Natural completed-turn interaction controlled by this agent implementation. */
+  interaction?: InteractionConfig;
   /** npm scripts to run after agent completes */
   scripts?: string[];
   /** Validation mode after agent completes */
@@ -94,6 +110,8 @@ export interface AgentRunResult {
   observedModel?: string;
   /** Codex only: model re-stated explicitly by the shell-tool repair (see RunnerResult.modelRepair) */
   modelRepair?: string;
+  /** Natural interaction history coordinated by the agent implementation. */
+  interaction?: { turns: InteractionTurn[] };
 }
 
 /**
@@ -105,6 +123,11 @@ export interface Agent {
 
   /** Human-readable display name */
   displayName: string;
+
+  /** Optional capabilities beyond the legacy one-shot contract. */
+  capabilities?: {
+    naturalMultiTurn?: boolean;
+  };
 
   /** Run the agent on a fixture */
   run(fixturePath: string, options: AgentRunOptions): Promise<AgentRunResult>;

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -38,6 +38,7 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).not.toThrow();
   });
 
+
   it('accepts a reusable sandbox template', () => {
     const sandboxTemplate = {
       key: 'deps-v1',
@@ -53,6 +54,19 @@ describe('validateConfig', () => {
   it('rejects a sandbox template without a non-empty key', () => {
     expect(() =>
       validateConfig({ agent: 'claude-code', sandboxTemplate: { key: '', prepare: async () => {} } })
+    ).toThrow('Invalid experiment configuration');
+  });
+
+  it('accepts natural interaction config', () => {
+    const interaction = { maxTurns: 2, respond: async () => null };
+    const validated = validateConfig({ agent: 'claude-code', interaction }).interaction;
+    expect(validated?.maxTurns).toBe(2);
+    expect(validated?.respond).toBeTypeOf('function');
+  });
+
+  it('rejects a non-positive interaction maxTurns', () => {
+    expect(() =>
+      validateConfig({ agent: 'claude-code', interaction: { maxTurns: 0, respond: () => null } })
     ).toThrow('Invalid experiment configuration');
   });
 
@@ -184,11 +198,20 @@ describe('resolveConfig', () => {
     );
   });
 
+
   it('passes sandboxTemplate through and leaves it undefined by default', () => {
     const sandboxTemplate = { key: 'deps-v1', prepare: async () => {} };
     expect(resolveConfig({ agent: 'claude-code' as const }).sandboxTemplate).toBeUndefined();
     expect(resolveConfig({ agent: 'claude-code' as const, sandboxTemplate }).sandboxTemplate).toBe(
       sandboxTemplate
+    );
+  });
+
+  it('passes interaction through and leaves it undefined by default', () => {
+    const interaction = { maxTurns: 2, respond: async () => null };
+    expect(resolveConfig({ agent: 'claude-code' as const }).interaction).toBeUndefined();
+    expect(resolveConfig({ agent: 'claude-code' as const, interaction }).interaction).toBe(
+      interaction
     );
   });
 

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -51,6 +51,12 @@ const experimentConfigSchema = z.object({
     .optional(),
   setup: z.function().optional(),
   sandbox: z.enum(['vercel', 'docker', 'auto']).optional(),
+  interaction: z
+    .object({
+      maxTurns: z.number().int().positive().optional(),
+      respond: z.function(),
+    })
+    .optional(),
   editPrompt: z.function().args(z.string()).returns(z.string()).optional(),
   copyFiles: z.enum(['none', 'changed', 'all']).optional(),
   agentOptions: z.record(z.unknown()).optional(),
@@ -126,6 +132,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     sandboxTemplate: config.sandboxTemplate,
     setup: config.setup,
     sandbox: config.sandbox ?? CONFIG_DEFAULTS.sandbox,
+    interaction: config.interaction,
     editPrompt: config.editPrompt,
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
     agentOptions: config.agentOptions,

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -67,6 +67,7 @@ describe('computeFingerprint', () => {
     expect(fp1).not.toBe(fp2);
   });
 
+
   it('changes when sandbox template key changes', () => {
     const evalDir = createEvalDir('eval-template', {
       'PROMPT.md': 'Do something',
@@ -82,6 +83,22 @@ describe('computeFingerprint', () => {
     const fp2 = computeFingerprint(evalDir, {
       ...baseConfig,
       sandboxTemplate: { key: 'deps-v2', prepare },
+    });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('changes when natural interaction is configured', () => {
+    const evalDir = createEvalDir('eval-interaction', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, {
+      ...baseConfig,
+      interaction: { maxTurns: 2, respond: () => null },
     });
 
     expect(fp1).not.toBe(fp2);

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -24,7 +24,11 @@ interface FingerprintableConfig {
   runs: number;
   webResearch?: boolean;
   judge?: { agent?: string; model: string };
+
   sandboxTemplate?: { key: string };
+
+  interaction?: { maxTurns: number };
+
 }
 
 /**
@@ -119,8 +123,12 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   if (config.judge) {
     configForHash.judge = { agent: config.judge.agent, model: config.judge.model };
   }
+
   if (config.sandboxTemplate) {
     configForHash.sandboxTemplate = { key: config.sandboxTemplate.key };
+  }
+  if (config.interaction) {
+    configForHash.interaction = { maxTurns: config.interaction.maxTurns ?? 3 };
   }
   hash.update(`config:${JSON.stringify(configForHash)}`);
 

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -67,6 +67,22 @@ describe('results utilities', () => {
       expect(runData.result.modelRepair).toBe('gpt-5.6-sol');
     });
 
+    it('preserves natural interaction history', () => {
+      const turns = [
+        { turn: 1, result: { text: 'Which region?' }, userResponse: 'Use iad1.' },
+        { turn: 2, result: { text: 'Done.' } },
+      ];
+      const runData = agentResultToEvalRunData({
+        success: true,
+        output: 'Done.',
+        duration: 100,
+        interaction: { turns },
+      });
+
+      expect(runData.interaction).toEqual({ turns });
+      expect(runData.result.interaction).toEqual({ turns });
+    });
+
     it('converts failed agent result', () => {
       const agentResult: AgentRunResult = {
         success: false,

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -65,6 +65,9 @@ export function agentResultToEvalRunData(
 	if (agentResult.modelRepair) {
 		result.modelRepair = agentResult.modelRepair;
 	}
+	if (agentResult.interaction) {
+		result.interaction = agentResult.interaction;
+	}
 
 	return {
 		result,
@@ -73,6 +76,7 @@ export function agentResultToEvalRunData(
 			Object.keys(outputContent).length > 0 ? outputContent : undefined,
 		generatedFiles: agentResult.generatedFiles,
 		deletedFiles: agentResult.deletedFiles,
+		interaction: agentResult.interaction,
 	};
 }
 

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -553,6 +553,8 @@ describe('runExperiment', () => {
         fixture: fixtures[0],
         experimentConfig: config,
         setup: mockSetup,
+        interaction: undefined,
+        runIndex: 0,
         scripts: ['build', 'lint'],
         validation: undefined,
         signal: expect.any(AbortSignal), // Signal always passed for timeout cleanup
@@ -560,6 +562,82 @@ describe('runExperiment', () => {
         agentOptions: undefined,
         webResearch: undefined,
       });
+    });
+
+    it('fails clearly when interaction is configured for a one-shot agent', async () => {
+      const mockAgent = {
+        name: 'one-shot-agent',
+        displayName: 'One-shot Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn(),
+      } as unknown as Agent;
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+
+      const results = await runExperiment({
+        config: {
+          agent: 'one-shot-agent',
+          model: 'model',
+          evals: '*',
+          runs: 1,
+          earlyExit: false,
+          scripts: [],
+          timeout: 600,
+          interaction: { respond: () => null },
+        },
+        fixtures: [{
+          name: 'test-eval',
+          path: '/fake/path',
+          prompt: 'prompt',
+          isModule: true,
+        }],
+        apiKey: 'key',
+        resultsDir: TEST_DIR,
+        experimentName: 'interaction-unsupported',
+      });
+
+      expect(mockAgent.run).not.toHaveBeenCalled();
+      expect(results.evals[0].runs[0].result.error).toContain(
+        'does not support natural multi-turn interaction'
+      );
+    });
+
+    it('forwards interaction and run context to a capable agent', async () => {
+      const run = vi.fn().mockResolvedValue({ success: true, output: 'done', duration: 1 });
+      const mockAgent = {
+        name: 'multi-turn-agent',
+        displayName: 'Multi-turn Agent',
+        capabilities: { naturalMultiTurn: true },
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run,
+      } as unknown as Agent;
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+      const fixture = { name: 'test-eval', path: '/fake/path', prompt: 'prompt', isModule: true };
+      const interaction = { maxTurns: 2, respond: () => null };
+
+      await runExperiment({
+        config: {
+          agent: 'multi-turn-agent',
+          model: 'model',
+          evals: '*',
+          runs: 1,
+          earlyExit: false,
+          scripts: [],
+          timeout: 600,
+          interaction,
+        },
+        fixtures: [fixture],
+        apiKey: 'key',
+        resultsDir: TEST_DIR,
+        experimentName: 'interaction-supported',
+      });
+
+      expect(run).toHaveBeenCalledWith('/fake/path', expect.objectContaining({
+        interaction,
+        fixture,
+        runIndex: 0,
+      }));
     });
 
     it('forwards webResearch to agent.run when set', async () => {

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -181,6 +181,20 @@ export async function runExperiment(
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
+    if (config.interaction && !agent.capabilities?.naturalMultiTurn) {
+      return {
+        fixtureName: fixture.name,
+        runIndex,
+        runData: {
+          result: {
+            status: 'failed',
+            error: `Agent "${agent.name}" does not support natural multi-turn interaction.`,
+            duration: 0,
+          },
+        },
+      };
+    }
+
     const modelPolicy = config.modelPolicy ?? 'agent-default';
     const requestedModel = modelPolicy === 'native-default' ? undefined : config.model;
     const agentResult = await Promise.race([
@@ -194,6 +208,8 @@ export async function runExperiment(
         fixture,
         experimentConfig: config,
         setup: config.setup,
+        interaction: config.interaction,
+        runIndex,
         scripts: config.scripts,
         validation: config.validation,
         signal: attemptController.signal,
@@ -282,7 +298,8 @@ export async function runExperiment(
         !result.aborted &&
         result.runData.result.status === 'failed' &&
         result.runData.result.duration < ANOMALY_THRESHOLD_S &&
-        !result.runData.result.error?.includes('timed out');
+        !result.runData.result.error?.includes('timed out') &&
+        !result.runData.result.error?.includes('does not support natural multi-turn interaction');
 
       if (!isSuspiciouslyFast || retry >= MAX_RETRIES) {
         return result;
@@ -389,6 +406,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     apiKey: string;
     sandboxTemplate?: ResolvedExperimentConfig['sandboxTemplate'];
     setup?: ResolvedExperimentConfig['setup'];
+    interaction?: ResolvedExperimentConfig['interaction'];
     scripts?: string[];
     validation?: ResolvedExperimentConfig['validation'];
     sandbox?: ResolvedExperimentConfig['sandbox'];
@@ -400,6 +418,9 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
+  if (options.interaction && !agent.capabilities?.naturalMultiTurn) {
+    throw new Error(`Agent "${agent.name}" does not support natural multi-turn interaction.`);
+  }
 
   const models: string[] = Array.isArray(options.model) ? options.model : [options.model];
   const prompt = options.editPrompt ? options.editPrompt(fixture.prompt) : fixture.prompt;
@@ -431,6 +452,8 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 			copyFiles: 'none',
 		},
 		setup: options.setup,
+		interaction: options.interaction,
+		runIndex: 0,
 		scripts: options.scripts,
 		validation: options.validation,
 		sandbox: options.sandbox,

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -45,6 +45,44 @@ export type EvalFilter = (name: string) => boolean;
 
 export type ValidationMode = 'vitest' | 'none';
 
+/** Minimal result shared by AI SDK and HarnessAgent completed turns. */
+export interface CompletedTurnResult {
+  text: string;
+  [key: string]: unknown;
+}
+
+export interface InteractionTurn<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  turn: number;
+  result: TResult;
+  userResponse?: string;
+}
+
+export interface InteractionContext<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  /** One-based number of the completed assistant turn. */
+  turn: number;
+  /** The completed generate result. The original object is passed through. */
+  result: TResult;
+  /** Previous completed turns plus the current turn. */
+  history: readonly InteractionTurn<TResult>[];
+  fixture: EvalFixture;
+  runIndex: number;
+}
+
+export interface InteractionConfig<
+  TResult extends CompletedTurnResult = CompletedTurnResult,
+> {
+  /** Maximum assistant turns, including the initial turn. @default 3 */
+  maxTurns?: number;
+  /** Return the next user prompt, or null to finish and begin validation. */
+  respond(
+    context: InteractionContext<TResult>
+  ): string | null | Promise<string | null>;
+}
+
 export interface BrandConfig {
   id?: string;
   name: string;
@@ -152,6 +190,10 @@ export interface ExperimentConfig {
   /** Sandbox backend to use. @default 'auto' (Vercel if token present, else Docker) */
   sandbox?: SandboxBackend | 'auto';
 
+  /** Continue natural completed turns with simulated user responses. Registered
+   * agents opt into this by consuming `AgentRunOptions.interaction`. @default undefined */
+  interaction?: InteractionConfig;
+
   /** Optional function to modify the prompt before running the experiment. @default undefined */
   editPrompt?: (prompt: string) => string;
 
@@ -198,6 +240,7 @@ export interface ResolvedExperimentConfig {
   sandboxTemplate?: SandboxTemplate;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
+  interaction?: InteractionConfig;
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
@@ -223,6 +266,7 @@ export interface RunnableExperimentConfig {
   sandboxTemplate?: SandboxTemplate;
   setup?: SetupFunction;
   sandbox: SandboxBackend | 'auto';
+  interaction?: InteractionConfig;
   editPrompt?: (prompt: string) => string;
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
@@ -294,6 +338,8 @@ export interface EvalRunResult {
   analysis?: Record<string, unknown>;
   /** Optional user-defined metadata attached by post-run hooks */
   metadata?: Record<string, unknown>;
+  /** Natural completed turns and simulated user responses. */
+  interaction?: { turns: InteractionTurn[] };
 }
 
 /**
@@ -315,6 +361,8 @@ export interface EvalRunData {
   generatedFiles?: Record<string, string>;
   /** Files deleted by the agent. Used for copyFiles option. */
   deletedFiles?: string[];
+  /** Natural completed turns and simulated user responses. */
+  interaction?: { turns: InteractionTurn[] };
 }
 
 /**


### PR DESCRIPTION
Supersedes #180 with an organization-owned stacked branch.\n\nDepends on the reusable sandbox template PR. Adds natural completed-turn interaction for capable registered agents without introducing a new event protocol.