### PR TITLE
Judge matchers must not block the vitest worker

### DIFF
--- a/.changeset/lazy-camels-breathe.md
+++ b/.changeset/lazy-camels-breathe.md
@@ -1,0 +1,5 @@
+---
+"@vercel/agent-eval": patch
+---
+
+Judge matchers no longer block the vitest worker. `toSatisfyCriterion` and `toScoreAtLeast` ran the in-sandbox judge agent with `spawnSync`, freezing the worker's event loop for the length of a model run. The worker answers the main process over an RPC channel whose per-call timeout is hardcoded to 60 seconds (birpc's default — no vitest option or env var reaches it), so any judge slower than that made vitest emit an unhandled `[vitest-worker]: Timeout calling "onTaskUpdate"` and exit non-zero even when every assertion passed: a green eval recorded as a failure, and the slower the judge model, the more often. The judge now runs via async `spawn` and the matchers are async, so the event loop keeps servicing the RPC channel while the judge works. Judge calls must be awaited — `await expect(environment).toSatisfyCriterion(...)` — which is what every published example already shows.

--- a/packages/agent-eval/src/lib/agents/eval-helper.mjs
+++ b/packages/agent-eval/src/lib/agents/eval-helper.mjs
@@ -27,7 +27,7 @@
  * these files before validation).
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { expect } from 'vitest';
 
@@ -129,12 +129,31 @@ function readJudgeConfig() {
   }
 }
 
+/** spawn + collect, resolving on exit. Never rejects: judge failures become verdicts. */
+function spawnCollect(cmd, args) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd: process.cwd(), env: process.env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.on('error', (err) => resolve({ stdout, stderr: `${stderr}\n${err.message}`, status: -1 }));
+    child.on('close', (status) => resolve({ stdout, stderr, status }));
+  });
+}
+
 /**
  * Run one agentic judgment IN this sandbox by re-invoking the codegen agent's
- * runner. Blocking (spawnSync) — the test has nothing else to do while the judge
- * works, and the sandbox-level timeout bounds it. Returns {pass, score?, reason}.
+ * runner. Async ON PURPOSE, not as style: the vitest worker answers the main
+ * process over an RPC channel whose per-call timeout is hardcoded to 60s (birpc's
+ * DEFAULT_TIMEOUT — no vitest config or env var reaches it). A judge run takes
+ * however long the model takes, routinely past a minute, and the old spawnSync
+ * blocked the worker's event loop for all of it, so in-flight calls like
+ * onTaskUpdate timed out and vitest failed the file EVEN WHEN EVERY TEST PASSED.
+ * Keeping the loop alive while the judge works is the entire fix; the sandbox
+ * timeout still bounds the run. Returns {pass, score?, reason}.
  */
-function runJudge(subject, criterion, opts = {}) {
+async function runJudge(subject, criterion, opts = {}) {
   const id = nextId();
   mkdirSync(JUDGE_IO_DIR, { recursive: true });
   const verdictPath = `${JUDGE_IO_DIR}/${id}-verdict.json`;
@@ -155,12 +174,7 @@ function runJudge(subject, criterion, opts = {}) {
     extra: cfg.extra ?? undefined,
   };
 
-  const res = spawnSync('node', [runnerPath, JSON.stringify(input)], {
-    cwd: process.cwd(),
-    env: process.env,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
+  const res = await spawnCollect('node', [runnerPath, JSON.stringify(input)]);
 
   // Prefer the verdict file the judge agent wrote; then the runner result's output
   // (the agent's final message); then raw stdout.
@@ -188,9 +202,12 @@ function subjectOf(received) {
   return received && typeof received === 'object' ? received.__judgeSubject : undefined;
 }
 
-// Sync matchers: spawnSync blocks, so these work whether or not you `await` them.
+// Async matchers — `await expect(...)`, as every example here shows. The await is
+// load-bearing: vitest does not track a custom matcher's promise, so an un-awaited
+// judge call floats free of its test — a failing verdict surfaces as an unhandled
+// rejection instead of failing the test, and a passing one is never even read.
 expect.extend({
-  toSatisfyCriterion(received, criterion) {
+  async toSatisfyCriterion(received, criterion) {
     const subject = subjectOf(received);
     if (!subject) {
       return {
@@ -199,7 +216,7 @@ expect.extend({
           'toSatisfyCriterion expects `environment` or `transcript` from @vercel/agent-eval/eval',
       };
     }
-    const v = runJudge(subject, criterion);
+    const v = await runJudge(subject, criterion);
     return {
       pass: v.pass,
       message: () =>
@@ -209,7 +226,7 @@ expect.extend({
     };
   },
 
-  toScoreAtLeast(received, criterion, threshold) {
+  async toScoreAtLeast(received, criterion, threshold) {
     const subject = subjectOf(received);
     if (!subject) {
       return {
@@ -218,7 +235,7 @@ expect.extend({
           'toScoreAtLeast expects `environment` or `transcript` from @vercel/agent-eval/eval',
       };
     }
-    const v = runJudge(subject, criterion, { numeric: true });
+    const v = await runJudge(subject, criterion, { numeric: true });
     const score = typeof v.score === 'number' ? v.score : v.pass ? 1 : 0;
     const pass = score >= threshold;
     return {

--- a/packages/agent-eval/src/lib/agents/eval-helper.test.ts
+++ b/packages/agent-eval/src/lib/agents/eval-helper.test.ts
@@ -18,6 +18,8 @@ declare module 'vitest' {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   interface Assertion<T = any> {
     toContainText(needle: string | RegExp): T;
+    toSatisfyCriterion(criterion: string): Promise<T>;
+    toScoreAtLeast(criterion: string, threshold: number): Promise<T>;
   }
 }
 
@@ -198,5 +200,78 @@ describe('toContainText', () => {
     expect(() => expect(transcript).toContainText(/z*/)).toThrowError(
       /matches the empty string/
     );
+  });
+});
+
+describe('judge matchers', () => {
+  // runJudge resolves the runner and judge-config relative to cwd, exactly as it
+  // does in-sandbox, so run each test from a temp dir holding a fake runner. The
+  // fake honors the runner contract's output fallback: verdict JSON on stdout.
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    prevCwd = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), 'eval-helper-judge-'));
+    process.chdir(dir);
+    mkdirSync('__agent_eval__', { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeFakeRunner(script: string) {
+    writeFileSync('fake-runner.mjs', script);
+    writeFileSync(
+      '__agent_eval__/judge-config.json',
+      JSON.stringify({ runnerPath: 'fake-runner.mjs', model: null, extra: null })
+    );
+  }
+
+  it('resolves a passing verdict through the runner round-trip', async () => {
+    writeFakeRunner(
+      `process.stdout.write(JSON.stringify({ pass: true, reason: 'fake evidence' }));`
+    );
+    await expect(environment).toSatisfyCriterion('anything at all');
+  });
+
+  it('a failing verdict fails the assertion (and .not inverts it)', async () => {
+    writeFakeRunner(
+      `process.stdout.write(JSON.stringify({ pass: false, reason: 'nope' }));`
+    );
+    await expect(expect(environment).toSatisfyCriterion('x')).rejects.toThrow(/reason: nope/);
+    await expect(environment).not.toSatisfyCriterion('x');
+  });
+
+  it('does not block the event loop while the judge runs', async () => {
+    // The regression this guards: the vitest worker's RPC heartbeat shares this
+    // event loop, and its per-call timeout is hardcoded to 60s. A judge that
+    // blocks the loop past that fails the whole file even when every test passes.
+    // A timer firing while the judge is still out is only possible if the loop
+    // stays alive — under the old spawnSync implementation this test hangs at
+    // 'timer' until the judge returns, and the order assertion fails.
+    writeFakeRunner(
+      `setTimeout(() => {
+        process.stdout.write(JSON.stringify({ pass: true, reason: 'slow ok' }));
+      }, 300);`
+    );
+    const order: string[] = [];
+    const judged = expect(environment)
+      .toSatisfyCriterion('slow criterion')
+      .then(() => order.push('judge'));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    order.push('timer');
+    await judged;
+    expect(order).toEqual(['timer', 'judge']);
+  });
+
+  it('toScoreAtLeast compares the numeric score', async () => {
+    writeFakeRunner(
+      `process.stdout.write(JSON.stringify({ pass: true, score: 0.7, reason: 'ok' }));`
+    );
+    await expect(environment).toScoreAtLeast('quality', 0.6);
+    await expect(environment).not.toScoreAtLeast('quality', 0.8);
   });
 });


### PR DESCRIPTION
A judge run slower than 60 seconds made vitest fail the file even when every assertion passed — the worker's RPC heartbeat shares the event loop the sync matchers were blocking, and its timeout is hardcoded. The matchers now run the judge async, so the eval's own duration no longer decides its result.