### PR TITLE
Add opt-in agent runtime controls

### DIFF
--- a/.changeset/clean-agent-research.md
+++ b/.changeset/clean-agent-research.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add opt-in isolation for agent-bundled skills and update Codex web research to use its current live-search configuration and CLI flag. Opt-in runtime compatibility is stored separately so cached legacy research results are not silently carried forward.

--- a/README.md
+++ b/README.md
@@ -419,6 +419,30 @@ Results use `modelPolicy: 'native-default'`, `requestedModel` is omitted, and
 `observedModel` is populated when the agent CLI exposes the runtime model in its
 transcript or logs. Provide `model` to force a specific model.
 
+### Opt-in runtime controls
+
+Agent Eval preserves each agent CLI's normal behavior by default. Recommendation
+and controlled-treatment evals can opt into a narrower runtime:
+
+```typescript
+const config: ExperimentConfig = {
+  agent: 'vercel-ai-gateway/claude-code',
+  disableBundledSkills: true,
+  webResearch: true,
+};
+```
+
+`disableBundledSkills` disables skills shipped by Claude Code or Codex while
+leaving caller-installed project and user skills available. OpenCode does not
+ship a bundled skill catalog, so this option does not change its runtime. The
+option is omitted by default, preserving existing arguments and agent behavior.
+Other built-in agents reject this option until they expose an equivalent control.
+
+`webResearch` remains opt-in. It allows Claude Code's `WebSearch`/`WebFetch`,
+enables Codex live search (including custom AI Gateway providers), and enables
+OpenCode's Exa-backed `websearch`/`webfetch` tools. Whether an agent chooses to
+use an available research tool remains part of the measured behavior.
+
 ### OpenCode model format
 
 OpenCode uses Vercel AI Gateway exclusively. The OpenCode CLI reads models as
@@ -604,7 +628,7 @@ Files are saved to `results/<experiment>/<timestamp>/<eval>/run-N/project/`. The
 
 ## Result Reuse
 
-The framework computes a SHA-256 fingerprint for each (eval, config) pair. The fingerprint covers all eval directory files and the config fields that affect results: `agent`, `model`, `scripts`, `timeout`, `earlyExit`, and `runs`.
+The framework computes a SHA-256 fingerprint for each (eval, config) pair. The fingerprint covers all eval directory files and result-affecting config including `agent`, `model`, `scripts`, `timeout`, `earlyExit`, `runs`, `webResearch`, `disableBundledSkills`, and a pinned `judge`.
 
 On subsequent runs, evals with a matching fingerprint and a valid cached result (at least one passing run) are skipped automatically. This means:
 
@@ -627,7 +651,7 @@ agent-eval refingerprint            # all experiments
 agent-eval refingerprint cc --dry   # preview one experiment
 ```
 
-For each cached result it compares the eval's current `contentFingerprint` to the stored one: if the content is unchanged it re-stamps the combined fingerprint (the result stays cached); if the content **changed** it leaves the result stale so it re-runs. `agent-eval status` already classifies by eval *content*, so it never reports a config-only change as work — run `refingerprint` after editing an experiment config to carry that change into the cache (`run` does this automatically).
+For each cached result it compares the eval's current `contentFingerprint` to the stored one: if the content is unchanged it re-stamps the combined fingerprint (the result stays cached); if the content **changed** it leaves the result stale so it re-runs. Opt-in runtime changes such as web research and bundled-skill isolation also store a `reuseCompatibilityFingerprint`; those boundaries are never carried forward. `agent-eval status` reports content or runtime-compatibility changes as work, while benign config-only edits stay cached. Run `refingerprint` after a benign experiment config edit to carry that change into the cache (`run` does this automatically).
 
 ### After changing or syncing evals: status → pick what to run
 

--- a/packages/agent-eval/src/cli.test.ts
+++ b/packages/agent-eval/src/cli.test.ts
@@ -238,6 +238,32 @@ describe('CLI', () => {
       const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
       expect(summary.fingerprint).toBe('STALE_COMBINED'); // unchanged under --dry
     });
+
+    it('does not carry legacy results across a runtime compatibility boundary', () => {
+      const { projectDir, evalPath, summaryPath } = setupProject();
+      writeFileSync(
+        join(projectDir, 'experiments', 'cc.ts'),
+        `export default { agent: 'vercel-ai-gateway/codex', model: 'openai/gpt-5.2-codex', webResearch: true };`
+      );
+      writeFileSync(
+        summaryPath,
+        JSON.stringify({
+          totalRuns: 1,
+          passedRuns: 1,
+          passRate: '100%',
+          meanDuration: 1,
+          fingerprint: 'LEGACY_RESEARCH',
+          contentFingerprint: computeContentFingerprint(evalPath),
+        })
+      );
+
+      const r = runCli(['refingerprint'], projectDir);
+      expect(r.exitCode).toBe(0);
+      const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
+      expect(summary.fingerprint).toBe('LEGACY_RESEARCH');
+      expect(r.stdout).toContain('left stale');
+      expect(runCli(['status', '--check'], projectDir).exitCode).toBe(1);
+    });
   });
 
   describe('staleness flow (status / refingerprint / --check / --json)', () => {

--- a/packages/agent-eval/src/cli.ts
+++ b/packages/agent-eval/src/cli.ts
@@ -20,7 +20,12 @@ import { initProject, getPostInitInstructions } from './lib/init.js';
 import { getAgent } from './lib/agents/index.js';
 import { resolveAgentApiKey } from './lib/agents/shared.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
-import { computeFingerprint, computeContentFingerprint, decideRefingerprint } from './lib/fingerprint.js';
+import {
+  computeFingerprint,
+  computeContentFingerprint,
+  computeReuseCompatibilityFingerprint,
+  decideRefingerprint,
+} from './lib/fingerprint.js';
 import { scanReusableResults } from './lib/results.js';
 import { isClassifierEnabled, classifyFailure } from './lib/classifier.js';
 import { housekeep } from './lib/housekeeping.js';
@@ -404,6 +409,7 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
             model,
             runs: options.smoke ? 1 : config.runs,
           };
+          const reuseCompatibilityFingerprint = computeReuseCompatibilityFingerprint(modelConfig);
 
           const selectedFixtures = fixtures.filter((f) => evalNames.includes(f.name));
           const fingerprints: Record<string, string> = {};
@@ -418,7 +424,10 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
           // Scan for reusable (fresh) results.
           let fixturesToRun = selectedFixtures;
           if (!options.force && !options.smoke) {
-            const reusable = scanReusableResults(resultsDir, experimentName, fingerprints);
+            const reusable = scanReusableResults(resultsDir, experimentName, fingerprints, {
+              enforceReuseCompatibility: true,
+              reuseCompatibilityFingerprint,
+            });
             if (reusable.size > 0) {
               fixturesToRun = selectedFixtures.filter((f) => !reusable.has(f.name));
             }
@@ -578,7 +587,10 @@ async function runAllCommand(experimentArgs: string[], options: { dry?: boolean;
           }
 
           // Determine final pass/fail for this experiment+model
-          const finalReusable = scanReusableResults(resultsDir, experimentName, fingerprints);
+          const finalReusable = scanReusableResults(resultsDir, experimentName, fingerprints, {
+            enforceReuseCompatibility: true,
+            reuseCompatibilityFingerprint,
+          });
           const experimentPassed = selectedFixtures.every((f) => {
             const r = finalReusable.get(f.name);
             return r != null && r.passRate !== '0%';
@@ -719,11 +731,13 @@ async function statusCommand(
         }
         const content = computeContentFingerprint(fx.path);
         const storedContent = summary.contentFingerprint as string | undefined;
+        const reuseCompatibilityFingerprint = computeReuseCompatibilityFingerprint(modelConfig as never);
+        const reuseCompatible = summary.reuseCompatibilityFingerprint === reuseCompatibilityFingerprint;
         // Content-based: a config-only change isn't work (refingerprint carries it).
         // Legacy results (no content hash) fall back to the combined fingerprint.
-        const fresh = storedContent !== undefined
+        const fresh = reuseCompatible && (storedContent !== undefined
           ? storedContent === content
-          : summary.fingerprint === computeFingerprint(fx.path, modelConfig as never);
+          : summary.fingerprint === computeFingerprint(fx.path, modelConfig as never));
         if (fresh) cached++;
         else {
           changedEvals.push(ev);
@@ -822,10 +836,15 @@ async function carryForwardConfigChanges(
           if (!existsSync(summaryPath) || !existsSync(evalPath)) continue;
           const summary = JSON.parse(readFileSync(summaryPath, 'utf-8'));
           const decision = decideRefingerprint(
-            { fingerprint: summary.fingerprint, contentFingerprint: summary.contentFingerprint },
+            {
+              fingerprint: summary.fingerprint,
+              contentFingerprint: summary.contentFingerprint,
+              reuseCompatibilityFingerprint: summary.reuseCompatibilityFingerprint,
+            },
             {
               fingerprint: computeFingerprint(evalPath, modelConfig as never),
               contentFingerprint: computeContentFingerprint(evalPath),
+              reuseCompatibilityFingerprint: computeReuseCompatibilityFingerprint(modelConfig as never),
             }
           );
           let changed = false;

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -90,7 +90,7 @@ export type { Agent, ScriptResult } from './lib/agents/types.js';
 export { getAgent, listAgents, registerAgent } from './lib/agents/index.js';
 
 // Re-export results utilities
-export type { SaveResultsOptions, ReusableResult } from './lib/results.js';
+export type { SaveResultsOptions, ReusableResult, ReuseScanOptions } from './lib/results.js';
 export {
   agentResultToEvalRunData,
   createEvalSummary,
@@ -103,7 +103,7 @@ export {
 } from './lib/results.js';
 
 // Re-export fingerprinting
-export { computeFingerprint } from './lib/fingerprint.js';
+export { computeFingerprint, computeReuseCompatibilityFingerprint } from './lib/fingerprint.js';
 
 // Re-export classifier
 export {

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -16,6 +16,7 @@ import { runSingleEval } from './lib/runner.js';
 import { loadConfig } from './lib/config.js';
 import { getSandboxBackendInfo } from './lib/sandbox.js';
 import { registerAgent } from './lib/agents/index.js';
+import { parseTranscript } from './lib/o11y/index.js';
 import type { Agent } from './lib/agents/types.js';
 import type { AgentDefinition } from './lib/agents/plugin/contract.js';
 
@@ -183,6 +184,40 @@ describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
   });
 
   describe.skipIf(!hasAiGatewayCredentials)('Claude Code (Vercel AI Gateway) sandbox execution', () => {
+    it('can opt out of Claude Code bundled skills', async () => {
+      const fixtureDir = join(TEST_DIR, 'claude-no-bundled-skills');
+      mkdirSync(fixtureDir, { recursive: true });
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Do not inspect or modify files. Reply with exactly: OK'
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'claude-no-bundled-skills', type: 'module' })
+      );
+
+      const fixture = loadFixture(TEST_DIR, 'claude-no-bundled-skills', {
+        validation: 'none',
+      });
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/claude-code',
+        model: 'sonnet',
+        timeout: 120,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: [],
+        validation: 'none',
+        disableBundledSkills: true,
+      });
+
+      if (result.result.status === 'failed') {
+        console.error('Claude bundled-skills isolation failed:', result.result.error);
+      }
+      expect(result.result.status).toBe('passed');
+      expect(result.transcript).toBeDefined();
+      expect(result.transcript).not.toContain('"type":"skill_listing"');
+      expect(result.transcript).not.toContain('claude-api');
+    }, 300000);
+
     it('surfaces CLI error when invalid model is provided', async () => {
       // Create a simple test fixture
       const fixtureDir = join(TEST_DIR, 'invalid-model-claude');
@@ -546,6 +581,41 @@ test('greet exists', () => {
   });
 
   describe.skipIf(!hasAiGatewayCredentials)('Codex (Vercel AI Gateway) sandbox execution', () => {
+    it('uses live web search through the AI Gateway when enabled', async () => {
+      const fixtureDir = join(TEST_DIR, 'codex-web-research');
+      mkdirSync(fixtureDir, { recursive: true });
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Use the web search tool, not shell commands, to find the official Vercel AI Gateway documentation. Return one source URL.'
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'codex-web-research', type: 'module' })
+      );
+
+      const fixture = loadFixture(TEST_DIR, 'codex-web-research', {
+        validation: 'none',
+      });
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/codex',
+        model: 'openai/gpt-5.6-sol',
+        timeout: 120,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: [],
+        validation: 'none',
+        webResearch: true,
+      });
+
+      if (result.result.status === 'failed') {
+        console.error('Codex web research failed:', result.result.error);
+      }
+      expect(result.result.status).toBe('passed');
+      expect(result.transcript).toBeDefined();
+      const parsed = parseTranscript(result.transcript!, 'codex');
+      expect(parsed.summary.toolCalls.web_search).toBeGreaterThan(0);
+      expect(result.transcript).toMatch(/https?:\/\//);
+    }, 300000);
+
     it('can run a simple eval with Codex', async () => {
       // Create a simple test fixture
       const fixtureDir = join(TEST_DIR, 'simple-eval-codex');

--- a/packages/agent-eval/src/lib/agents/claude-code.test.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code.test.ts
@@ -22,6 +22,24 @@ describe('buildClaudeCodeCliArgs', () => {
     ]);
   });
 
+  it('disables bundled skills only when explicitly requested', () => {
+    const args = buildClaudeCodeCliArgs({
+      ...baseOptions,
+      model: 'opus',
+      disableBundledSkills: true,
+    });
+
+    expect(args).toEqual([
+      '--print',
+      '--settings',
+      '{"disableBundledSkills":true}',
+      '--model',
+      'opus',
+      '--dangerously-skip-permissions',
+      'where should this run?',
+    ]);
+  });
+
   it('allows web tools as a single comma-separated --allowedTools value', () => {
     const args = buildClaudeCodeCliArgs({ ...baseOptions, model: 'opus', webResearch: true });
     expect(args).toEqual([

--- a/packages/agent-eval/src/lib/agents/claude-code/agent.ts
+++ b/packages/agent-eval/src/lib/agents/claude-code/agent.ts
@@ -30,6 +30,7 @@ export function createClaudeCodeDefinition({ useVercelAiGateway }: { useVercelAi
     displayName: useVercelAiGateway ? 'Claude Code (Vercel AI Gateway)' : 'Claude Code',
     defaultModel: 'opus',
     o11yAgentName: 'claude-code',
+    bundledSkillsControl: 'configurable',
     // Resolve run.mjs next to this file (works in src during dev and in dist after
     // the build copies run.mjs alongside the compiled agent.js).
     runnerPath: fileURLToPath(new URL('./run.mjs', import.meta.url)),

--- a/packages/agent-eval/src/lib/agents/claude-code/run.mjs
+++ b/packages/agent-eval/src/lib/agents/claude-code/run.mjs
@@ -35,11 +35,16 @@ import { fileURLToPath } from 'node:url';
  * `--dangerously-skip-permissions` is always emitted and terminates the variadic
  * capture before the trailing positional prompt (the #141 regression).
  *
- * @param {{prompt:string, model?:string, webResearch?:boolean, agentOptions?:Record<string,unknown>}} input
+ * @param {{prompt:string, model?:string, webResearch?:boolean, disableBundledSkills?:boolean, agentOptions?:Record<string,unknown>}} input
  * @returns {string[]}
  */
 export function buildClaudeCodeCliArgs(input) {
   const cliArgs = ['--print'];
+  if (input.disableBundledSkills) {
+    // CLI-scoped settings override only this run and preserve explicitly
+    // installed project/user skills; --bare would hide treatment skills too.
+    cliArgs.push('--settings', JSON.stringify({ disableBundledSkills: true }));
+  }
   if (input.webResearch) {
     cliArgs.push('--allowedTools', 'WebSearch,WebFetch');
   }

--- a/packages/agent-eval/src/lib/agents/codex.test.ts
+++ b/packages/agent-eval/src/lib/agents/codex.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildCodexExecArgs,
   buildModelRepairToml,
+  buildShellCanaryInput,
   buildShellCanaryPrompt,
   extractCodexThreadId,
   extractObservedModelFromCodexSession,
@@ -86,19 +88,66 @@ describe('generateCodexConfig', () => {
   it('omits the tools section by default', () => {
     expect(generateCodexConfig(undefined, true)).not.toContain('[tools]');
     expect(generateCodexConfig(undefined, false)).not.toContain('[tools]');
+    expect(generateCodexConfig(undefined, true)).not.toContain('web_search =');
+    expect(generateCodexConfig(undefined, true)).not.toContain('supports_standalone_web_search');
+    expect(generateCodexConfig(undefined, true)).not.toContain('[skills.bundled]');
   });
 
-  it('enables web_search when webResearch is set', () => {
+  it('enables current live web search when webResearch is set', () => {
     const gatewayConfig = generateCodexConfig(undefined, true, undefined, true);
-    expect(gatewayConfig).toContain('[tools]');
-    expect(gatewayConfig).toContain('web_search = true');
-    // The tools table must come after the provider table's keys so the
-    // provider settings are not absorbed into [tools].
-    expect(gatewayConfig.indexOf('[tools]')).toBeGreaterThan(gatewayConfig.indexOf('wire_api'));
+    expect(gatewayConfig).toContain('web_search = "live"');
+    expect(gatewayConfig).toContain('supports_standalone_web_search = true');
+    expect(gatewayConfig).not.toContain('[tools]');
+    // The top-level setting must precede the provider table or TOML absorbs it
+    // into model_providers.vercel.
+    expect(gatewayConfig.indexOf('web_search = "live"')).toBeLessThan(
+      gatewayConfig.indexOf('[model_providers.vercel]')
+    );
 
     const directConfig = generateCodexConfig(undefined, false, undefined, true);
-    expect(directConfig).toContain('[tools]');
-    expect(directConfig).toContain('web_search = true');
+    expect(directConfig).toContain('web_search = "live"');
+    expect(directConfig).not.toContain('supports_standalone_web_search');
+  });
+
+  it('disables bundled skills only when explicitly requested', () => {
+    const gatewayConfig = generateCodexConfig(undefined, true, undefined, false, true);
+    expect(gatewayConfig).toContain('[skills.bundled]');
+    expect(gatewayConfig).toContain('enabled = false');
+
+    const directConfig = generateCodexConfig(undefined, false, undefined, false, true);
+    expect(directConfig).toContain('[skills.bundled]');
+    expect(directConfig).toContain('enabled = false');
+  });
+});
+
+describe('buildCodexExecArgs', () => {
+  const baseInput = { prompt: 'where should this run?' };
+
+  it('keeps default arguments unchanged', () => {
+    expect(buildCodexExecArgs(baseInput)).toEqual([
+      'exec',
+      '--profile',
+      'default',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--json',
+      '--skip-git-repo-check',
+      'where should this run?',
+    ]);
+  });
+
+  it('passes --search only when webResearch is enabled', () => {
+    const args = buildCodexExecArgs({ ...baseInput, webResearch: true });
+    expect(args).toContain('--search');
+    expect(args).toContain('--strict-config');
+    expect(args.indexOf('--search')).toBeLessThan(args.indexOf('exec'));
+    expect(args[args.length - 1]).toBe(baseInput.prompt);
+  });
+
+  it('strictly validates opt-in bundled skill configuration', () => {
+    const args = buildCodexExecArgs({ ...baseInput, disableBundledSkills: true });
+    expect(args).toContain('--strict-config');
+    expect(args).not.toContain('--search');
+    expect(args.indexOf('--strict-config')).toBeLessThan(args.indexOf('exec'));
   });
 });
 
@@ -129,6 +178,25 @@ describe('codex shell-tool canary (native-default toolless repair)', () => {
     const prompt = buildShellCanaryPrompt(nonce);
     expect(prompt).toContain(`echo ${nonce}`);
     expect(prompt).toContain('NO-SHELL-TOOL');
+  });
+
+  it('keeps opt-in capability flags on canary executions', () => {
+    const input = buildShellCanaryInput(
+      {
+        prompt: 'real task',
+        cwd: '/workspace',
+        resultPath: '/tmp/result.json',
+        webResearch: true,
+        disableBundledSkills: true,
+        extra: { cliModel: null },
+      },
+      nonce,
+    );
+    const args = buildCodexExecArgs(input);
+
+    expect(input.prompt).toContain(nonce);
+    expect(args).toContain('--strict-config');
+    expect(args).toContain('--search');
   });
 
   it('confirms only on a completed command_execution carrying the nonce', () => {

--- a/packages/agent-eval/src/lib/agents/codex/agent.ts
+++ b/packages/agent-eval/src/lib/agents/codex/agent.ts
@@ -80,6 +80,7 @@ function parseOptionsModel(options: AgentRunOptions): { model?: string; reasonin
  */
 const DEFAULT_REASONING_EFFORT = 'medium';
 const DEFAULT_MODEL_VERBOSITY = 'medium';
+const WEB_RESEARCH_PROTOCOL = 'live-v1';
 
 /**
  * Generate Codex profile config content.
@@ -96,33 +97,35 @@ export function generateCodexConfig(
   useVercelAiGateway: boolean,
   reasoningEffort?: string,
   webResearch?: boolean,
+  disableBundledSkills?: boolean,
 ): string {
-  // Opt-in web research. Note: through the AI Gateway (`wire_api =
-  // "responses"`), no `web_search` items have been observed — Codex instead
-  // researches via shell commands when it decides to. The setting is still
-  // written so direct-OpenAI runs and future gateway support pick it up; it
-  // is harmless when the server-side tool is unavailable.
-  const toolsSection = webResearch ? `\n[tools]\nweb_search = true\n` : '';
+  // Codex replaced the legacy boolean [tools].web_search setting with this
+  // top-level mode. Custom providers must also declare standalone support or
+  // the CLI omits the tool before it sends a Responses request.
+  const webSearchSetting = webResearch ? `web_search = "live"\n` : '';
+  const bundledSkillsSection = disableBundledSkills
+    ? `\n[skills.bundled]\nenabled = false\n`
+    : '';
   if (useVercelAiGateway) {
     // AI Gateway uses prefixed model names like "openai/gpt-5.2-codex".
     // Native-default runs intentionally omit model and reasoning overrides.
     const fullModel = model ? (model.includes('/') ? model : `openai/${model}`) : undefined;
     return `# Codex configuration for Vercel AI Gateway
 model_provider = "vercel"
-${fullModel ? `model = "${fullModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}
+${fullModel ? `model = "${fullModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}${webSearchSetting}
 [model_providers.vercel]
 name = "Vercel AI Gateway"
 base_url = "${AI_GATEWAY.openAiBaseUrl}"
 env_key = "${AI_GATEWAY.apiKeyEnvVar}"
 wire_api = "responses"
-${toolsSection}`;
+${webResearch ? 'supports_standalone_web_search = true\n' : ''}${bundledSkillsSection}`;
   } else {
     // Direct OpenAI API — use the built-in "openai" provider (no custom provider needed).
     // Native-default runs intentionally omit model and reasoning overrides.
     const directModel = model ? (model.includes('/') ? model.split('/').pop()! : model) : undefined;
     return `# Direct OpenAI API configuration
 model_provider = "openai"
-${directModel ? `model = "${directModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}${toolsSection}`;
+${directModel ? `model = "${directModel}"\n` : ''}${model ? `model_reasoning_effort = "${reasoningEffort ?? DEFAULT_REASONING_EFFORT}"\nmodel_verbosity = "${DEFAULT_MODEL_VERBOSITY}"\n` : ''}${webSearchSetting}${bundledSkillsSection}`;
   }
 }
 
@@ -141,6 +144,7 @@ export function createCodexDefinition({ useVercelAiGateway }: { useVercelAiGatew
     displayName: useVercelAiGateway ? 'OpenAI Codex (Vercel AI Gateway)' : 'OpenAI Codex',
     defaultModel: 'openai/gpt-5.2-codex',
     o11yAgentName: 'codex',
+    bundledSkillsControl: 'configurable',
     // Resolve run.mjs next to this file (works in src during dev and in dist after
     // the build copies run.mjs alongside the compiled agent.js).
     runnerPath: fileURLToPath(new URL('./run.mjs', import.meta.url)),
@@ -167,7 +171,13 @@ export function createCodexDefinition({ useVercelAiGateway }: { useVercelAiGatew
       // value is visible in saved configs and so the CLI's own default of "low"
       // can't sneak through. For native-default runs we omit these settings.
       const parsed = parseOptionsModel(options);
-      const configContent = generateCodexConfig(parsed.model, useVercelAiGateway, parsed.reasoningEffort, options.webResearch);
+      const configContent = generateCodexConfig(
+        parsed.model,
+        useVercelAiGateway,
+        parsed.reasoningEffort,
+        options.webResearch,
+        options.disableBundledSkills,
+      );
       // Absolute `~` path writeFiles can't target → heredoc via shell. Combines the
       // old `mkdir -p ~/.codex` + `cat > ~/.codex/default.config.toml << 'EOF'`.
       return [
@@ -219,6 +229,12 @@ export function createCodexDefinition({ useVercelAiGateway }: { useVercelAiGatew
         reasoningEffort: reasoningEffort ?? null,
         verbosity: verbosity ?? null,
       };
+    },
+
+    fingerprintExtra(config): Record<string, unknown> | undefined {
+      return config.webResearch
+        ? { webResearchProtocol: WEB_RESEARCH_PROTOCOL }
+        : undefined;
     },
   };
 }

--- a/packages/agent-eval/src/lib/agents/codex/run.mjs
+++ b/packages/agent-eval/src/lib/agents/codex/run.mjs
@@ -192,7 +192,7 @@ export function buildCodexLoginArgs() {
  * literal quotes exactly as the old shell string had them, and the prompt is a
  * plain argv element (no shell escaping needed).
  *
- * @param {{prompt:string, extra?:Record<string,unknown>}} input
+ * @param {{prompt:string, webResearch?:boolean, disableBundledSkills?:boolean, extra?:Record<string,unknown>}} input
  * @returns {string[]}
  */
 export function buildCodexExecArgs(input) {
@@ -201,7 +201,19 @@ export function buildCodexExecArgs(input) {
   const reasoningEffort = extra.reasoningEffort ?? null;
   const verbosity = extra.verbosity ?? null;
 
-  const args = ['exec', '--profile', 'default'];
+  const args = [];
+  if (input.webResearch || input.disableBundledSkills) {
+    // Opt-in capability controls must fail loudly on a CLI version that does
+    // not recognize their generated profile settings.
+    args.push('--strict-config');
+  }
+  if (input.webResearch) {
+    // Current Codex CLI flag; the generated profile also opts the custom
+    // Gateway provider into standalone live search. --search is a global
+    // option and must precede the exec subcommand.
+    args.push('--search');
+  }
+  args.push('exec', '--profile', 'default');
   if (cliModel) {
     args.push('--model', String(cliModel));
   }
@@ -280,6 +292,20 @@ export function buildShellCanaryPrompt(nonce) {
 }
 
 /**
+ * Build the canary input with the same capability flags as the real task.
+ *
+ * @param {import('../plugin/contract.js').AgentRunInput} input
+ * @param {string} nonce
+ * @returns {import('../plugin/contract.js').AgentRunInput}
+ */
+export function buildShellCanaryInput(input, nonce) {
+  return {
+    ...input,
+    prompt: buildShellCanaryPrompt(nonce),
+  };
+}
+
+/**
  * True iff the codex --json stdout proves the shell ran: a completed
  * `command_execution` item with exit_code 0 whose command or aggregated_output
  * contains the nonce. Agent messages containing the nonce do NOT count — a
@@ -339,7 +365,7 @@ export function buildModelRepairToml(observedModel) {
  * @returns {{confirmed: boolean, stdout: string, output: string}}
  */
 function runShellCanary(input, nonce) {
-  const res = spawnSync('codex', buildCodexExecArgs({ prompt: buildShellCanaryPrompt(nonce), extra: input.extra }), {
+  const res = spawnSync('codex', buildCodexExecArgs(buildShellCanaryInput(input, nonce)), {
     cwd: input.cwd,
     env: process.env,
     encoding: 'utf8',

--- a/packages/agent-eval/src/lib/agents/eval-helper.mjs
+++ b/packages/agent-eval/src/lib/agents/eval-helper.mjs
@@ -150,6 +150,7 @@ function runJudge(subject, criterion, opts = {}) {
   const input = {
     prompt: buildJudgePrompt(subject, criterion, verdictPath, opts),
     model: cfg.model ?? undefined,
+    disableBundledSkills: cfg.disableBundledSkills ?? undefined,
     cwd: process.cwd(),
     resultPath,
     extra: cfg.extra ?? undefined,

--- a/packages/agent-eval/src/lib/agents/index.ts
+++ b/packages/agent-eval/src/lib/agents/index.ts
@@ -8,6 +8,8 @@ import { createCodexAgent } from './codex/agent.js';
 import { createOpenCodeAgent } from './opencode/agent.js';
 import { createGeminiAgent } from './gemini/agent.js';
 import { createCursorAgent } from './cursor/agent.js';
+import { assertBundledSkillsControl } from './plugin/contract.js';
+import type { AgentType } from '../types.js';
 
 // Register all agent variants (Vercel AI Gateway + Direct API)
 registerAgent(createClaudeCodeAgent({ useVercelAiGateway: true }));   // vercel-ai-gateway/claude-code
@@ -17,6 +19,18 @@ registerAgent(createCodexAgent({ useVercelAiGateway: false }));       // codex
 registerAgent(createOpenCodeAgent());                                 // vercel-ai-gateway/opencode
 registerAgent(createGeminiAgent());                                   // gemini
 registerAgent(createCursorAgent());                                   // cursor
+
+/** Validate bundled-skill isolation for every agent used by a run. */
+export function assertRunBundledSkillsControl(
+  agentName: AgentType,
+  requested?: boolean,
+  judgeAgentName?: AgentType,
+): void {
+  const agentNames = new Set([agentName, judgeAgentName ?? agentName]);
+  for (const name of agentNames) {
+    assertBundledSkillsControl(getAgent(name).definition, requested);
+  }
+}
 
 // Re-export registry functions
 export { registerAgent, getAgent, listAgents, hasAgent };

--- a/packages/agent-eval/src/lib/agents/opencode/agent.ts
+++ b/packages/agent-eval/src/lib/agents/opencode/agent.ts
@@ -138,6 +138,7 @@ export function createOpenCodeDefinition(): AgentDefinition {
     displayName: 'OpenCode (Vercel AI Gateway)',
     defaultModel: 'vercel/anthropic/claude-sonnet-4',
     o11yAgentName: 'vercel-ai-gateway/opencode',
+    bundledSkillsControl: 'not-applicable',
     // Resolve run.mjs next to this file (works in src during dev and in dist after
     // the build copies run.mjs alongside the compiled agent.js).
     runnerPath: fileURLToPath(new URL('./run.mjs', import.meta.url)),

--- a/packages/agent-eval/src/lib/agents/plugin/contract.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/contract.ts
@@ -19,7 +19,7 @@
  * host. See the migration notes in the PR for the full rationale.
  */
 
-import type { ModelTier } from '../../types.js';
+import type { ModelTier, RunnableExperimentConfig } from '../../types.js';
 import type { AgentRunOptions } from '../types.js';
 
 /**
@@ -79,6 +79,9 @@ export interface AgentDefinition {
   o11yAgentName: string;
   /** Absolute path to this agent's run.mjs (resolved from the definition's import.meta.url). */
   runnerPath: string;
+  /** Whether the CLI can disable vendor-bundled skills, or has none to disable.
+   * Omitted means the opt-in control is unsupported. */
+  bundledSkillsControl?: 'configurable' | 'not-applicable';
 
   /**
    * Which host env var the apiKey is read from. Mirrors the old getApiKeyEnvVar()
@@ -112,6 +115,23 @@ export interface AgentDefinition {
    * JSON). Omit (or return undefined) for agents that don't need it.
    */
   runnerExtra?(options: AgentRunOptions): Record<string, unknown>;
+
+  /**
+   * OPTIONAL agent-owned protocol/version data that affects result reuse.
+   * Returned keys are hashed into both the combined result fingerprint and
+   * the non-carryable reuse compatibility fingerprint.
+   */
+  fingerprintExtra?(config: RunnableExperimentConfig): Record<string, unknown> | undefined;
+}
+
+/** Reject an opt-in capability when an agent cannot honor it. */
+export function assertBundledSkillsControl(
+  definition: AgentDefinition,
+  requested?: boolean,
+): void {
+  if (requested && !definition.bundledSkillsControl) {
+    throw new Error(`Agent ${definition.name} does not support disableBundledSkills`);
+  }
 }
 
 /**
@@ -130,6 +150,8 @@ export interface AgentRunInput {
   modelPolicy?: string;
   /** Web-research toggle (claude --allowedTools, opencode permissions/env). */
   webResearch?: boolean;
+  /** Opt-in vendor-bundled skill isolation. */
+  disableBundledSkills?: boolean;
   /** Passthrough of agentOptions (e.g. claude effort). Secrets must NOT be in here. */
   agentOptions?: Record<string, unknown>;
   /** Absolute sandbox cwd AFTER neutral-workspace relocation (transcript paths use it). */

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.test.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.test.ts
@@ -29,12 +29,14 @@ describe('resolveJudgeRuntime', () => {
     expect(rt.config.runnerPath).toBe(RUNNER_PATH);
     expect(rt.config.model).toBe('claude-sonnet-4-5'); // codegen model
     expect(rt.authEnv.ANTHROPIC_AUTH_TOKEN).toBe('codegen-key'); // codegen auth
+    expect(rt.config.disableBundledSkills).toBeUndefined();
   });
 
   it('pins the judge model but reuses the codegen runner when the agent matches', () => {
     const def = getAgent('vercel-ai-gateway/claude-code').definition;
     const rt = resolveJudgeRuntime(def, {
       ...baseOptions,
+      disableBundledSkills: true,
       judge: { model: 'claude-opus-4-8' }, // agent omitted → same as codegen
     });
 
@@ -43,6 +45,7 @@ describe('resolveJudgeRuntime', () => {
     expect(rt.config.runnerPath).toBe(RUNNER_PATH);
     expect(rt.config.model).toBe('claude-opus-4-8'); // PINNED, not codegen's sonnet
     expect(rt.authEnv.ANTHROPIC_AUTH_TOKEN).toBe('codegen-key'); // same-agent auth reused
+    expect(rt.config.disableBundledSkills).toBe(true);
   });
 
   it('resolves a different judge agent with its own runner, model, and auth', () => {
@@ -50,6 +53,7 @@ describe('resolveJudgeRuntime', () => {
     const codegen = getAgent('codex').definition; // codegen is codex...
     const rt = resolveJudgeRuntime(codegen, {
       ...baseOptions,
+      disableBundledSkills: true,
       judge: { agent: 'vercel-ai-gateway/claude-code', model: 'claude-opus-4-8' }, // ...judge is Claude
     });
 
@@ -61,5 +65,17 @@ describe('resolveJudgeRuntime', () => {
     // Judge uses ITS OWN gateway auth (resolved from AI_GATEWAY_API_KEY), not codex's.
     expect(rt.authEnv.ANTHROPIC_BASE_URL).toBeTruthy();
     expect(rt.authEnv.ANTHROPIC_AUTH_TOKEN).toBe('judge-gateway-key');
+    expect(rt.config.disableBundledSkills).toBe(true);
+  });
+
+  it('rejects a pinned judge that cannot disable bundled skills', () => {
+    const codegen = getAgent('vercel-ai-gateway/claude-code').definition;
+    expect(() =>
+      resolveJudgeRuntime(codegen, {
+        ...baseOptions,
+        disableBundledSkills: true,
+        judge: { agent: 'gemini', model: 'gemini-2.5-pro' },
+      })
+    ).toThrow('Agent gemini does not support disableBundledSkills');
   });
 });

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -40,7 +40,12 @@ import {
 } from '../shared.js';
 import { redactRunResult } from '../redact.js';
 import { getAgent } from '../registry.js';
-import type { AgentDefinition, AgentRunInput, RunnerResult } from './contract.js';
+import {
+  assertBundledSkillsControl,
+  type AgentDefinition,
+  type AgentRunInput,
+  type RunnerResult,
+} from './contract.js';
 
 /** Union of the two sandbox backends (same alias the old adapters used). */
 type AnySandbox = SandboxManager | DockerSandboxManager;
@@ -66,6 +71,8 @@ interface JudgeRuntimeConfig {
   runnerPath: string;
   /** Model the judge grades with (null → let the agent CLI default). */
   model: string | null;
+  /** Preserve the caller's opt-in bundled-skill isolation for judge runs. */
+  disableBundledSkills?: boolean;
   /** Host-computed runner extra (e.g. codex's resolved model/effort). */
   extra: Record<string, unknown> | null;
 }
@@ -99,6 +106,7 @@ interface JudgeRuntime {
  */
 export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptions): JudgeRuntime {
   const spec = options.judge;
+  assertBundledSkillsControl(def, options.disableBundledSkills);
 
   // Same harness as codegen (default, or judge.agent omitted/equal): reuse run.mjs,
   // just pin the model when asked. Identical to pre-feature behavior when unset.
@@ -113,6 +121,7 @@ export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptio
       config: {
         runnerPath: RUNNER_PATH,
         model: spec?.model ?? options.model ?? null,
+        disableBundledSkills: judgeOptions.disableBundledSkills,
         extra: def.runnerExtra?.(judgeOptions) ?? null,
       },
     };
@@ -120,6 +129,7 @@ export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptio
 
   // Pinned to a DIFFERENT agent — resolve its definition + key + runner.
   const judgeDef = getAgent(spec.agent!).definition;
+  assertBundledSkillsControl(judgeDef, options.disableBundledSkills);
   const judgeApiKey = resolveAgentApiKey(judgeDef.getApiKeyEnvVar) ?? '';
   const judgeOptions: AgentRunOptions = { ...options, model: spec.model, apiKey: judgeApiKey };
   return {
@@ -131,6 +141,7 @@ export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptio
     config: {
       runnerPath: JUDGE_RUNNER_PATH,
       model: spec.model,
+      disableBundledSkills: judgeOptions.disableBundledSkills,
       extra: judgeDef.runnerExtra?.(judgeOptions) ?? null,
     },
   };
@@ -354,6 +365,7 @@ async function runOnce(
       model: options.model,
       modelPolicy: options.modelPolicy,
       webResearch: options.webResearch,
+      disableBundledSkills: options.disableBundledSkills,
       agentOptions: options.agentOptions,
       cwd: sandbox.getWorkingDirectory(), // post-relocation cwd; transcript paths use it
       resultPath: RESULT_PATH,

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -40,11 +40,14 @@ export interface AgentRunOptions {
    *   comma-separated `--allowedTools` value. The flag is variadic, so the
    *   tools MUST be one comma-separated token — separate tokens swallow the
    *   trailing positional prompt (the #141 regression).
-   * - Codex: sets `tools.web_search = true` in the generated profile config.
+   * - Codex: enables live search in the generated profile and passes `--search`.
    * - OpenCode: sets `OPENCODE_ENABLE_EXA=1` and allows the
    *   `websearch`/`webfetch` tools.
    */
   webResearch?: boolean;
+  /** Disable vendor-bundled skills without hiding caller-installed skills.
+   * Default false: existing agent behavior is unchanged. */
+  disableBundledSkills?: boolean;
   /** Agent-specific options (e.g., binaryUrl, extraProviders for opencode) */
   agentOptions?: Record<string, unknown>;
   /** Pin the agentic LLM judge to a fixed agent+model. Undefined → the judge

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -79,6 +79,16 @@ describe('validateConfig', () => {
     expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
   });
 
+  it('keeps disableBundledSkills through validation', () => {
+    const config = { agent: 'claude-code', disableBundledSkills: true };
+    expect(validateConfig(config).disableBundledSkills).toBe(true);
+  });
+
+  it('rejects non-boolean disableBundledSkills', () => {
+    const config = { agent: 'claude-code', disableBundledSkills: 'yes' };
+    expect(() => validateConfig(config)).toThrow('Invalid experiment configuration');
+  });
+
   it('accepts a pinned judge (model only, agent defaults to codegen)', () => {
     const config = { agent: 'claude-code', judge: { model: 'claude-opus-4-8' } };
     expect(validateConfig(config).judge).toEqual({ model: 'claude-opus-4-8' });
@@ -169,6 +179,31 @@ describe('resolveConfig', () => {
   it('passes webResearch through and leaves it undefined by default', () => {
     expect(resolveConfig({ agent: 'claude-code' as const }).webResearch).toBeUndefined();
     expect(resolveConfig({ agent: 'claude-code' as const, webResearch: true }).webResearch).toBe(true);
+  });
+
+  it('passes disableBundledSkills through and leaves it undefined by default', () => {
+    expect(resolveConfig({ agent: 'claude-code' as const }).disableBundledSkills).toBeUndefined();
+    expect(
+      resolveConfig({ agent: 'claude-code' as const, disableBundledSkills: true })
+        .disableBundledSkills
+    ).toBe(true);
+  });
+
+  it('accepts agents with no bundled skills and rejects unsupported agents', () => {
+    expect(
+      resolveConfig({ agent: 'vercel-ai-gateway/opencode', disableBundledSkills: true })
+        .disableBundledSkills
+    ).toBe(true);
+    expect(() =>
+      resolveConfig({ agent: 'gemini', disableBundledSkills: true })
+    ).toThrow('Agent gemini does not support disableBundledSkills');
+    expect(() =>
+      resolveConfig({
+        agent: 'vercel-ai-gateway/claude-code',
+        disableBundledSkills: true,
+        judge: { agent: 'gemini', model: 'gemini-2.5-pro' },
+      })
+    ).toThrow('Agent gemini does not support disableBundledSkills');
   });
 
   it('passes judge through and leaves it undefined by default', () => {

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -10,7 +10,7 @@ import type {
   EvalFilter,
 } from './types.js';
 import { NATIVE_DEFAULT_MODEL } from './types.js';
-import { getAgent } from './agents/index.js';
+import { assertRunBundledSkillsControl } from './agents/index.js';
 
 /**
  * Default configuration values.
@@ -50,6 +50,7 @@ const experimentConfigSchema = z.object({
   // Must be in the schema: z.object strips unknown keys, so omitting it here
   // would make validateConfig silently drop the option.
   webResearch: z.boolean().optional(),
+  disableBundledSkills: z.boolean().optional(),
   brands: z.array(z.object({
     id: z.string().optional(),
     name: z.string().min(1),
@@ -101,7 +102,11 @@ export function validateConfig(config: unknown): ExperimentConfig {
  */
 export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfig {
   // Validate agent exists
-  getAgent(config.agent);
+  assertRunBundledSkillsControl(
+    config.agent,
+    config.disableBundledSkills,
+    config.judge?.agent,
+  );
 
   const modelPolicy = config.model === undefined ? 'native-default' : 'agent-default';
   const defaultModel = config.model ?? NATIVE_DEFAULT_MODEL;
@@ -122,6 +127,7 @@ export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfi
     copyFiles: config.copyFiles ?? CONFIG_DEFAULTS.copyFiles,
     agentOptions: config.agentOptions,
     webResearch: config.webResearch,
+    disableBundledSkills: config.disableBundledSkills,
     brands: config.brands,
     onRunComplete: config.onRunComplete,
     judge: config.judge,

--- a/packages/agent-eval/src/lib/fingerprint.test.ts
+++ b/packages/agent-eval/src/lib/fingerprint.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
-import { computeFingerprint, computeContentFingerprint, decideRefingerprint } from './fingerprint.js';
+import {
+  computeFingerprint,
+  computeContentFingerprint,
+  computeReuseCompatibilityFingerprint,
+  decideRefingerprint,
+  fingerprintConfigInput,
+} from './fingerprint.js';
 import type { RunnableExperimentConfig } from './types.js';
 
 const TEST_DIR = '/tmp/eval-framework-fingerprint-test';
@@ -130,6 +136,96 @@ describe('computeFingerprint', () => {
 
     const fp1 = computeFingerprint(evalDir, baseConfig);
     const fp2 = computeFingerprint(evalDir, { ...baseConfig, webResearch: true });
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('versions the repaired Codex web research mechanism only when opted in', () => {
+    const gateway = fingerprintConfigInput({
+      ...baseConfig,
+      agent: 'vercel-ai-gateway/codex',
+      webResearch: true,
+    });
+    const direct = fingerprintConfigInput({ ...baseConfig, agent: 'codex', webResearch: true });
+    const claude = fingerprintConfigInput({ ...baseConfig, webResearch: true });
+    const codexParametric = fingerprintConfigInput({ ...baseConfig, agent: 'codex' });
+
+    expect(gateway.agentFingerprint).toEqual({ webResearchProtocol: 'live-v1' });
+    expect(direct.agentFingerprint).toEqual({ webResearchProtocol: 'live-v1' });
+    expect(claude.agentFingerprint).toBeUndefined();
+    expect(codexParametric.agentFingerprint).toBeUndefined();
+  });
+
+  it('creates a non-carryable compatibility fingerprint only for opt-in runtime behavior', () => {
+    expect(computeReuseCompatibilityFingerprint(baseConfig)).toBeUndefined();
+    expect(
+      computeReuseCompatibilityFingerprint({ ...baseConfig, disableBundledSkills: true })
+    ).toMatch(/^[a-f0-9]{64}$/);
+
+    const legacyResearch = computeReuseCompatibilityFingerprint({
+      ...baseConfig,
+      webResearch: true,
+    });
+    const codexResearch = computeReuseCompatibilityFingerprint({
+      ...baseConfig,
+      agent: 'vercel-ai-gateway/codex',
+      webResearch: true,
+    });
+    expect(legacyResearch).toMatch(/^[a-f0-9]{64}$/);
+    expect(codexResearch).toMatch(/^[a-f0-9]{64}$/);
+    expect(codexResearch).not.toBe(legacyResearch);
+  });
+
+  it('does not create a cache boundary when bundled skills are not applicable', () => {
+    const opencode = {
+      ...baseConfig,
+      agent: 'vercel-ai-gateway/opencode',
+      disableBundledSkills: true,
+    };
+    expect(fingerprintConfigInput(opencode).disableBundledSkills).toBeUndefined();
+    expect(computeReuseCompatibilityFingerprint(opencode)).toBeUndefined();
+  });
+
+  it('creates a cache boundary when isolation applies to a pinned judge', () => {
+    const opencodeWithClaudeJudge = {
+      ...baseConfig,
+      agent: 'vercel-ai-gateway/opencode',
+      disableBundledSkills: true,
+      judge: {
+        agent: 'vercel-ai-gateway/claude-code',
+        model: 'claude-opus-4-8',
+      },
+    };
+    expect(fingerprintConfigInput(opencodeWithClaudeJudge).disableBundledSkills).toBe(true);
+    expect(computeReuseCompatibilityFingerprint(opencodeWithClaudeJudge)).toMatch(
+      /^[a-f0-9]{64}$/
+    );
+  });
+
+  it('keeps bundled-skill defaults equivalent to existing fingerprints', () => {
+    const evalDir = createEvalDir('eval-skills-default', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, disableBundledSkills: false });
+    const fp3 = computeFingerprint(evalDir, { ...baseConfig, disableBundledSkills: undefined });
+
+    expect(fp1).toBe(fp2);
+    expect(fp1).toBe(fp3);
+  });
+
+  it('changes when bundled skills are explicitly disabled', () => {
+    const evalDir = createEvalDir('eval-skills-disabled', {
+      'PROMPT.md': 'Do something',
+      'EVAL.ts': 'test code',
+      'package.json': '{"type":"module"}',
+    });
+
+    const fp1 = computeFingerprint(evalDir, baseConfig);
+    const fp2 = computeFingerprint(evalDir, { ...baseConfig, disableBundledSkills: true });
 
     expect(fp1).not.toBe(fp2);
   });
@@ -297,6 +393,19 @@ describe('decideRefingerprint', () => {
       { fingerprint: 'same', contentFingerprint: 'C' }
     );
     expect(d).toEqual({ stale: false });
+  });
+
+  it('never carries results across an opt-in runtime compatibility boundary', () => {
+    const d = decideRefingerprint(
+      { fingerprint: 'old-combined', contentFingerprint: 'C' },
+      {
+        fingerprint: 'new-combined',
+        contentFingerprint: 'C',
+        reuseCompatibilityFingerprint: 'runtime-v1',
+      }
+    );
+    expect(d).toEqual({ stale: true });
+    expect(d.fingerprint).toBeUndefined();
   });
 
   it('leaves a changed eval STALE — never masks it', () => {

--- a/packages/agent-eval/src/lib/fingerprint.ts
+++ b/packages/agent-eval/src/lib/fingerprint.ts
@@ -9,6 +9,7 @@ import { createHash } from 'crypto';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import type { RunnableExperimentConfig } from './types.js';
+import { getAgent, hasAgent } from './agents/index.js';
 
 /**
  * Fields from the config that affect eval results.
@@ -23,7 +24,77 @@ interface FingerprintableConfig {
   earlyExit: boolean;
   runs: number;
   webResearch?: boolean;
+  disableBundledSkills?: boolean;
+  agentFingerprint?: Record<string, unknown>;
   judge?: { agent?: string; model: string };
+}
+
+interface ReuseCompatibilityInput {
+  webResearch?: true;
+  disableBundledSkills?: true;
+  agentFingerprint?: Record<string, unknown>;
+}
+
+function agentFingerprintExtra(config: RunnableExperimentConfig): Record<string, unknown> | undefined {
+  if (!hasAgent(config.agent)) return undefined;
+  return getAgent(config.agent).definition?.fingerprintExtra?.(config);
+}
+
+function bundledSkillsIsolationApplies(config: RunnableExperimentConfig): boolean {
+  if (!config.disableBundledSkills) return false;
+  const agentNames = new Set([config.agent, config.judge?.agent ?? config.agent]);
+  for (const agentName of agentNames) {
+    if (!hasAgent(agentName)) return true;
+    if (getAgent(agentName).definition?.bundledSkillsControl !== 'not-applicable') return true;
+  }
+  return false;
+}
+
+/** Build the config slice hashed into result-reuse fingerprints. */
+export function fingerprintConfigInput(config: RunnableExperimentConfig): FingerprintableConfig {
+  const input: FingerprintableConfig = {
+    agent: config.agent,
+    model: config.model,
+    scripts: [...config.scripts].sort(),
+    timeout: config.timeout,
+    earlyExit: config.earlyExit,
+    runs: config.runs,
+  };
+  if (config.modelPolicy === 'native-default') {
+    input.modelPolicy = config.modelPolicy;
+  }
+  if (config.webResearch) {
+    input.webResearch = true;
+  }
+  if (bundledSkillsIsolationApplies(config)) {
+    input.disableBundledSkills = true;
+  }
+  const agentFingerprint = agentFingerprintExtra(config);
+  if (agentFingerprint && Object.keys(agentFingerprint).length > 0) {
+    input.agentFingerprint = agentFingerprint;
+  }
+  if (config.judge) {
+    input.judge = { agent: config.judge.agent, model: config.judge.model };
+  }
+  return input;
+}
+
+/**
+ * Hash opt-in runtime behavior that must never be silently carried across
+ * cached results. Undefined preserves historical default behavior.
+ */
+export function computeReuseCompatibilityFingerprint(
+  config: RunnableExperimentConfig,
+): string | undefined {
+  const input: ReuseCompatibilityInput = {};
+  if (config.webResearch) input.webResearch = true;
+  if (bundledSkillsIsolationApplies(config)) input.disableBundledSkills = true;
+  const agentFingerprint = agentFingerprintExtra(config);
+  if (agentFingerprint && Object.keys(agentFingerprint).length > 0) {
+    input.agentFingerprint = agentFingerprint;
+  }
+  if (Object.keys(input).length === 0) return undefined;
+  return createHash('sha256').update(JSON.stringify(input)).digest('hex');
 }
 
 /**
@@ -95,29 +166,7 @@ export function computeFingerprint(evalPath: string, config: RunnableExperimentC
   hashEvalFiles(hash, evalPath);
 
   // Hash config fields that affect results
-  const configForHash: FingerprintableConfig = {
-    agent: config.agent,
-    model: config.model,
-    scripts: [...config.scripts].sort(),
-    timeout: config.timeout,
-    earlyExit: config.earlyExit,
-    runs: config.runs,
-  };
-  if (config.modelPolicy === 'native-default') {
-    configForHash.modelPolicy = config.modelPolicy;
-  }
-  // Included only when enabled so existing (default-off) fingerprints are
-  // unchanged, while research and non-research configs never share a
-  // fingerprint — result reuse must not serve a cached parametric-only
-  // result for a research run, or vice versa.
-  if (config.webResearch) {
-    configForHash.webResearch = true;
-  }
-  // Included only when the judge is pinned, so existing (unpinned) fingerprints are
-  // unchanged. Changing the judge agent/model invalidates the cache → re-runs.
-  if (config.judge) {
-    configForHash.judge = { agent: config.judge.agent, model: config.judge.model };
-  }
+  const configForHash = fingerprintConfigInput(config);
   hash.update(`config:${JSON.stringify(configForHash)}`);
 
   return hash.digest('hex');
@@ -144,9 +193,20 @@ export interface RefingerprintDecision {
  *     is already fully current; otherwise leave stale (we can't prove content matches)
  */
 export function decideRefingerprint(
-  stored: { fingerprint?: string; contentFingerprint?: string },
-  current: { fingerprint: string; contentFingerprint: string }
+  stored: {
+    fingerprint?: string;
+    contentFingerprint?: string;
+    reuseCompatibilityFingerprint?: string;
+  },
+  current: {
+    fingerprint: string;
+    contentFingerprint: string;
+    reuseCompatibilityFingerprint?: string;
+  }
 ): RefingerprintDecision {
+  if (stored.reuseCompatibilityFingerprint !== current.reuseCompatibilityFingerprint) {
+    return { stale: true };
+  }
   if (stored.contentFingerprint === undefined) {
     if (stored.fingerprint === current.fingerprint) {
       return { contentFingerprint: current.contentFingerprint, stale: false };

--- a/packages/agent-eval/src/lib/o11y/o11y.test.ts
+++ b/packages/agent-eval/src/lib/o11y/o11y.test.ts
@@ -223,6 +223,32 @@ describe('o11y', () => {
       expect(events[0].type).toBe('tool_result');
       expect(events[0].tool?.success).toBe(true);
     });
+
+    it('parses current Codex web search item events', () => {
+      const transcript = [
+        JSON.stringify({
+          type: 'item.started',
+          item: { id: 'item_1', type: 'web_search', query: 'Vercel AI Gateway docs' },
+        }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'item_1',
+            type: 'web_search',
+            query: 'Vercel AI Gateway docs',
+            status: 'completed',
+          },
+        }),
+      ].join('\n');
+      const { events } = parseCodexTranscript(transcript);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('tool_call');
+      expect(events[0].tool?.name).toBe('web_search');
+      expect(events[0].tool?.args?.query).toBe('Vercel AI Gateway docs');
+      expect(events[1].type).toBe('tool_result');
+      expect(events[1].tool?.success).toBe(true);
+    });
   });
 
   describe('OpenCode parser', () => {

--- a/packages/agent-eval/src/lib/o11y/parsers/codex.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/codex.ts
@@ -276,6 +276,35 @@ function parseCodexLine(line: string): TranscriptEvent[] {
             break;
           }
 
+          case 'web_search':
+          case 'web_search_call': {
+            if (eventType === 'item.started') {
+              events.push({
+                timestamp: data.timestamp || data.ts,
+                type: 'tool_call',
+                tool: {
+                  name: 'web_search',
+                  originalName: itemType,
+                  args: { query: item.query || item.action?.query },
+                },
+                raw: data,
+              });
+            } else {
+              events.push({
+                timestamp: data.timestamp || data.ts,
+                type: 'tool_result',
+                tool: {
+                  name: 'web_search',
+                  originalName: itemType,
+                  result: item.results || item.action || item,
+                  success: item.status !== 'failed',
+                },
+                raw: data,
+              });
+            }
+            break;
+          }
+
           case 'agent_message': {
             // Agent message is an assistant message
             events.push({

--- a/packages/agent-eval/src/lib/results.test.ts
+++ b/packages/agent-eval/src/lib/results.test.ts
@@ -255,6 +255,34 @@ describe('results utilities', () => {
       expect(parsedTranscript).toHaveProperty('summary');
     });
 
+    it('stores opt-in runtime compatibility in summaries', () => {
+      const config: ResolvedExperimentConfig = {
+        agent: 'vercel-ai-gateway/codex',
+        model: 'openai/gpt-5.2-codex',
+        evals: ['eval-1'],
+        runs: 1,
+        earlyExit: true,
+        scripts: [],
+        timeout: 300,
+        webResearch: true,
+      };
+      const results = createExperimentResults(
+        config,
+        [createEvalSummary('eval-1', [{ result: { status: 'passed', duration: 1 } }])],
+        new Date('2024-01-26T12:00:00Z'),
+        new Date('2024-01-26T12:01:00Z')
+      );
+      const outputDir = saveResults(results, {
+        resultsDir: TEST_DIR,
+        experimentName: 'compatibility-experiment',
+      });
+      const summary = JSON.parse(
+        readFileSync(join(outputDir, 'eval-1', 'summary.json'), 'utf-8')
+      );
+
+      expect(summary.reuseCompatibilityFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    });
+
     it('saves observed model metadata for native-default runs', () => {
       const config: ResolvedExperimentConfig = {
         agent: 'vercel-ai-gateway/opencode',
@@ -486,6 +514,21 @@ describe('results utilities', () => {
       );
 
       const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'new-hash' });
+      expect(result.size).toBe(0);
+    });
+
+    it('skips legacy results across an enforced runtime compatibility boundary', () => {
+      const expDir = join(TEST_DIR, 'my-exp', '2024-01-26T12-00-00.000Z', 'eval-1');
+      mkdirSync(expDir, { recursive: true });
+      writeFileSync(
+        join(expDir, 'summary.json'),
+        JSON.stringify({ totalRuns: 1, passedRuns: 1, passRate: '100%', fingerprint: 'abc123' })
+      );
+
+      const result = scanReusableResults(TEST_DIR, 'my-exp', { 'eval-1': 'abc123' }, {
+        enforceReuseCompatibility: true,
+        reuseCompatibilityFingerprint: 'runtime-v1',
+      });
       expect(result.size).toBe(0);
     });
 

--- a/packages/agent-eval/src/lib/results.ts
+++ b/packages/agent-eval/src/lib/results.ts
@@ -24,6 +24,7 @@ import type { AgentRunResult } from './agents/types.js';
 import { parseTranscript, type Transcript } from './o11y/index.js';
 import { isNonModelFailure } from './classifier.js';
 import { copyFixtureFiles } from './fixture.js';
+import { computeReuseCompatibilityFingerprint } from './fingerprint.js';
 
 /**
  * Convert AgentRunResult to EvalRunData (result + transcript).
@@ -173,6 +174,7 @@ export function saveResults(
 		// Save summary (simplified format per design)
 		const fingerprint = options.fingerprints?.[evalSummary.name];
 		const contentFingerprint = options.contentFingerprints?.[evalSummary.name];
+		const reuseCompatibilityFingerprint = computeReuseCompatibilityFingerprint(results.config);
 		const valid = options.validity?.[evalSummary.name];
 		const summaryForFile: Record<string, unknown> = {
 			totalRuns: evalSummary.totalRuns,
@@ -185,6 +187,9 @@ export function saveResults(
 		}
 		if (contentFingerprint) {
 			summaryForFile.contentFingerprint = contentFingerprint;
+		}
+		if (reuseCompatibilityFingerprint) {
+			summaryForFile.reuseCompatibilityFingerprint = reuseCompatibilityFingerprint;
 		}
 		if (valid === false) {
 			summaryForFile.valid = false;
@@ -478,6 +483,12 @@ export interface ReusableResult {
 	timestamp: string;
 }
 
+export interface ReuseScanOptions {
+	/** Enforce exact opt-in runtime compatibility, including missing legacy values. */
+	enforceReuseCompatibility?: boolean;
+	reuseCompatibilityFingerprint?: string;
+}
+
 /**
  * Scan existing results for an experiment to find reusable eval results.
  *
@@ -492,6 +503,7 @@ export function scanReusableResults(
 	resultsDir: string,
 	experimentName: string,
 	fingerprints: Record<string, string>,
+	options: ReuseScanOptions = {},
 ): Map<string, ReusableResult> {
 	const reusable = new Map<string, ReusableResult>();
 	const experimentDir = join(resultsDir, experimentName);
@@ -536,6 +548,10 @@ export function scanReusableResults(
 				// re-run; "which staleness is acceptable" is the consumer's policy (via
 				// `agent-eval status --json` in CI), not the framework's.
 				if (summary.fingerprint !== expectedFingerprint) continue;
+				if (
+					options.enforceReuseCompatibility &&
+					summary.reuseCompatibilityFingerprint !== options.reuseCompatibilityFingerprint
+				) continue;
 
 				// Check validity (valid defaults to true if not explicitly set to false)
 				if (summary.valid === false) continue;

--- a/packages/agent-eval/src/lib/runner.test.ts
+++ b/packages/agent-eval/src/lib/runner.test.ts
@@ -610,6 +610,51 @@ describe('runExperiment', () => {
       );
     });
 
+    it('forwards disableBundledSkills to agent.run when set', async () => {
+      const mockAgent: Agent = {
+        name: 'mock-agent',
+        displayName: 'Mock Agent',
+        getApiKeyEnvVar: () => 'MOCK_API_KEY',
+        getDefaultModel: () => 'mock-model',
+        run: vi.fn().mockResolvedValue({
+          success: true,
+          output: 'Agent output',
+          duration: 1000,
+          scriptsResults: {},
+        }),
+        definition: { bundledSkillsControl: 'configurable' } as Agent['definition'],
+      };
+      vi.spyOn(agentsIndex, 'getAgent').mockReturnValue(mockAgent);
+      const config: ResolvedExperimentConfig = {
+        agent: 'claude-code',
+        model: 'opus',
+        evals: ['test-eval'],
+        runs: 1,
+        earlyExit: false,
+        scripts: [],
+        timeout: 600,
+        disableBundledSkills: true,
+      };
+
+      await runExperiment({
+        config,
+        fixtures: [{
+          name: 'test-eval',
+          path: '/fake/path',
+          prompt: 'Test prompt for agent',
+          isModule: true,
+        }],
+        apiKey: 'my-api-key',
+        resultsDir: TEST_DIR,
+        experimentName: 'test-experiment',
+      });
+
+      expect(mockAgent.run).toHaveBeenCalledWith(
+        '/fake/path',
+        expect.objectContaining({ disableBundledSkills: true })
+      );
+    });
+
     it('does not pass a model override for native-default policy', async () => {
       const mockAgent: Agent = {
         name: 'mock-agent',

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -14,7 +14,7 @@ import type {
   RunnableExperimentConfig,
   ProgressEvent,
 } from './types.js';
-import { getAgent } from './agents/index.js';
+import { assertRunBundledSkillsControl, getAgent } from './agents/index.js';
 import {
   agentResultToEvalRunData,
   createEvalSummary,
@@ -126,6 +126,12 @@ export async function runExperiment(
   const { config, fixtures, apiKey, resultsDir, experimentName, fingerprints, contentFingerprints, onProgress, smoke, rateLimiter } = options;
   const startedAt = new Date();
 
+  assertRunBundledSkillsControl(
+    config.agent,
+    config.disableBundledSkills,
+    config.judge?.agent,
+  );
+
   // Get the agent from registry
   const agent = getAgent(config.agent);
 
@@ -197,6 +203,7 @@ export async function runExperiment(
         sandbox: config.sandbox,
         agentOptions: config.agentOptions,
         webResearch: config.webResearch,
+        disableBundledSkills: config.disableBundledSkills,
         judge: config.judge,
       }),
       new Promise<never>((_, reject) => {
@@ -392,10 +399,17 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
     verbose?: boolean;
     agentOptions?: ResolvedExperimentConfig['agentOptions'];
     webResearch?: ResolvedExperimentConfig['webResearch'];
+    disableBundledSkills?: ResolvedExperimentConfig['disableBundledSkills'];
     judge?: ResolvedExperimentConfig['judge'];
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
-  const agent = getAgent(options.agent ?? 'vercel-ai-gateway/claude-code');
+  const agentName = options.agent ?? 'vercel-ai-gateway/claude-code';
+  assertRunBundledSkillsControl(
+    agentName,
+    options.disableBundledSkills,
+    options.judge?.agent,
+  );
+  const agent = getAgent(agentName);
 
   const models: string[] = Array.isArray(options.model) ? options.model : [options.model];
   const prompt = options.editPrompt ? options.editPrompt(fixture.prompt) : fixture.prompt;
@@ -416,6 +430,7 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
 		sandbox: options.sandbox,
 		agentOptions: options.agentOptions,
 		webResearch: options.webResearch,
+		disableBundledSkills: options.disableBundledSkills,
 		judge: options.judge,
 	});
 

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -168,6 +168,12 @@ export interface ExperimentConfig {
    * @default false — command construction is unchanged when omitted. */
   webResearch?: boolean;
 
+  /** Disable skills bundled by the underlying agent CLI while preserving
+   * project/user skills installed by the caller. Currently supported by Claude
+   * Code and Codex; OpenCode does not bundle skills. @default false — the
+   * underlying CLI's normal skill behavior is unchanged when omitted. */
+  disableBundledSkills?: boolean;
+
   /** Brands to track or compare in downstream analysis. @default undefined */
   brands?: BrandConfig[];
 
@@ -198,6 +204,7 @@ export interface ResolvedExperimentConfig {
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
   webResearch?: boolean;
+  disableBundledSkills?: boolean;
   brands?: BrandConfig[];
   onRunComplete?: RunCompleteHook;
   judge?: JudgeConfig;
@@ -222,6 +229,7 @@ export interface RunnableExperimentConfig {
   copyFiles: 'none' | 'changed' | 'all';
   agentOptions?: Record<string, unknown>;
   webResearch?: boolean;
+  disableBundledSkills?: boolean;
   brands?: BrandConfig[];
   onRunComplete?: RunCompleteHook;
   judge?: JudgeConfig;


### PR DESCRIPTION
## Summary

- add opt-in bundled-skill isolation for Claude Code and Codex while preserving default behavior
- update Codex web research to use live search through AI Gateway and parse web-search events
- prevent legacy cached results from crossing opt-in runtime compatibility boundaries
- validate codegen and pinned-judge capability support before execution

## Testing

- `npm run build`
- `npm run lint`
- `npm test` (342 passed, 15 skipped)
- credentialed Vercel Sandbox probes for Claude bundled-skill isolation and Codex AI Gateway live search (2 passed)