### PR TITLE
Add fx research agent

### DIFF
--- a/.changeset/tiny-dingos-research.md
+++ b/.changeset/tiny-dingos-research.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": minor
+---
+
+Add a Vercel AI Gateway adapter for research evals with fx, including a pinned binary installer and saved-session transcript parser.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ export default config;
 agent: 'vercel-ai-gateway/claude-code'  // Claude Code via AI Gateway
 agent: 'vercel-ai-gateway/codex'        // OpenAI Codex via AI Gateway
 agent: 'vercel-ai-gateway/opencode'     // OpenCode via AI Gateway
+agent: 'vercel-ai-gateway/fx'           // fx via AI Gateway (research runs)
 
 // Direct API (uses provider keys directly)
 agent: 'claude-code'  // requires ANTHROPIC_API_KEY
@@ -433,15 +434,44 @@ const config: ExperimentConfig = {
 ```
 
 `disableBundledSkills` disables skills shipped by Claude Code or Codex while
-leaving caller-installed project and user skills available. OpenCode does not
-ship a bundled skill catalog, so this option does not change its runtime. The
-option is omitted by default, preserving existing arguments and agent behavior.
-Other built-in agents reject this option until they expose an equivalent control.
+leaving caller-installed project and user skills available. OpenCode and fx do
+not ship bundled skill catalogs, so this option does not change their runtimes.
+The option is omitted by default, preserving existing arguments and agent
+behavior. Other built-in agents reject this option until they expose an
+equivalent control.
 
 `webResearch` remains opt-in. It allows Claude Code's `WebSearch`/`WebFetch`,
 enables Codex live search (including custom AI Gateway providers), and enables
 OpenCode's Exa-backed `websearch`/`webfetch` tools. Whether an agent chooses to
 use an available research tool remains part of the measured behavior.
+
+The fx adapter currently requires `webResearch: true`. fx does not yet expose a
+prompt-free way to disable every web tool while retaining unrestricted coding
+tools, so Agent Eval rejects non-research fx runs instead of silently changing
+the treatment.
+
+### Run research evals with fx
+
+fx runs through Vercel AI Gateway and uses its native `web_search` and
+`web_fetch` tools. Agent Eval pins fx `0.0.5`, verifies the downloaded Linux
+binary checksum, and captures the supported saved-session JSON transcript.
+
+```typescript
+import type { ExperimentConfig } from '@vercel/agent-eval';
+
+const config: ExperimentConfig = {
+  agent: 'vercel-ai-gateway/fx',
+  webResearch: true,
+  disableBundledSkills: true,
+};
+
+export default config;
+```
+
+The fx adapter supports Linux x86-64 and arm64 sandboxes. Agent Eval disables
+fx permission prompts inside the disposable sandbox, matching the execution
+model used by the other built-in coding agents. fx can self-grade its own runs,
+but it cannot serve as a pinned judge for a different agent.
 
 ### OpenCode model format
 
@@ -726,7 +756,9 @@ Every run requires an API key for the agent and a token for the sandbox. Classif
 
 The **classifier is optional**: if neither `AI_GATEWAY_API_KEY` nor `VERCEL_OIDC_TOKEN` is set, failure classification is skipped and all results are preserved as-is. Set either key to enable the classifier, which automatically identifies and removes non-model failures (infrastructure errors, rate limits, timeouts).
 
-OpenCode only supports Vercel AI Gateway (`vercel-ai-gateway/opencode`). There is no direct API option for OpenCode.
+OpenCode and fx only support Vercel AI Gateway
+(`vercel-ai-gateway/opencode` and `vercel-ai-gateway/fx`). There are no direct
+API variants for these agents.
 
 ### Setup
 

--- a/packages/agent-eval/src/index.ts
+++ b/packages/agent-eval/src/index.ts
@@ -146,4 +146,5 @@ export {
   parseClaudeCodeTranscript,
   parseCodexTranscript,
   parseOpenCodeTranscript,
+  parseFxTranscript,
 } from './lib/o11y/index.js';

--- a/packages/agent-eval/src/integration.test.ts
+++ b/packages/agent-eval/src/integration.test.ts
@@ -50,6 +50,7 @@ const hasGeminiCredentials = !!process.env.GEMINI_API_KEY && hasSandbox;
 const hasCursorCredentials = !!process.env.CURSOR_API_KEY && hasSandbox;
 // OpenCode credentials (only supports AI Gateway)
 const hasOpenCodeCredentials = hasAiGatewayCredentials;
+const hasFxCredentials = hasAiGatewayCredentials;
 
 describe.skipIf(!process.env.INTEGRATION_TEST)('integration tests', () => {
   beforeAll(() => {
@@ -1372,6 +1373,46 @@ test('contains greeting', () => {
         }
       }
     }, 300000); // 5 minute timeout
+  });
+
+  describe.skipIf(!hasFxCredentials)('fx (Vercel AI Gateway) sandbox execution', () => {
+    it('runs a research eval and captures the saved session transcript', async () => {
+      const fixtureDir = join(TEST_DIR, 'fx-web-research');
+      mkdirSync(fixtureDir, { recursive: true });
+      writeFileSync(
+        join(fixtureDir, 'PROMPT.md'),
+        'Use web search to find the official fx website. Return one source URL.'
+      );
+      writeFileSync(
+        join(fixtureDir, 'package.json'),
+        JSON.stringify({ name: 'fx-web-research', type: 'module' })
+      );
+
+      const fixture = loadFixture(TEST_DIR, 'fx-web-research', {
+        validation: 'none',
+      });
+      const result = await runSingleEval(fixture, {
+        agent: 'vercel-ai-gateway/fx',
+        model: 'openai/gpt-5.6-sol',
+        timeout: 180,
+        apiKey: process.env.AI_GATEWAY_API_KEY!,
+        scripts: [],
+        validation: 'none',
+        webResearch: true,
+        disableBundledSkills: true,
+      });
+
+      if (result.result.status === 'failed') {
+        console.error('fx web research failed:', result.result.error);
+      }
+      expect(result.result.status).toBe('passed');
+      expect(result.transcript).toBeDefined();
+      const parsed = parseTranscript(result.transcript!, 'vercel-ai-gateway/fx');
+      expect(parsed.parseSuccess).toBe(true);
+      expect(parsed.summary.toolCalls.web_search).toBeGreaterThan(0);
+      expect(result.transcript).toMatch(/https?:\/\//);
+      expect(result.result.observedModel).toBe('openai/gpt-5.6-sol');
+    }, 300000);
   });
 
   // ============================================================================

--- a/packages/agent-eval/src/lib/agents/fx.test.ts
+++ b/packages/agent-eval/src/lib/agents/fx.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildFxEnvironment,
+  buildFxCliArgs,
+  isFxSessionDetail,
+  parseFxAskResult,
+} from './fx/run.mjs';
+import {
+  buildFxInstallScript,
+  createFxDefinition,
+  FX_RELEASE_SHA256,
+  FX_VERSION,
+} from './fx/agent.js';
+
+describe('fx definition', () => {
+  const definition = createFxDefinition();
+  const options = { prompt: 'p', apiKey: 'test-key', timeout: 1000, webResearch: true };
+
+  it('registers a Gateway-only research agent with no bundled skills', () => {
+    expect(definition.name).toBe('vercel-ai-gateway/fx');
+    expect(definition.defaultModel).toBe('zai/glm-5.2');
+    expect(definition.bundledSkillsControl).toBe('not-applicable');
+    expect(definition.requiresWebResearch).toBe(true);
+    expect(definition.supportsCrossAgentJudge).toBe(false);
+    expect(definition.getApiKeyEnvVar()).toBe('AI_GATEWAY_API_KEY');
+    expect(definition.authEnv(options)).toEqual({ AI_GATEWAY_API_KEY: 'test-key' });
+  });
+
+  it('pins the binary release and runtime protocol in the fingerprint', () => {
+    expect(definition.fingerprintExtra!({} as never)).toEqual({
+      fxVersion: FX_VERSION,
+      fxRuntimeProtocol: 'ask-json-session-v1',
+    });
+  });
+
+  it('installs a checksum-verified binary for both Linux architectures', () => {
+    const script = buildFxInstallScript();
+    expect(script).toContain(`const version = "${FX_VERSION}"`);
+    expect(script).toContain(FX_RELEASE_SHA256.x64);
+    expect(script).toContain(FX_RELEASE_SHA256.arm64);
+    expect(script).toContain('createHash');
+    expect(script).toContain('for await (const chunk of response.body)');
+    expect(script).not.toContain('response.arrayBuffer()');
+    expect(script).toContain("spawnSync('tar'");
+
+    const install = definition.install(options);
+    expect(install).toHaveLength(2);
+    expect(install[1]).toMatchObject({
+      kind: 'command',
+      cmd: 'node',
+      errorPrefix: 'fx install failed',
+    });
+  });
+});
+
+describe('fx runner helpers', () => {
+  it('builds a noninteractive research invocation', () => {
+    expect(buildFxCliArgs({ prompt: 'research this' })).toEqual([
+      'ask',
+      '--yolo',
+      '--json',
+      '--no-color',
+      '--',
+      'research this',
+    ]);
+  });
+
+  it('sets explicit models without contaminating native-default runs', () => {
+    const explicit = buildFxEnvironment({ model: 'openai/gpt-5.6-sol' });
+    expect(explicit.FX_MODEL).toBe('openai/gpt-5.6-sol');
+    expect(explicit.FX_AUTO_UPGRADE).toBe('0');
+
+    const native = buildFxEnvironment({});
+    expect(native.FX_MODEL).toBeUndefined();
+    expect(native.FX_AUTO_UPGRADE).toBe('0');
+  });
+
+  it('parses the stable ask result and rejects malformed output', () => {
+    const result = parseFxAskResult(JSON.stringify({
+      output: 'done',
+      exit_code: 0,
+      model: 'openai/gpt-5.6-sol',
+      session_id: 'session-1',
+      steps: 1,
+      tool_calls: [],
+    }));
+    expect(result?.output).toBe('done');
+    expect(parseFxAskResult('not json')).toBeNull();
+    expect(parseFxAskResult('{}')).toBeNull();
+  });
+
+  it('recognizes only the supported session detail projection', () => {
+    expect(isFxSessionDetail(JSON.stringify({ kind: 'session_detail', history: [] }))).toBe(true);
+    expect(isFxSessionDetail(JSON.stringify({ kind: 'session_summary', history: [] }))).toBe(false);
+  });
+});

--- a/packages/agent-eval/src/lib/agents/fx/agent.ts
+++ b/packages/agent-eval/src/lib/agents/fx/agent.ts
@@ -1,0 +1,152 @@
+/**
+ * fx agent definition for research-enabled runs through Vercel AI Gateway.
+ */
+
+import { fileURLToPath } from 'node:url';
+
+import type { Agent, AgentRunOptions } from '../types.js';
+import type { ModelTier } from '../../types.js';
+import { AI_GATEWAY } from '../shared.js';
+import type { AgentDefinition, InstallStep } from '../plugin/contract.js';
+import { runWithDefinition } from '../plugin/orchestrator.js';
+
+export const FX_VERSION = '0.0.5';
+
+export const FX_RELEASE_SHA256 = {
+  x64: 'd5639d173267774aa8228a474baf619a7076ac41a91023915007c865143429b1',
+  arm64: '8bbcde6a41256c4fac4e0a022291cf02740419e27afabde3b8f45e7a4e393edb',
+} as const;
+
+const FX_RUNTIME_PROTOCOL = 'ask-json-session-v1';
+
+/** Build the zero-dependency installer executed inside the Linux sandbox. */
+export function buildFxInstallScript(): string {
+  return `
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const version = ${JSON.stringify(FX_VERSION)};
+const checksums = ${JSON.stringify(FX_RELEASE_SHA256)};
+if (process.platform !== 'linux' || !(process.arch in checksums)) {
+  throw new Error(\`Unsupported fx sandbox platform: \${process.platform}/\${process.arch}\`);
+}
+
+const releaseArch = process.arch === 'x64' ? 'x86_64' : 'aarch64';
+const asset = \`fx-linux-\${releaseArch}.tar.gz\`;
+const url = \`https://github.com/vercel-labs/fx/releases/download/v\${version}/\${asset}\`;
+const installDir = resolve('__agent_eval__/bin');
+const archivePath = join(installDir, asset);
+const binaryPath = join(installDir, 'fx');
+
+mkdirSync(installDir, { recursive: true });
+const maxArchiveBytes = 32 * 1024 * 1024;
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), 60_000);
+let archive;
+try {
+  const response = await fetch(url, { signal: controller.signal });
+  if (!response.ok) throw new Error(\`fx download failed: HTTP \${response.status}\`);
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > maxArchiveBytes) {
+    throw new Error('fx archive exceeds 32 MB');
+  }
+  if (!response.body) throw new Error('fx download returned no body');
+
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of response.body) {
+    const bytes = Buffer.from(chunk);
+    size += bytes.length;
+    if (size > maxArchiveBytes) {
+      controller.abort();
+      throw new Error('fx archive exceeds 32 MB');
+    }
+    chunks.push(bytes);
+  }
+  archive = Buffer.concat(chunks, size);
+} finally {
+  clearTimeout(timeout);
+}
+
+const actual = createHash('sha256').update(archive).digest('hex');
+const expected = checksums[process.arch];
+if (actual !== expected) throw new Error(\`fx checksum mismatch: expected \${expected}, got \${actual}\`);
+
+writeFileSync(archivePath, archive);
+const extracted = spawnSync('tar', ['-xzf', archivePath, '-C', installDir, 'fx'], { encoding: 'utf8' });
+unlinkSync(archivePath);
+if (extracted.status !== 0) throw new Error(\`fx extraction failed: \${extracted.stderr || extracted.error?.message || 'unknown error'}\`);
+chmodSync(binaryPath, 0o755);
+
+const installed = spawnSync(binaryPath, ['--version'], { encoding: 'utf8' });
+if (installed.status !== 0 || installed.stdout.trim() !== version) {
+  throw new Error(\`fx version check failed: \${installed.stdout || installed.stderr || installed.error?.message || 'unknown error'}\`);
+}
+`;
+}
+
+export function createFxDefinition(): AgentDefinition {
+  return {
+    name: 'vercel-ai-gateway/fx',
+    displayName: 'fx (Vercel AI Gateway)',
+    defaultModel: 'zai/glm-5.2',
+    o11yAgentName: 'vercel-ai-gateway/fx',
+    bundledSkillsControl: 'not-applicable',
+    requiresWebResearch: true,
+    supportsCrossAgentJudge: false,
+    runnerPath: fileURLToPath(new URL('./run.mjs', import.meta.url)),
+
+    getApiKeyEnvVar(): string {
+      return AI_GATEWAY.apiKeyEnvVar;
+    },
+
+    install(_options: AgentRunOptions): InstallStep[] {
+      return [
+        {
+          kind: 'command',
+          cmd: 'npm',
+          args: ['install'],
+          retryOnce: true,
+          errorPrefix: 'npm install failed',
+          errorBody: 'last10',
+        },
+        {
+          kind: 'command',
+          cmd: 'node',
+          args: ['--input-type=module', '--eval', buildFxInstallScript()],
+          errorPrefix: 'fx install failed',
+          errorBody: 'stderr',
+        },
+      ];
+    },
+
+    configFiles: () => [],
+
+    authEnv(options: AgentRunOptions): Record<string, string> {
+      return { [AI_GATEWAY.apiKeyEnvVar]: options.apiKey };
+    },
+
+    fingerprintExtra(): Record<string, unknown> {
+      return {
+        fxVersion: FX_VERSION,
+        fxRuntimeProtocol: FX_RUNTIME_PROTOCOL,
+      };
+    },
+  };
+}
+
+export function createFxAgent(): Agent {
+  const definition = createFxDefinition();
+  return {
+    name: definition.name,
+    displayName: definition.displayName,
+    getApiKeyEnvVar: definition.getApiKeyEnvVar,
+    getDefaultModel(): ModelTier {
+      return definition.defaultModel;
+    },
+    run: (fixturePath, options) => runWithDefinition(definition, fixturePath, options),
+    definition,
+  };
+}

--- a/packages/agent-eval/src/lib/agents/fx/run.mjs
+++ b/packages/agent-eval/src/lib/agents/fx/run.mjs
@@ -1,0 +1,150 @@
+/**
+ * fx in-sandbox runner. This file must remain zero-dependency.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** @param {{prompt:string}} input */
+export function buildFxCliArgs(input) {
+  return ['ask', '--yolo', '--json', '--no-color', '--', input.prompt];
+}
+
+/** @param {string} raw */
+export function parseFxAskResult(raw) {
+  if (!raw || !raw.trim()) return null;
+  try {
+    const value = JSON.parse(raw.trim());
+    if (
+      value &&
+      typeof value === 'object' &&
+      typeof value.output === 'string' &&
+      typeof value.exit_code === 'number' &&
+      Array.isArray(value.tool_calls)
+    ) {
+      return value;
+    }
+  } catch {
+    // The caller reports malformed stdout as an agent failure.
+  }
+  return null;
+}
+
+/** @param {string} raw */
+export function isFxSessionDetail(raw) {
+  if (!raw || !raw.trim()) return false;
+  try {
+    const value = JSON.parse(raw.trim());
+    return value?.kind === 'session_detail' && Array.isArray(value.history);
+  } catch {
+    return false;
+  }
+}
+
+/** @param {{model?:string}} input */
+export function buildFxEnvironment(input) {
+  const env = { ...process.env, FX_AUTO_UPGRADE: '0' };
+  if (input.model) env.FX_MODEL = input.model;
+  else delete env.FX_MODEL;
+  return env;
+}
+
+/**
+ * @param {import('../plugin/contract.js').AgentRunInput} input
+ * @returns {Promise<import('../plugin/contract.js').RunnerResult>}
+ */
+export async function runAgent(input) {
+  const binary = join(input.cwd, '__agent_eval__', 'bin', 'fx');
+  const env = buildFxEnvironment(input);
+  const res = spawnSync(binary, buildFxCliArgs(input), {
+    cwd: input.cwd,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+  const stdout = res.stdout || '';
+  const stderr = res.stderr || '';
+  const output = stdout + stderr;
+  const askResult = parseFxAskResult(stdout);
+  const processExitCode = res.status == null ? -1 : res.status;
+  const agentExitCode = askResult?.exit_code ?? processExitCode;
+
+  // The supported session projection is richer than fx ask's final summary.
+  // Fall back to the ask JSON when a session cannot be read.
+  let transcript = askResult ? stdout.trim() : null;
+  if (askResult?.session_id) {
+    const session = spawnSync(binary, ['session', '--id', askResult.session_id, '--json'], {
+      cwd: input.cwd,
+      env,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (session.status === 0 && isFxSessionDetail(session.stdout || '')) {
+      transcript = session.stdout.trim();
+    }
+  }
+
+  const ok = !res.error && processExitCode === 0 && askResult?.exit_code === 0;
+  if (!ok) {
+    const errorLines = output.trim().split('\n').slice(-5).join('\n');
+    const error = askResult?.error || (res.error ? `Failed to run fx: ${res.error.message}` : null);
+    return {
+      ok: false,
+      output,
+      transcript,
+      observedModel: askResult?.model || null,
+      error: error || errorLines || `fx exited with code ${agentExitCode}`,
+      agentExitCode,
+    };
+  }
+
+  return {
+    ok: true,
+    output,
+    transcript,
+    observedModel: askResult.model || null,
+    error: null,
+    agentExitCode,
+  };
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  const input = JSON.parse(process.argv[2]);
+  let result;
+  try {
+    result = await runAgent(input);
+  } catch (error) {
+    result = {
+      ok: false,
+      output: '',
+      transcript: null,
+      observedModel: null,
+      error: error && error.message ? error.message : String(error),
+      agentExitCode: -1,
+    };
+  }
+
+  try {
+    mkdirSync(dirname(input.resultPath), { recursive: true });
+    writeFileSync(input.resultPath, JSON.stringify(result));
+  } catch {
+    // The marker below remains available when the result file cannot be written.
+  }
+
+  process.stdout.write(
+    '__AGENT_RESULT__ ' +
+      JSON.stringify({
+        ok: result.ok,
+        observedModel: result.observedModel,
+        error: result.error,
+        agentExitCode: result.agentExitCode,
+      }) +
+      '\n'
+  );
+  process.exit(0);
+}

--- a/packages/agent-eval/src/lib/agents/index.ts
+++ b/packages/agent-eval/src/lib/agents/index.ts
@@ -6,9 +6,14 @@ import { registerAgent, getAgent, listAgents, hasAgent } from './registry.js';
 import { createClaudeCodeAgent } from './claude-code/agent.js';
 import { createCodexAgent } from './codex/agent.js';
 import { createOpenCodeAgent } from './opencode/agent.js';
+import { createFxAgent } from './fx/agent.js';
 import { createGeminiAgent } from './gemini/agent.js';
 import { createCursorAgent } from './cursor/agent.js';
-import { assertBundledSkillsControl } from './plugin/contract.js';
+import {
+  assertBundledSkillsControl,
+  assertCrossAgentJudgeSupport,
+  assertWebResearchControl,
+} from './plugin/contract.js';
 import type { AgentType } from '../types.js';
 
 // Register all agent variants (Vercel AI Gateway + Direct API)
@@ -17,18 +22,24 @@ registerAgent(createClaudeCodeAgent({ useVercelAiGateway: false }));  // claude-
 registerAgent(createCodexAgent({ useVercelAiGateway: true }));        // vercel-ai-gateway/codex
 registerAgent(createCodexAgent({ useVercelAiGateway: false }));       // codex
 registerAgent(createOpenCodeAgent());                                 // vercel-ai-gateway/opencode
+registerAgent(createFxAgent());                                       // vercel-ai-gateway/fx
 registerAgent(createGeminiAgent());                                   // gemini
 registerAgent(createCursorAgent());                                   // cursor
 
-/** Validate bundled-skill isolation for every agent used by a run. */
-export function assertRunBundledSkillsControl(
+/** Validate opt-in runtime controls for every agent used by a run. */
+export function assertRunRuntimeControls(
   agentName: AgentType,
-  requested?: boolean,
+  controls: { disableBundledSkills?: boolean; webResearch?: boolean },
   judgeAgentName?: AgentType,
 ): void {
-  const agentNames = new Set([agentName, judgeAgentName ?? agentName]);
-  for (const name of agentNames) {
-    assertBundledSkillsControl(getAgent(name).definition, requested);
+  const definition = getAgent(agentName).definition;
+  assertBundledSkillsControl(definition, controls.disableBundledSkills);
+  assertWebResearchControl(definition, controls.webResearch);
+
+  if (judgeAgentName && judgeAgentName !== agentName) {
+    const judgeDefinition = getAgent(judgeAgentName).definition;
+    assertBundledSkillsControl(judgeDefinition, controls.disableBundledSkills);
+    assertCrossAgentJudgeSupport(judgeDefinition);
   }
 }
 

--- a/packages/agent-eval/src/lib/agents/plugin/contract.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/contract.ts
@@ -82,6 +82,10 @@ export interface AgentDefinition {
   /** Whether the CLI can disable vendor-bundled skills, or has none to disable.
    * Omitted means the opt-in control is unsupported. */
   bundledSkillsControl?: 'configurable' | 'not-applicable';
+  /** Whether this adapter currently supports only research-enabled runs. */
+  requiresWebResearch?: boolean;
+  /** Whether another agent may select this adapter as its pinned judge. */
+  supportsCrossAgentJudge?: boolean;
 
   /**
    * Which host env var the apiKey is read from. Mirrors the old getApiKeyEnvVar()
@@ -131,6 +135,23 @@ export function assertBundledSkillsControl(
 ): void {
   if (requested && !definition.bundledSkillsControl) {
     throw new Error(`Agent ${definition.name} does not support disableBundledSkills`);
+  }
+}
+
+/** Reject a run when an adapter requires the research tool surface. */
+export function assertWebResearchControl(
+  definition: AgentDefinition,
+  requested?: boolean,
+): void {
+  if (definition.requiresWebResearch && !requested) {
+    throw new Error(`Agent ${definition.name} requires webResearch: true`);
+  }
+}
+
+/** Reject an adapter that cannot serve as another agent's pinned judge. */
+export function assertCrossAgentJudgeSupport(definition: AgentDefinition): void {
+  if (definition.supportsCrossAgentJudge === false) {
+    throw new Error(`Agent ${definition.name} does not support cross-agent judging`);
   }
 }
 

--- a/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
+++ b/packages/agent-eval/src/lib/agents/plugin/orchestrator.ts
@@ -42,6 +42,8 @@ import { redactRunResult } from '../redact.js';
 import { getAgent } from '../registry.js';
 import {
   assertBundledSkillsControl,
+  assertCrossAgentJudgeSupport,
+  assertWebResearchControl,
   type AgentDefinition,
   type AgentRunInput,
   type RunnerResult,
@@ -107,6 +109,7 @@ interface JudgeRuntime {
 export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptions): JudgeRuntime {
   const spec = options.judge;
   assertBundledSkillsControl(def, options.disableBundledSkills);
+  assertWebResearchControl(def, options.webResearch);
 
   // Same harness as codegen (default, or judge.agent omitted/equal): reuse run.mjs,
   // just pin the model when asked. Identical to pre-feature behavior when unset.
@@ -130,6 +133,7 @@ export function resolveJudgeRuntime(def: AgentDefinition, options: AgentRunOptio
   // Pinned to a DIFFERENT agent — resolve its definition + key + runner.
   const judgeDef = getAgent(spec.agent!).definition;
   assertBundledSkillsControl(judgeDef, options.disableBundledSkills);
+  assertCrossAgentJudgeSupport(judgeDef);
   const judgeApiKey = resolveAgentApiKey(judgeDef.getApiKeyEnvVar) ?? '';
   const judgeOptions: AgentRunOptions = { ...options, model: spec.model, apiKey: judgeApiKey };
   return {
@@ -250,6 +254,8 @@ export async function runWithDefinition(
   fixturePath: string,
   options: AgentRunOptions
 ): Promise<AgentRunResult> {
+  assertBundledSkillsControl(def, options.disableBundledSkills);
+  assertWebResearchControl(def, options.webResearch);
   const result = await runOnce(def, fixturePath, options);
 
   // A judge pinned to a different agent authenticates with its own key, and it can

--- a/packages/agent-eval/src/lib/agents/types.ts
+++ b/packages/agent-eval/src/lib/agents/types.ts
@@ -43,6 +43,7 @@ export interface AgentRunOptions {
    * - Codex: enables live search in the generated profile and passes `--search`.
    * - OpenCode: sets `OPENCODE_ENABLE_EXA=1` and allows the
    *   `websearch`/`webfetch` tools.
+   * - fx: required for this adapter; runs the native research tool surface.
    */
   webResearch?: boolean;
   /** Disable vendor-bundled skills without hiding caller-installed skills.

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -220,11 +220,11 @@ describe('resolveConfig', () => {
   });
 
   it('does not allow fx as a cross-agent judge', () => {
-    const config = {
-      agent: 'vercel-ai-gateway/claude-code' as const,
-      judge: { agent: 'vercel-ai-gateway/fx' as const, model: 'openai/gpt-5.6-sol' },
+    const config = validateConfig({
+      agent: 'vercel-ai-gateway/claude-code',
+      judge: { agent: 'vercel-ai-gateway/fx', model: 'openai/gpt-5.6-sol' },
       webResearch: true,
-    };
+    });
     expect(() => resolveConfig(config)).toThrow(
       'Agent vercel-ai-gateway/fx does not support cross-agent judging'
     );

--- a/packages/agent-eval/src/lib/config.test.ts
+++ b/packages/agent-eval/src/lib/config.test.ts
@@ -206,6 +206,30 @@ describe('resolveConfig', () => {
     ).toThrow('Agent gemini does not support disableBundledSkills');
   });
 
+  it('requires research mode for fx', () => {
+    expect(() => resolveConfig({ agent: 'vercel-ai-gateway/fx' })).toThrow(
+      'Agent vercel-ai-gateway/fx requires webResearch: true'
+    );
+    expect(
+      resolveConfig({
+        agent: 'vercel-ai-gateway/fx',
+        webResearch: true,
+        disableBundledSkills: true,
+      }).agent
+    ).toBe('vercel-ai-gateway/fx');
+  });
+
+  it('does not allow fx as a cross-agent judge', () => {
+    const config = {
+      agent: 'vercel-ai-gateway/claude-code' as const,
+      judge: { agent: 'vercel-ai-gateway/fx' as const, model: 'openai/gpt-5.6-sol' },
+      webResearch: true,
+    };
+    expect(() => resolveConfig(config)).toThrow(
+      'Agent vercel-ai-gateway/fx does not support cross-agent judging'
+    );
+  });
+
   it('passes judge through and leaves it undefined by default', () => {
     expect(resolveConfig({ agent: 'claude-code' as const }).judge).toBeUndefined();
     expect(

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -10,7 +10,7 @@ import type {
   EvalFilter,
 } from './types.js';
 import { NATIVE_DEFAULT_MODEL } from './types.js';
-import { assertRunBundledSkillsControl } from './agents/index.js';
+import { assertRunRuntimeControls } from './agents/index.js';
 
 /**
  * Default configuration values.
@@ -102,9 +102,12 @@ export function validateConfig(config: unknown): ExperimentConfig {
  */
 export function resolveConfig(config: ExperimentConfig): ResolvedExperimentConfig {
   // Validate agent exists
-  assertRunBundledSkillsControl(
+  assertRunRuntimeControls(
     config.agent,
-    config.disableBundledSkills,
+    {
+      disableBundledSkills: config.disableBundledSkills,
+      webResearch: config.webResearch,
+    },
     config.judge?.agent,
   );
 

--- a/packages/agent-eval/src/lib/config.ts
+++ b/packages/agent-eval/src/lib/config.ts
@@ -71,6 +71,7 @@ const experimentConfigSchema = z.object({
           'vercel-ai-gateway/codex',
           'codex',
           'vercel-ai-gateway/opencode',
+          'vercel-ai-gateway/fx',
           'gemini',
           'cursor',
         ])

--- a/packages/agent-eval/src/lib/o11y/index.ts
+++ b/packages/agent-eval/src/lib/o11y/index.ts
@@ -22,5 +22,6 @@ export type { ParseableAgent } from './parsers/index.js';
 export { parseClaudeCodeTranscript } from './parsers/claude-code.js';
 export { parseCodexTranscript } from './parsers/codex.js';
 export { parseOpenCodeTranscript } from './parsers/opencode.js';
+export { parseFxTranscript } from './parsers/fx.js';
 export { parseGeminiTranscript } from './parsers/gemini.js';
 export { parseCursorTranscript } from './parsers/cursor.js';

--- a/packages/agent-eval/src/lib/o11y/o11y.test.ts
+++ b/packages/agent-eval/src/lib/o11y/o11y.test.ts
@@ -8,6 +8,7 @@ import type { Transcript } from './types.js';
 import { parseClaudeCodeTranscript } from './parsers/claude-code.js';
 import { parseCodexTranscript } from './parsers/codex.js';
 import { parseOpenCodeTranscript } from './parsers/opencode.js';
+import { parseFxTranscript } from './parsers/fx.js';
 import { parseGeminiTranscript } from './parsers/gemini.js';
 import { parseCursorTranscript } from './parsers/cursor.js';
 
@@ -33,6 +34,9 @@ describe('o11y', () => {
       const opencodeResult = parseTranscript(claudeTranscript, 'vercel-ai-gateway/opencode');
       expect(opencodeResult.agent).toBe('vercel-ai-gateway/opencode');
 
+      const fxResult = parseTranscript(claudeTranscript, 'vercel-ai-gateway/fx');
+      expect(fxResult.agent).toBe('vercel-ai-gateway/fx');
+
       const geminiResult = parseTranscript(claudeTranscript, 'gemini');
       expect(geminiResult.agent).toBe('gemini');
 
@@ -47,10 +51,16 @@ describe('o11y', () => {
 
       expect(result.parseSuccess).toBe(false);
       expect(result.parseErrors).toContain(
-        'No parser available for agent: unsupported-agent. Supported agents: claude-code, codex, opencode, gemini, cursor'
+        'No parser available for agent: unsupported-agent. Supported agents: claude-code, codex, opencode, fx, gemini, cursor'
       );
       expect(result.events).toEqual([]);
       expect(result.summary.totalToolCalls).toBe(0);
+    });
+
+    it('does not route custom agent names containing fx to the fx parser', () => {
+      const result = parseTranscript('{}', 'vfx-agent');
+      expect(result.parseSuccess).toBe(false);
+      expect(result.parseErrors?.[0]).toContain('No parser available for agent: vfx-agent');
     });
 
     it('includes model in result', () => {
@@ -271,6 +281,142 @@ describe('o11y', () => {
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe('tool_call');
       expect(events[0].tool?.name).toBe('file_read');
+    });
+  });
+
+  describe('fx parser', () => {
+    it('parses saved messages, terminal commands, and web fetches', () => {
+      const transcript = JSON.stringify({
+        kind: 'session_detail',
+        id: 'session-1',
+        created_at_ms: 1787000000000,
+        updated_at_ms: 1787000005000,
+        history: [
+          {
+            kind: 'assistant',
+            user: { text: 'Research fx', images: [] },
+            assistant: 'The official site is https://fx.sh/.',
+            execution: {
+              schema_version: 2,
+              tool_steps: [
+                {
+                  assistant: null,
+                  tool_calls: [
+                    {
+                      id: 'terminal-1',
+                      name: 'terminal',
+                      arguments_json: JSON.stringify({
+                        request: { action: 'exec', command: 'npm test' },
+                      }),
+                      provider_result: null,
+                    },
+                    {
+                      id: 'fetch-1',
+                      name: 'web_fetch',
+                      arguments_json: JSON.stringify({ url: 'https://fx.sh/docs' }),
+                      provider_result: null,
+                    },
+                  ],
+                  tool_results: [
+                    {
+                      tool_call_id: 'terminal-1',
+                      tool_name: 'terminal',
+                      status: 'success',
+                      output: 'exit_code=0\nTests passed',
+                      created_at_ms: 1787000001000,
+                    },
+                    {
+                      tool_call_id: 'fetch-1',
+                      tool_name: 'web_fetch',
+                      status: 'success',
+                      output: '<url>https://fx.sh/docs</url>\n<status>200</status>',
+                      created_at_ms: 1787000002000,
+                    },
+                  ],
+                },
+              ],
+              files: [],
+            },
+          },
+        ],
+      });
+
+      const parsed = parseTranscript(transcript, 'vercel-ai-gateway/fx');
+      expect(parsed.parseSuccess).toBe(true);
+      expect(parsed.summary.totalTurns).toBe(1);
+      expect(parsed.summary.toolCalls.shell).toBe(1);
+      expect(parsed.summary.toolCalls.web_fetch).toBe(1);
+      expect(parsed.summary.shellCommands).toEqual([
+        { command: 'npm test', exitCode: 0, success: true },
+      ]);
+      expect(parsed.summary.webFetches).toEqual([
+        { url: 'https://fx.sh/docs', success: true },
+      ]);
+      expect(parsed.events.at(-1)?.content).toBe('The official site is https://fx.sh/.');
+    });
+
+    it('uses file evidence when a tool argument has no path', () => {
+      const transcript = JSON.stringify({
+        kind: 'session_detail',
+        history: [
+          {
+            kind: 'assistant',
+            user: { text: 'Read the config', images: [] },
+            assistant: 'Done',
+            execution: {
+              schema_version: 2,
+              tool_steps: [
+                {
+                  assistant: null,
+                  tool_calls: [
+                    { id: 'read-1', name: 'read_file', arguments_json: '{}' },
+                  ],
+                  tool_results: [],
+                },
+              ],
+              files: [
+                {
+                  path: 'src/config.ts',
+                  new_path: null,
+                  tool_call_id: 'read-1',
+                  tool_name: 'read_file',
+                  action: 'read',
+                  status: 'success',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      const parsed = parseTranscript(transcript, 'fx');
+      expect(parsed.summary.filesRead).toEqual(['src/config.ts']);
+    });
+
+    it('parses the ask JSON fallback when session capture is unavailable', () => {
+      const transcript = JSON.stringify({
+        output: 'Found https://fx.sh/.',
+        exit_code: 0,
+        model: 'openai/gpt-5.6-sol',
+        session_id: '',
+        steps: 1,
+        tool_calls: [
+          {
+            name: 'web_fetch',
+            status: 'success',
+            web_fetch: { url: 'https://fx.sh/', status: 200 },
+          },
+        ],
+      });
+
+      const { events, errors } = parseFxTranscript(transcript);
+      expect(errors).toEqual([]);
+      expect(events.some((event) => event.type === 'message' && event.content === 'Found https://fx.sh/.')).toBe(true);
+      expect(events.find((event) => event.type === 'tool_call')?.tool?.args?._extractedUrl).toBe('https://fx.sh/');
+    });
+
+    it('reports malformed transcript JSON', () => {
+      expect(parseFxTranscript('not json').errors[0]).toContain('Failed to parse fx transcript');
     });
   });
 

--- a/packages/agent-eval/src/lib/o11y/parsers/fx.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/fx.ts
@@ -1,0 +1,295 @@
+/** Parser for the supported `fx session --id <id> --json` projection. */
+
+import type { ToolName, TranscriptEvent } from '../types.js';
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseJsonObject(value: unknown): JsonRecord {
+  return asRecord(parseJsonValue(value)) ?? {};
+}
+
+function timestamp(value: unknown): string | undefined {
+  const milliseconds = asNumber(value);
+  return milliseconds === undefined ? undefined : new Date(milliseconds).toISOString();
+}
+
+function normalizeToolName(name: string): ToolName {
+  const names: Record<string, ToolName> = {
+    read_file: 'file_read',
+    file_info: 'file_read',
+    write_file: 'file_write',
+    create_folder: 'file_write',
+    copy_file: 'file_write',
+    edit_file: 'file_edit',
+    delete_file: 'file_edit',
+    rename_file: 'file_edit',
+    terminal: 'shell',
+    run_command: 'shell',
+    web_fetch: 'web_fetch',
+    web_search: 'web_search',
+    glob_files: 'glob',
+    grep_files: 'grep',
+    semantic_search: 'grep',
+    list_files: 'list_dir',
+    subagent: 'agent_task',
+  };
+  return names[name.toLowerCase()] ?? 'unknown';
+}
+
+function extractFilePath(args: JsonRecord): string | undefined {
+  for (const key of ['path', 'file_path', 'old_path', 'source', 'destination']) {
+    const value = asString(args[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function normalizeToolArgs(name: ToolName, args: JsonRecord, evidencePath?: string): JsonRecord {
+  const normalized = { ...args };
+  const request = asRecord(args.request) ?? args;
+
+  if (name === 'shell') {
+    const command = asString(request.command);
+    if (command) normalized._extractedCommand = command;
+  }
+  if (name === 'web_fetch') {
+    const url = asString(args.url);
+    if (url) normalized._extractedUrl = url;
+  }
+  if (name === 'file_read' || name === 'file_write' || name === 'file_edit') {
+    const path = extractFilePath(args) ?? evidencePath;
+    if (path) normalized._extractedPath = path;
+  }
+
+  return normalized;
+}
+
+function extractExitCode(output: string, parsed: unknown): number | undefined {
+  const parsedRecord = asRecord(parsed);
+  const error = asRecord(parsedRecord?.error);
+  const details = asRecord(error?.details);
+  const structured = asNumber(details?.exit_code) ?? asNumber(parsedRecord?.exit_code);
+  if (structured !== undefined) return structured;
+
+  const match = output.match(/(?:^|\n)exit_code=(-?\d+)/);
+  return match ? Number(match[1]) : undefined;
+}
+
+function normalizeToolResult(name: ToolName, value: JsonRecord): unknown {
+  const output = asString(value.output) ?? '';
+  const parsed = parseJsonValue(output);
+  if (name !== 'shell') return parsed;
+
+  const exitCode = extractExitCode(output, parsed);
+  return exitCode === undefined ? { output } : { output, exitCode };
+}
+
+function pushMessage(
+  events: TranscriptEvent[],
+  role: 'user' | 'assistant' | 'system',
+  content: unknown,
+): void {
+  const text = asString(content);
+  if (!text?.trim()) return;
+  events.push({ type: 'message', role, content: text });
+}
+
+function fileEvidenceByCall(execution: JsonRecord): Map<string, string> {
+  const paths = new Map<string, string>();
+  const files = Array.isArray(execution.files) ? execution.files : [];
+  for (const item of files) {
+    const file = asRecord(item);
+    const callId = asString(file?.tool_call_id);
+    const path = asString(file?.new_path) ?? asString(file?.path);
+    if (callId && path && !paths.has(callId)) paths.set(callId, path);
+  }
+  return paths;
+}
+
+function pushExecution(events: TranscriptEvent[], value: unknown): void {
+  const execution = asRecord(value);
+  if (!execution) return;
+
+  const evidencePaths = fileEvidenceByCall(execution);
+  const toolSteps = Array.isArray(execution.tool_steps) ? execution.tool_steps : [];
+  for (const item of toolSteps) {
+    const step = asRecord(item);
+    if (!step) continue;
+    pushMessage(events, 'assistant', step.assistant);
+
+    const namesById = new Map<string, { canonical: ToolName; original: string }>();
+    const calls = Array.isArray(step.tool_calls) ? step.tool_calls : [];
+    for (const itemCall of calls) {
+      const call = asRecord(itemCall);
+      const originalName = asString(call?.name);
+      if (!call || !originalName) continue;
+
+      const id = asString(call.id);
+      const canonical = normalizeToolName(originalName);
+      if (id) namesById.set(id, { canonical, original: originalName });
+      const args = normalizeToolArgs(
+        canonical,
+        parseJsonObject(call.arguments_json),
+        id ? evidencePaths.get(id) : undefined,
+      );
+      events.push({
+        type: 'tool_call',
+        tool: { name: canonical, originalName, args },
+        raw: call,
+      });
+    }
+
+    const results = Array.isArray(step.tool_results) ? step.tool_results : [];
+    for (const itemResult of results) {
+      const result = asRecord(itemResult);
+      if (!result) continue;
+      const callId = asString(result.tool_call_id);
+      const originalName = asString(result.tool_name) ?? (callId ? namesById.get(callId)?.original : undefined) ?? 'unknown';
+      const canonical = normalizeToolName(originalName);
+      events.push({
+        timestamp: timestamp(result.created_at_ms),
+        type: 'tool_result',
+        tool: {
+          name: canonical,
+          originalName,
+          result: normalizeToolResult(canonical, result),
+          success: result.status === 'success',
+        },
+        raw: result,
+      });
+    }
+  }
+}
+
+function pushSessionTurn(events: TranscriptEvent[], value: unknown): void {
+  const turn = asRecord(value);
+  if (!turn) return;
+
+  if (turn.kind === 'compacted_summary') {
+    pushMessage(events, 'system', turn.summary);
+    return;
+  }
+
+  const user = asRecord(turn.user);
+  pushMessage(events, 'user', user?.text);
+  pushExecution(events, turn.execution);
+  pushMessage(events, 'assistant', turn.assistant);
+
+  if (turn.kind === 'interrupted') {
+    const call = asRecord(turn.tool_call);
+    const originalName = asString(call?.name);
+    if (call && originalName) {
+      const canonical = normalizeToolName(originalName);
+      events.push({
+        type: 'tool_call',
+        tool: {
+          name: canonical,
+          originalName,
+          args: normalizeToolArgs(canonical, parseJsonObject(call.arguments_json)),
+        },
+        raw: call,
+      });
+    }
+  }
+}
+
+function parseSessionDetail(data: JsonRecord): TranscriptEvent[] {
+  const events: TranscriptEvent[] = [];
+  const history = Array.isArray(data.history) ? data.history : [];
+  for (const turn of history) pushSessionTurn(events, turn);
+  return events;
+}
+
+function parseAskResult(data: JsonRecord): TranscriptEvent[] {
+  const events: TranscriptEvent[] = [];
+  const calls = Array.isArray(data.tool_calls) ? data.tool_calls : [];
+  for (const item of calls) {
+    const call = asRecord(item);
+    const originalName = asString(call?.name);
+    if (!call || !originalName) continue;
+
+    const canonical = normalizeToolName(originalName);
+    const commandResult = asRecord(call.command_result);
+    const webFetch = asRecord(call.web_fetch);
+    const args: JsonRecord = commandResult
+      ? { command: commandResult.command, cwd: commandResult.cwd }
+      : webFetch
+        ? { url: webFetch.url }
+        : {};
+    events.push({
+      type: 'tool_call',
+      tool: { name: canonical, originalName, args: normalizeToolArgs(canonical, args) },
+      raw: call,
+    });
+
+    const result = commandResult
+      ? { ...commandResult, exitCode: commandResult.exit_code }
+      : call.web_fetch ?? call.web_search;
+    events.push({
+      type: 'tool_result',
+      tool: {
+        name: canonical,
+        originalName,
+        result,
+        success: call.status === 'success',
+      },
+      raw: call,
+    });
+  }
+
+  pushMessage(events, 'assistant', data.output);
+  const error = asString(data.error);
+  if (error) events.push({ type: 'error', content: error, raw: data });
+  return events;
+}
+
+/** Parse fx session detail JSON, with `fx ask --json` as the runner fallback. */
+export function parseFxTranscript(raw: string): {
+  events: TranscriptEvent[];
+  errors: string[];
+} {
+  if (!raw.trim()) return { events: [], errors: [] };
+
+  let data: JsonRecord | undefined;
+  try {
+    data = asRecord(JSON.parse(raw));
+  } catch (error) {
+    return {
+      events: [],
+      errors: [`Failed to parse fx transcript: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+
+  if (!data) return { events: [], errors: ['Failed to parse fx transcript: expected an object'] };
+  if (data.kind === 'session_detail') return { events: parseSessionDetail(data), errors: [] };
+  if (typeof data.exit_code === 'number' && Array.isArray(data.tool_calls)) {
+    return { events: parseAskResult(data), errors: [] };
+  }
+  if (data.kind === 'session' && typeof data.error === 'string') {
+    return { events: [{ type: 'error', content: data.error, raw: data }], errors: [] };
+  }
+  return { events: [], errors: ['Failed to parse fx transcript: unknown document shape'] };
+}

--- a/packages/agent-eval/src/lib/o11y/parsers/index.ts
+++ b/packages/agent-eval/src/lib/o11y/parsers/index.ts
@@ -14,6 +14,7 @@ import type {
 import { parseClaudeCodeTranscript } from './claude-code.js';
 import { parseCodexTranscript } from './codex.js';
 import { parseOpenCodeTranscript } from './opencode.js';
+import { parseFxTranscript } from './fx.js';
 import { parseGeminiTranscript } from './gemini.js';
 import { parseCursorTranscript } from './cursor.js';
 
@@ -26,6 +27,7 @@ export type ParseableAgent =
   | 'vercel-ai-gateway/codex'
   | 'codex'
   | 'vercel-ai-gateway/opencode'
+  | 'vercel-ai-gateway/fx'
   | 'gemini'
   | 'cursor';
 
@@ -36,6 +38,7 @@ const AGENT_PARSERS = {
   'claude-code': parseClaudeCodeTranscript,
   'codex': parseCodexTranscript,
   'opencode': parseOpenCodeTranscript,
+  'fx': parseFxTranscript,
   'gemini': parseGeminiTranscript,
   'cursor': parseCursorTranscript,
 } as const;
@@ -52,7 +55,11 @@ export const SUPPORTED_AGENTS = Object.keys(AGENT_PARSERS) as Array<keyof typeof
 function getParserForAgent(
   agent: string
 ): ((raw: string) => { events: TranscriptEvent[]; errors: string[] }) | null {
+  const terminalName = agent.slice(agent.lastIndexOf('/') + 1);
+  if (terminalName === 'fx') return AGENT_PARSERS.fx;
+
   for (const key of SUPPORTED_AGENTS) {
+    if (key === 'fx') continue;
     if (agent.includes(key)) {
       return AGENT_PARSERS[key];
     }

--- a/packages/agent-eval/src/lib/runner.ts
+++ b/packages/agent-eval/src/lib/runner.ts
@@ -14,7 +14,7 @@ import type {
   RunnableExperimentConfig,
   ProgressEvent,
 } from './types.js';
-import { assertRunBundledSkillsControl, getAgent } from './agents/index.js';
+import { assertRunRuntimeControls, getAgent } from './agents/index.js';
 import {
   agentResultToEvalRunData,
   createEvalSummary,
@@ -126,9 +126,12 @@ export async function runExperiment(
   const { config, fixtures, apiKey, resultsDir, experimentName, fingerprints, contentFingerprints, onProgress, smoke, rateLimiter } = options;
   const startedAt = new Date();
 
-  assertRunBundledSkillsControl(
+  assertRunRuntimeControls(
     config.agent,
-    config.disableBundledSkills,
+    {
+      disableBundledSkills: config.disableBundledSkills,
+      webResearch: config.webResearch,
+    },
     config.judge?.agent,
   );
 
@@ -404,9 +407,12 @@ export async function runSingleEval<T extends ResolvedExperimentConfig['model']>
   }
 ): Promise<T extends Array<unknown> ? EvalRunData[] : EvalRunData> {
   const agentName = options.agent ?? 'vercel-ai-gateway/claude-code';
-  assertRunBundledSkillsControl(
+  assertRunRuntimeControls(
     agentName,
-    options.disableBundledSkills,
+    {
+      disableBundledSkills: options.disableBundledSkills,
+      webResearch: options.webResearch,
+    },
     options.judge?.agent,
   );
   const agent = getAgent(agentName);

--- a/packages/agent-eval/src/lib/types.ts
+++ b/packages/agent-eval/src/lib/types.ts
@@ -11,6 +11,7 @@ export type BuiltInAgentType =
   | 'vercel-ai-gateway/codex'
   | 'codex'
   | 'vercel-ai-gateway/opencode'
+  | 'vercel-ai-gateway/fx'
   | 'gemini'
   | 'cursor';
 


### PR DESCRIPTION
Adds fx as a Gateway-only agent for research-enabled evals, so consumers can compare it with existing harnesses without contaminating no-web runs. The adapter pins fx 0.0.5 and preserves its supported saved-session evidence for result parsing.

Verified with `npm test`, `npm run build`, `npm run lint`, focused adapter tests, and an npm package dry-run. The credentialed integration test is included but skipped locally because sandbox and Gateway credentials are unavailable.