### PR TITLE
Redact run credentials from agent run results

### DIFF
--- a/.changeset/quiet-moons-redact.md
+++ b/.changeset/quiet-moons-redact.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Redact run credentials from agent run results. Agents configured through a file we write into the sandbox (opencode's `opencode.json`, codex's TOML) carry the live API key in the agent's cwd, so models read it while orienting and the value lands in the transcript — which consumers commit. Every text-bearing field of `AgentRunResult` (output, transcript, error, test and script output, generated file contents) is now scrubbed on the way out of a run. Redaction is exact-string against the key the framework injected, and happens after the in-sandbox judge reads the transcript so scoring is unaffected.

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -38,6 +38,7 @@ import {
   JUDGE_CONFIG_PATH,
   JUDGE_RUNNER_PATH,
 } from '../shared.js';
+import { redactRunResult } from '../redact.js';
 import { getAgent } from '../registry.js';
 import type { AgentDefinition, AgentRunInput, RunnerResult } from './contract.js';
 
@@ -226,8 +227,36 @@ async function readRunnerResult(
 /**
  * The shared host-side run(). Each agent's createXxxAgent() wires this up with its
  * definition; the public Agent interface is unchanged, so runner.ts is untouched.
+ *
+ * Thin wrapper over {@link runOnce} that strips the run's credentials from the
+ * result. It wraps rather than patching each `return` because runOnce has eight of
+ * them and a ninth added later must not be able to leak by omission. See redact.ts
+ * for why this happens on the way out instead of before the judge reads the
+ * transcript.
  */
 export async function runWithDefinition(
+  def: AgentDefinition,
+  fixturePath: string,
+  options: AgentRunOptions
+): Promise<AgentRunResult> {
+  const result = await runOnce(def, fixturePath, options);
+
+  // A judge pinned to a different agent authenticates with its own key, and it can
+  // reach the transcript too, so redact both. Resolving the judge can throw (an
+  // unregistered agent, a missing runner file) — that is the run's failure to
+  // report, not redaction's, so fall back to the codegen key rather than turning it
+  // into a throw on a path that previously returned a result.
+  let judgeApiKey: string | undefined;
+  try {
+    judgeApiKey = resolveJudgeRuntime(def, options).judgeOptions.apiKey;
+  } catch {
+    judgeApiKey = undefined;
+  }
+
+  return redactRunResult(result, [options.apiKey, judgeApiKey]);
+}
+
+async function runOnce(
   def: AgentDefinition,
   fixturePath: string,
   options: AgentRunOptions

--- a/packages/agent-eval/src/lib/agents/redact.test.ts
+++ b/packages/agent-eval/src/lib/agents/redact.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { REDACTED, redactRunResult, redactSecrets } from './redact.js';
+import type { AgentRunResult } from './types.js';
+
+// Shaped like the real leak: an OIDC token the framework wrote into opencode.json
+// at provider.vercel.options.apiKey, which the agent then read.
+const TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL29pZGMudmVyY2VsLmNvbSJ9.c2lnbmF0dXJlLWJ5dGVz';
+
+describe('redactSecrets', () => {
+  it('replaces every occurrence of the secret', () => {
+    const text = `apiKey: ${TOKEN}, again: ${TOKEN}`;
+
+    expect(redactSecrets(text, [TOKEN])).toBe(`apiKey: ${REDACTED}, again: ${REDACTED}`);
+  });
+
+  it('leaves text alone when the secret is absent', () => {
+    expect(redactSecrets('nothing to see', [TOKEN])).toBe('nothing to see');
+  });
+
+  it('treats the secret as literal text, not a pattern', () => {
+    // A regex-based implementation would read `.` and `+` as metacharacters and
+    // either over-match or throw.
+    const secret = 'a.b+c[d]e(f)g*h$i^j{k}l|m'.repeat(2);
+
+    expect(redactSecrets(`x ${secret} y`, [secret])).toBe(`x ${REDACTED} y`);
+    expect(redactSecrets('x aXbXc y', [secret])).toBe('x aXbXc y');
+  });
+
+  it('ignores empty and short secrets rather than shredding the text', () => {
+    // An unset apiKey is '', and replacing '' would corrupt every position.
+    expect(redactSecrets('keep me intact', ['', undefined, 'short'])).toBe('keep me intact');
+  });
+
+  it('redacts a secret that contains another secret whole', () => {
+    const inner = 'inner-secret-value-0123';
+    const outer = `${inner}-plus-more-suffix`;
+
+    // Longest-first ordering: the outer must not be left as `[REDACTED]-plus-more-suffix`.
+    expect(redactSecrets(`v=${outer}`, [inner, outer])).toBe(`v=${REDACTED}`);
+  });
+});
+
+describe('redactRunResult', () => {
+  const base: AgentRunResult = {
+    success: true,
+    output: `wrote apiKey ${TOKEN}`,
+    transcript: `{"tool":"read","output":"apiKey: ${TOKEN}"}`,
+    error: `auth failed for ${TOKEN}`,
+    duration: 1234,
+    testResult: { success: true, output: `env had ${TOKEN}` },
+    scriptsResults: { build: { success: true, output: `build saw ${TOKEN}` } },
+    generatedFiles: { 'copy.json': `{"apiKey":"${TOKEN}"}` },
+    deletedFiles: ['old.ts'],
+    sandboxId: 'sbx_123',
+    observedModel: 'vercel/xai/grok-4.6',
+  };
+
+  it('redacts every text-bearing field', () => {
+    const result = redactRunResult(base, [TOKEN]);
+
+    expect(result.output).toBe(`wrote apiKey ${REDACTED}`);
+    expect(result.transcript).toBe(`{"tool":"read","output":"apiKey: ${REDACTED}"}`);
+    expect(result.error).toBe(`auth failed for ${REDACTED}`);
+    expect(result.testResult?.output).toBe(`env had ${REDACTED}`);
+    expect(result.scriptsResults?.build.output).toBe(`build saw ${REDACTED}`);
+    expect(result.generatedFiles?.['copy.json']).toBe(`{"apiKey":"${REDACTED}"}`);
+  });
+
+  it('leaves the whole result free of the secret', () => {
+    expect(JSON.stringify(redactRunResult(base, [TOKEN]))).not.toContain(TOKEN);
+  });
+
+  it('passes non-text fields through untouched', () => {
+    const result = redactRunResult(base, [TOKEN]);
+
+    expect(result.success).toBe(true);
+    expect(result.duration).toBe(1234);
+    expect(result.sandboxId).toBe('sbx_123');
+    expect(result.observedModel).toBe('vercel/xai/grok-4.6');
+    expect(result.deletedFiles).toEqual(['old.ts']);
+    expect(result.testResult?.success).toBe(true);
+  });
+
+  it('does not mutate the input', () => {
+    const input = structuredClone(base);
+    redactRunResult(input, [TOKEN]);
+
+    expect(input).toEqual(base);
+  });
+
+  it('preserves optional fields as absent rather than undefined', () => {
+    const minimal: AgentRunResult = { success: false, output: TOKEN, duration: 0 };
+    const result = redactRunResult(minimal, [TOKEN]);
+
+    expect(result.output).toBe(REDACTED);
+    expect('transcript' in result).toBe(false);
+    expect('error' in result).toBe(false);
+    expect('testResult' in result).toBe(false);
+  });
+
+  it('returns the result as-is when there is no usable secret', () => {
+    const result = redactRunResult(base, ['', undefined]);
+
+    expect(result).toBe(base);
+  });
+
+  it('redacts the judge key as well as the codegen key', () => {
+    const judgeToken = 'judge-token-value-abcdefghij';
+    const withBoth: AgentRunResult = {
+      success: true,
+      output: `codegen ${TOKEN} judge ${judgeToken}`,
+      duration: 0,
+    };
+
+    expect(redactRunResult(withBoth, [TOKEN, judgeToken]).output).toBe(
+      `codegen ${REDACTED} judge ${REDACTED}`
+    );
+  });
+});

--- a/packages/agent-eval/src/lib/agents/redact.ts
+++ b/packages/agent-eval/src/lib/agents/redact.ts
@@ -1,0 +1,117 @@
+/**
+ * Redaction of run credentials from everything a run hands back to the host.
+ *
+ * Why this is needed: several agents are configured through a file we write into
+ * the sandbox with the live credential in it (opencode's `opencode.json` carries
+ * it at `provider.vercel.options.apiKey`; codex's TOML is the same shape). Those
+ * files sit in the agent's cwd, so models read them as a matter of course while
+ * orienting, and the read lands in the transcript. Consumers commit transcripts,
+ * so without this the credential ends up in their repo — which is how it was
+ * found: a public repo tripped secret scanning on a transcript.
+ *
+ * This runs at the host boundary, on the way out of a run, NOT before the judge
+ * sees the transcript. That is deliberate. The judge runs inside the sandbox,
+ * where the credential is present anyway, and rewriting the transcript before it
+ * is judged would change what the judge reads and therefore the score. Redacting
+ * on the way out keeps in-sandbox behavior byte-identical and only affects what
+ * the host persists.
+ *
+ * Matching is exact-string, not pattern-based. The framework knows the precise
+ * value it injected, so there is nothing to infer and no false positives — a
+ * pattern would have to guess, and credential-shaped substrings do occur in
+ * transcripts (the agents' own `ses_…` session IDs contain base64url runs that a
+ * JWT prefix match flags). The tradeoff is that a credential the framework never
+ * saw is not covered: if a run refreshes its own token mid-flight, only the value
+ * we started with is redacted.
+ */
+import type { AgentRunResult, ScriptResult } from './types.js';
+
+export const REDACTED = '[REDACTED]';
+
+/**
+ * Below this length a "secret" is not treated as one. A short or empty value
+ * would match incidental text everywhere and shred the transcript, which is a
+ * worse failure than not redacting — an unset apiKey is '' and would otherwise
+ * replace every empty string in the output.
+ */
+const MIN_SECRET_LENGTH = 16;
+
+/** Usable secrets, deduped and ordered longest-first so overlaps redact whole. */
+function usableSecrets(secrets: readonly (string | undefined)[]): string[] {
+  const seen = new Set<string>();
+  for (const s of secrets) {
+    if (s && s.length >= MIN_SECRET_LENGTH) seen.add(s);
+  }
+  return [...seen].sort((a, b) => b.length - a.length);
+}
+
+/** Replace every occurrence of each secret with {@link REDACTED}. */
+export function redactSecrets(
+  text: string,
+  secrets: readonly (string | undefined)[]
+): string {
+  let out = text;
+  for (const secret of usableSecrets(secrets)) {
+    // split/join rather than RegExp: the secret is arbitrary text and must not be
+    // interpreted as a pattern.
+    out = out.split(secret).join(REDACTED);
+  }
+  return out;
+}
+
+function redactScriptResult(
+  result: ScriptResult,
+  secrets: readonly (string | undefined)[]
+): ScriptResult {
+  return { ...result, output: redactSecrets(result.output, secrets) };
+}
+
+/**
+ * Redact every text-bearing field of a run result. Returns a new object; the
+ * input is not mutated.
+ *
+ * Covers what gets persisted or shown: the agent's stdout/stderr, the transcript,
+ * the error message, the test and script outputs, and the contents of generated
+ * files (an agent that copies its config into a new file would otherwise smuggle
+ * the credential past the transcript check). Non-text fields — durations, ids,
+ * model names, deleted-file paths — are passed through untouched.
+ */
+export function redactRunResult(
+  result: AgentRunResult,
+  secrets: readonly (string | undefined)[]
+): AgentRunResult {
+  if (usableSecrets(secrets).length === 0) return result;
+
+  const redacted: AgentRunResult = {
+    ...result,
+    output: redactSecrets(result.output, secrets),
+  };
+
+  if (result.transcript !== undefined) {
+    redacted.transcript = redactSecrets(result.transcript, secrets);
+  }
+  if (result.error !== undefined) {
+    redacted.error = redactSecrets(result.error, secrets);
+  }
+  if (result.testResult) {
+    redacted.testResult = redactScriptResult(result.testResult, secrets);
+  }
+  if (result.scriptsResults) {
+    redacted.scriptsResults = Object.fromEntries(
+      Object.entries(result.scriptsResults).map(([name, script]) => [
+        name,
+        redactScriptResult(script, secrets),
+      ])
+    );
+  }
+  if (result.generatedFiles) {
+    redacted.generatedFiles = Object.fromEntries(
+      Object.entries(result.generatedFiles).map(([path, content]) => [
+        path,
+        redactSecrets(content, secrets),
+      ])
+    );
+  }
+
+  return redacted;
+}


### PR DESCRIPTION
Agents configured through a file we write into the sandbox carry the live credential in the agent's cwd: opencode's `opencode.json` holds it at `provider.vercel.options.apiKey`, and codex's TOML is the same shape. Models read those files as a matter of course while orienting, the read lands in the transcript, and consumers commit transcripts — so the credential ends up in their repo.

That is not hypothetical. It is how this was found: [vercel/next-evals-oss](https://github.com/vercel/next-evals-oss) is public and tripped secret scanning on a committed transcript. Sweeping that repo turned up **287 occurrences of 5 distinct credentials across 82 files in 8 experiments**, going back ten weeks (the scrub is [vercel/next-evals-oss#108](https://github.com/vercel/next-evals-oss/pull/108)).

All 5 were Vercel OIDC tokens with a 12-hour TTL and all had expired, so that exposure was limited. But nothing about the mechanism guarantees that: a consumer authenticating with a long-lived Gateway key would have published a live credential.

## What this does

Adds `redactRunResult`, applied at the host boundary in the plugin orchestrator, over every text-bearing field of `AgentRunResult`: `output`, `transcript`, `error`, test and script output, and generated file contents. Generated files are included because an agent that copies its config into a new file would otherwise route around a transcript-only check.

## Three choices worth reviewing

**Exact-string matching, not patterns.** The framework knows the precise value it injected, so there is nothing to infer and no false positives. A pattern would have to guess, and credential-shaped substrings genuinely occur in transcripts — the agents' own `ses_…` session IDs contain base64url runs that a JWT prefix match flags as secrets. The tradeoff: a credential the framework never saw is not covered, so if a run refreshes its own token mid-flight, only the value we started with is redacted.

**On the way out, not before the judge.** The judge runs inside the sandbox where the credential is present anyway, and rewriting the transcript before it is judged would change what the judge reads and therefore the score. Redacting at the boundary keeps in-sandbox behavior byte-identical and only changes what the host persists.

**Wrapping `runWithDefinition` rather than patching each `return`.** It has eight return paths, and a ninth added later must not be able to leak by omission. The wrapper also redacts a pinned judge's key (which differs from the codegen key when the judge is pinned to another agent), and tolerates judge resolution throwing — an unregistered agent or missing runner file is the run's error to report, not redaction's, so it must not become a throw on a path that previously returned a result.

There is also a guard against short or empty secrets: an unset `apiKey` is `''`, and replacing that would shred the transcript, which is a worse failure than not redacting.

## Verification

- 12 new unit tests in `redact.test.ts`; full agents suite green (94 tests).
- `tsc --noEmit` and `eslint` clean.
- Full suite: 291 passed. 7 pre-existing environmental failures (6 `docker-sandbox` needing `/var/run/docker.sock`, 1 `init` running `npx tsc` in a scaffolded temp project) — confirmed identical on `main` with this change fully reverted, so they are not from this PR.
- Cross-validated on the real leaked data: this redaction applied to the pre-scrub transcript from the flagged commit targets **byte-identical ranges** to the manual scrub in vercel/next-evals-oss#108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
